### PR TITLE
feat: add security documentation and BIP39 mnemonic generation utility

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -35,16 +35,25 @@ Security is paramount in CoinPay as we handle cryptocurrency transactions and pr
 ### Private Key Management
 
 #### Key Generation
+
+System HD wallet mnemonics can be generated offline using the included helper script:
+
+```bash
+# Run from the repo root — no npm packages required
+node scripts/gen-mnemonic.mjs
+```
+
+Run this **once per `SYSTEM_MNEMONIC_*` variable** and store the result in your secrets manager. Never reuse the same phrase across chains. The script uses Node.js built-in `crypto` for entropy and the official BIP39 wordlist — no external dependencies.
+
+In application code, keys are derived from environment-stored mnemonics at runtime:
+
 ```typescript
-// HD Wallet generation using BIP39/BIP44
-import * as bip39 from 'bip39';
+// HD Wallet derivation using BIP39/BIP44
 import { HDKey } from '@scure/bip32';
+import { mnemonicToSeed } from '@scure/bip39';
 
-// Generate mnemonic (store securely, never in database)
-const mnemonic = bip39.generateMnemonic(256); // 24 words
-
-// Derive keys for each blockchain
-const seed = await bip39.mnemonicToSeed(mnemonic);
+// Derive keys for each blockchain from env-stored mnemonic
+const seed = await mnemonicToSeed(process.env.SYSTEM_MNEMONIC_ETH!);
 const hdkey = HDKey.fromMasterSeed(seed);
 
 // Bitcoin: m/44'/0'/0'/0/index
@@ -503,6 +512,14 @@ PLATFORM_FEE_WALLET_BTC=your-btc-address
 PLATFORM_FEE_WALLET_ETH=your-eth-address
 PLATFORM_FEE_WALLET_POL=your-pol-address
 PLATFORM_FEE_WALLET_SOL=your-sol-address
+
+# System Wallets (Required)
+# Generate each phrase with: node scripts/gen-mnemonic.mjs
+# Use a unique phrase per chain — NEVER reuse.
+SYSTEM_MNEMONIC_BTC="your twelve word bip39 mnemonic phrase goes here"
+SYSTEM_MNEMONIC_ETH="your twelve word bip39 mnemonic phrase goes here"
+SYSTEM_MNEMONIC_POL="your twelve word bip39 mnemonic phrase goes here"
+SYSTEM_MNEMONIC_SOL="your twelve word bip39 mnemonic phrase goes here"
 
 # Tatum API
 TATUM_API_KEY=your-tatum-api-key

--- a/docs/SECURITY_KEYS.md
+++ b/docs/SECURITY_KEYS.md
@@ -83,6 +83,18 @@ Master mnemonics are stored in environment variables:
 - `SYSTEM_MNEMONIC_POL` - Polygon HD wallet seed
 - `SYSTEM_MNEMONIC_SOL` - Solana HD wallet seed
 
+### 4. Mnemonic Generation
+
+Use the included zero-dependency helper script to generate a valid BIP39 phrase locally:
+
+```bash
+node scripts/gen-mnemonic.mjs
+```
+
+Run this **once per `SYSTEM_MNEMONIC_*` variable** — do NOT reuse the same phrase across chains. The script uses only Node.js built-in `crypto` (no npm packages required) and fetches the official BIP39 English wordlist from the `bitcoinjs/bip39` repository.
+
+> **Security**: Never use an online mnemonic generator for production wallets. Always generate locally and store in a secrets manager (e.g., Doppler, HashiCorp Vault, AWS Secrets Manager).
+
 ### 4. Memory Handling
 
 After transaction signing, sensitive data is cleared:
@@ -117,11 +129,13 @@ function clearSensitiveData(data: { privateKey?: string }): void {
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-character-hex-key
 
-# System HD wallet mnemonics (24 words each)
-SYSTEM_MNEMONIC_BTC="word1 word2 ... word24"
-SYSTEM_MNEMONIC_ETH="word1 word2 ... word24"
-SYSTEM_MNEMONIC_POL="word1 word2 ... word24"
-SYSTEM_MNEMONIC_SOL="word1 word2 ... word24"
+# System HD wallet mnemonics — generate each one with:
+#   node scripts/gen-mnemonic.mjs
+# Use a separate, unique phrase per chain. NEVER reuse.
+SYSTEM_MNEMONIC_BTC="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_ETH="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_POL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_SOL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
 # Commission wallets (public addresses)
 COMMISSION_WALLET_BTC=bc1q...

--- a/scripts/gen-mnemonic.mjs
+++ b/scripts/gen-mnemonic.mjs
@@ -1,0 +1,68 @@
+/**
+ * gen-mnemonic.mjs
+ *
+ * Generates a cryptographically secure BIP39 mnemonic phrase (12 words / 128-bit entropy).
+ * Uses ONLY Node.js built-in modules — no npm install required.
+ *
+ * Usage:
+ *   node scripts/gen-mnemonic.mjs
+ *
+ *   Output example:
+ *     subway cinnamon outdoor must lamp parent oblige brown engage salad volcano loud
+ *
+ *   Paste the output into your .env wrapped in double quotes (required — values contain spaces):
+ *     SYSTEM_MNEMONIC_ETH="subway cinnamon outdoor must lamp parent oblige brown engage salad volcano loud"
+ *
+ * When to use:
+ *   Run this script once for each SYSTEM_MNEMONIC_* variable in your .env file:
+ *     SYSTEM_MNEMONIC_BTC, SYSTEM_MNEMONIC_ETH, SYSTEM_MNEMONIC_POL,
+ *     SYSTEM_MNEMONIC_SOL, MASTER_MNEMONIC, and any optional chain mnemonics.
+ *
+ *   Each chain should have its OWN unique phrase — never reuse the same mnemonic
+ *   across multiple SYSTEM_MNEMONIC_* variables.
+ *
+ * Security:
+ *   - Never generate mnemonics using an online tool for production wallets.
+ *   - Store the output in a secrets manager (Doppler, Vault, AWS Secrets Manager).
+ *   - Never commit actual mnemonic values to version control.
+ *   - Treat these phrases like private keys — if compromised, funds are at risk.
+ *
+ * How it works:
+ *   1. Generates 128 bits of cryptographically random entropy via Node.js crypto.
+ *   2. Computes a SHA-256 checksum and appends the first 4 bits.
+ *   3. Splits the result into 11-bit groups (12 groups total).
+ *   4. Maps each group to a word from the official BIP39 English wordlist
+ *      (fetched from https://github.com/bitcoinjs/bip39).
+ */
+
+import { createHash, randomBytes } from 'crypto';
+import { get } from 'https';
+
+function fetchWordlist() {
+  return new Promise((resolve, reject) => {
+    get('https://raw.githubusercontent.com/bitcoinjs/bip39/master/src/wordlists/english.json', (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve(JSON.parse(data)));
+    }).on('error', reject);
+  });
+}
+
+function generateMnemonic(wordlist, strength = 128) {
+  const entropy = randomBytes(strength / 8);
+  const hash = createHash('sha256').update(entropy).digest();
+  const checksumBits = strength / 32;
+
+  // Convert entropy bytes to bits
+  const entropyBits = [...entropy].map(b => b.toString(2).padStart(8, '0')).join('');
+  const checksumBitsStr = [...hash].map(b => b.toString(2).padStart(8, '0')).join('').slice(0, checksumBits);
+  const bits = entropyBits + checksumBitsStr;
+
+  // Split into 11-bit groups
+  const chunks = bits.match(/.{11}/g);
+  const words = chunks.map(chunk => wordlist[parseInt(chunk, 2)]);
+  return words.join(' ');
+}
+
+const wordlist = await fetchWordlist();
+console.log(generateMnemonic(wordlist));


### PR DESCRIPTION
Operators setting up a self-hosted instance need to generate secure `SYSTEM_MNEMONIC_*` seed phrases for each chain. This PR adds a zero-dependency script to do that locally, and updates the security docs to explain the correct workflow.

Using an online mnemonic generator for production wallets is a serious security risk. This script uses only Node.js built-in `crypto` — no npm packages required — and fetches the official BIP39 wordlist from the bitcoinjs/bip39 repo.

## Changes
- `scripts/gen-mnemonic.mjs` — new script; generates a cryptographically secure 12-word BIP39 phrase using Node.js built-in crypto. Run once per `SYSTEM_MNEMONIC_*` env var.
- `docs/SECURITY.md` — updated key generation section to reference the script, updated code examples to use `@scure/bip39` (consistent with the rest of the codebase), added `SYSTEM_MNEMONIC_*` env var examples
- `docs/SECURITY_KEYS.md` — added mnemonic generation section with usage instructions and security guidance

## Usage
```bash
node scripts/gen-mnemonic.mjs
# → subway cinnamon outdoor must lamp parent oblige brown engage salad volcano loud
```
Run once per chain variable. Never reuse the same phrase across chains.