### PR TITLE
feat: add platform_fee_amount column to stripe_transactions table

### DIFF
--- a/supabase/migrations/20260407053129_add_platform_fee_to_stripe_transactions.sql
+++ b/supabase/migrations/20260407053129_add_platform_fee_to_stripe_transactions.sql
@@ -1,0 +1,2 @@
+-- Add platform_fee_amount column to stripe_transactions table
+ALTER TABLE stripe_transactions ADD COLUMN IF NOT EXISTS platform_fee_amount numeric;


### PR DESCRIPTION
The `stripe_transactions` table was missing a column to store the platform fee amount (the portion CoinPay retains from a Stripe transaction). Without this, platform fee data returned from Stripe couldn't be persisted, making reconciliation and reporting incomplete.

## Changes
- `supabase/migrations/20260407053129_add_platform_fee_to_stripe_transactions.sql` — adds `platform_fee_amount numeric` column using `ADD COLUMN IF NOT EXISTS` so it's safe to run on existing deployments