### PR TITLE
fix(invoices): SupabaseClient type mismatch breaking prod build

### DIFF
--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
 import { getFeePercentage } from '@/lib/payments/fees';
@@ -12,7 +12,7 @@ import { isApiKey, getBusinessByApiKey } from '@/lib/auth/apikey';
  * or { merchantId, businessId: null } for JWT auth (caller must resolve businessId).
  */
 async function resolveMerchant(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   authHeader: string | null
 ): Promise<
   | { merchantId: string; apiKeyBusinessId: string | null }


### PR DESCRIPTION
## Summary

Fixes the `Failed to compile` TypeScript error on `/api/invoices` that's blocking the Railway build.

## Root cause

`resolveMerchant` in `src/app/api/invoices/route.ts` typed its `supabase` parameter as `ReturnType<typeof createClient>`, then passed that instance to `getBusinessByApiKey` which accepts the default `SupabaseClient` (no generic args).

In the current `@supabase/supabase-js` version these resolve to incompatible shapes:

```
ReturnType<typeof createClient>  =>  SupabaseClient<any, "public", "public", any, any>
SupabaseClient (default)          =>  SupabaseClient<unknown, { PostgrestVersion: string }, never, never, { PostgrestVersion: string }>
```

TS flags the call with `Type '"public"' is not assignable to type 'never'` and Next.js refuses to compile.

## Fix

Type the parameter as `SupabaseClient` (same type `getBusinessByApiKey` already uses) so both call sites share one shape. Works against either Supabase version.

2-line change.

## Test plan

- [x] `pnpm build` green end to end
- [x] Full pre-commit vitest suite passes (3,198 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)