### PR TITLE
feat: update Docker setup for port 8080 and deployment configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+Dockerfile
+Dockerfile.coolify
+docker/Dockerfile
+docker/.dockerignore
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,8 +37,9 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 
 # 11. Expose the port Next.js uses
-EXPOSE 3000
-ENV PORT=3000
+EXPOSE 8080
+ENV PORT=8080
+ENV HOSTNAME="0.0.0.0"
 
 # 12. Start the application
 CMD ["pnpm", "start"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    expose:
+      - "8080"
+    environment:
+      - PORT=8080
+      - HOSTNAME=0.0.0.0


### PR DESCRIPTION

When the Dockerfile was moved into the `docker/` subdirectory, it broke the ability to reference files relative to the project root (e.g. `package.json`, `pnpm-lock.yaml`). This PR adds a `docker/docker-compose.yml` that sets the build context to `..` (the repo root) so the Dockerfile can still `COPY` from the correct paths, while keeping the file organization in the `docker/` directory.

Also aligns the port configuration to match your recent changes:
- `EXPOSE 3000` → `EXPOSE 8080`
- `ENV PORT=3000` → `ENV PORT=8080`
- Adds `ENV HOSTNAME="0.0.0.0"` so Next.js binds correctly inside the container

## Changes
- `docker/docker-compose.yml` — new file; sets build context to repo root, exposes 8080
- `docker/Dockerfile` — updated port from 3000 → 8080, added HOSTNAME binding
- `.dockerignore` — new file; excludes node_modules, .next, .git from build context