### PR TITLE
fix(.env.example): full env schema (95 keys) — selfhoster feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,36 +7,49 @@
 # ------------------------------------------
 # SUPABASE ALIGNMENT (REQUIRED)
 # ------------------------------------------
+# From your Supabase project dashboard: Settings → API
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
+# New API-keys style (gradually replacing anon/service_role)
+# From Settings → API → API Keys
+SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
+SUPABASE_SECRET_KEY=your-supabase-secret-key
+SUPABASE_SECRETMAT_KEY=your-supabase-secret-mat-key
+
+# For migrations + CLI (Settings → Database → Connection string)
+SUPABASE_ACCESS_TOKEN=your-supabase-personal-access-token
+SUPABASE_DB_PASSWORD=your-supabase-db-password
+SUPABASE_JWT_SECRET=your-supabase-jwt-secret
 
 # ------------------------------------------
 # ENCRYPTION & AUTHENTICATION (REQUIRED)
 # ------------------------------------------
 # Generate with: openssl rand -hex 32
-ENCRYPTION_KEY=your-32-byte-hex-encryption-key-here
+ENCRYPTION_KEY=changeme-generate-with-openssl-rand-hex-32
 # Master encryption key for advanced features
-MASTER_ENCRYPTION_KEY=your-master-encryption-key
+MASTER_ENCRYPTION_KEY=changeme-generate-with-openssl-rand-hex-32
 # Used for Lightning Network keys
-LN_KEY_ENCRYPTION_KEY=your-ln-key-encryption-key
+LN_KEY_ENCRYPTION_KEY=changeme-generate-with-openssl-rand-hex-32
 # Generate with: openssl rand -base64 64
-JWT_SECRET=your-jwt-secret-here
+JWT_SECRET=changeme-generate-with-openssl-rand-base64-64
 # Generate with: openssl rand -hex 32
-OIDC_SIGNING_SECRET=your-oidc-signing-secret-here
+OIDC_SIGNING_SECRET=changeme-generate-with-openssl-rand-hex-32
 # Generate with: openssl rand -hex 32
-REPUTATION_SIGNING_SECRET=your-reputation-signing-secret-here
+REPUTATION_SIGNING_SECRET=changeme-generate-with-openssl-rand-hex-32
 
 # ------------------------------------------
 # APPLICATION URLS & CORS (REQUIRED)
 # ------------------------------------------
-NODE_ENV=development
+NODE_ENV=production
 PORT=8080
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-APP_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:3000/api
-ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
-CORS_ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+NEXT_PUBLIC_APP_URL=https://your-domain.com
+APP_URL=https://your-domain.com
+NEXT_PUBLIC_API_URL=https://your-domain.com/api
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS=https://your-domain.com
+CORS_ALLOWED_ORIGINS=https://your-domain.com
 
 # ------------------------------------------
 # RPC PROVIDER URLS
@@ -45,34 +58,49 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
 ALCHEMY_API_KEY=your-alchemy-api-key
 
 # REQUIRED for Core Chains
-BITCOIN_RPC_URL=https://btc-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-ETHEREUM_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-POLYGON_RPC_URL=https://polygon-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-SOLANA_RPC_URL=https://solana-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-NEXT_PUBLIC_SOLANA_RPC_URL=https://solana-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-NEXT_PUBLIC_SOLANA_NETWORK=mainnet
+BITCOIN_RPC_URL=https://your-bitcoin-rpc-endpoint
+ETHEREUM_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/your-api-key
+POLYGON_RPC_URL=https://polygon-mainnet.g.alchemy.com/v2/your-api-key
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta
 
 # OPTIONAL for Alt Chains
-BCH_RPC_URL=https://rest.cryptoapis.io/blockchain-data/bitcoin-cash/mainnet
+BCH_RPC_URL=https://your-bitcoin-cash-rpc-endpoint
 BNB_RPC_URL=https://bsc-dataseed.binance.org
 BSC_RPC_URL=https://bsc-dataseed.binance.org
-ADA_RPC_URL=https://cardano-mainnet.blockfrost.io/api/v0
-XRP_RPC_URL=https://xrplcluster.com
-DOGE_RPC_URL=https://doge-rpc.example.com
-BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
-ARB_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
+ADA_RPC_URL=https://your-cardano-rpc-endpoint
+XRP_RPC_URL=wss://xrplcluster.com
+DOGE_RPC_URL=https://your-dogecoin-rpc-endpoint
+BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/your-api-key
+ARB_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/your-api-key
 AVAX_RPC_URL=https://api.avax.network/ext/bc/C/rpc
-OP_RPC_URL=https://opt-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
+OP_RPC_URL=https://opt-mainnet.g.alchemy.com/v2/your-api-key
 
 # ------------------------------------------
 # PLATFORM FEE WALLETS (REQUIRED)
 # ------------------------------------------
 # Where the system's 0.5% commission is sent (NEVER commit actual values)
-PLATFORM_FEE_WALLET_BTC=your-bitcoin-address
-PLATFORM_FEE_WALLET_BCH=your-bitcoin-cash-address
-PLATFORM_FEE_WALLET_ETH=your-ethereum-address
-PLATFORM_FEE_WALLET_POL=your-polygon-address
-PLATFORM_FEE_WALLET_SOL=your-solana-address
+# Native chain wallets
+PLATFORM_FEE_WALLET_BTC=your-btc-platform-fee-address
+PLATFORM_FEE_WALLET_BCH=your-bch-platform-fee-address
+PLATFORM_FEE_WALLET_ETH=your-eth-platform-fee-address
+PLATFORM_FEE_WALLET_POL=your-polygon-platform-fee-address
+PLATFORM_FEE_WALLET_SOL=your-solana-platform-fee-address
+PLATFORM_FEE_WALLET_BNB=your-bnb-platform-fee-address
+PLATFORM_FEE_WALLET_ADA=your-ada-platform-fee-address
+PLATFORM_FEE_WALLET_DOGE=your-doge-platform-fee-address
+PLATFORM_FEE_WALLET_XRP=your-xrp-platform-fee-address
+
+# Stablecoin wallets (per-chain variants — set the ones you accept)
+PLATFORM_FEE_WALLET_USDC=your-usdc-platform-fee-address
+PLATFORM_FEE_WALLET_USDC_ETH=your-usdc-on-ethereum-address
+PLATFORM_FEE_WALLET_USDC_POL=your-usdc-on-polygon-address
+PLATFORM_FEE_WALLET_USDC_SOL=your-usdc-on-solana-address
+PLATFORM_FEE_WALLET_USDT=your-usdt-platform-fee-address
+PLATFORM_FEE_WALLET_USDT_ETH=your-usdt-on-ethereum-address
+PLATFORM_FEE_WALLET_USDT_POL=your-usdt-on-polygon-address
+PLATFORM_FEE_WALLET_USDT_SOL=your-usdt-on-solana-address
 
 # ------------------------------------------
 # SYSTEM HD WALLET SEED PHRASES
@@ -89,59 +117,81 @@ PLATFORM_FEE_WALLET_SOL=your-solana-address
 # NEVER commit actual values — treat these like private keys.
 
 # REQUIRED Core Chains:
-SYSTEM_MNEMONIC_BTC="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_ETH="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_POL="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_SOL="your twelve word bip39 mnemonic phrase goes here like this example"
+SYSTEM_MNEMONIC_BTC="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_ETH="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_POL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_SOL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
-# OPTIONAL Alt Chains & Tokens:
-SYSTEM_MNEMONIC_ADA="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_BCH="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_BNB="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_DOGE="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_USDC="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_USDT="your twelve word bip39 mnemonic phrase goes here like this example"
-SYSTEM_MNEMONIC_XRP="your twelve word bip39 mnemonic phrase goes here like this example"
-MASTER_MNEMONIC="your twelve word bip39 mnemonic phrase goes here like this example"
+# OPTIONAL Alt Chains:
+SYSTEM_MNEMONIC_ADA="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_BCH="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_BNB="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_DOGE="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_XRP="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
+# Stablecoin mnemonics (per-chain variants — set the ones you accept)
+SYSTEM_MNEMONIC_USDC="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDC_ETH="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDC_POL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDC_SOL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDT="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDT_ETH="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDT_POL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+SYSTEM_MNEMONIC_USDT_SOL="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+
+# Master mnemonic (optional — kept for legacy single-wallet deployments)
+MASTER_MNEMONIC="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
 # ------------------------------------------
 # THIRD_PARTY APIS
 # ------------------------------------------
 # Tatum API (Exchange Rates for BTC, ETH, SOL)
-TATUM_API_KEY=your-tatum-api-key-here
+TATUM_API_KEY=your-tatum-api-key
+
+# Kraken API (fallback for exchange rates, used for POL/Polygon)
+# Public Ticker API doesn't require auth, but keys enable private APIs
+KRAKEN_API_KEY=your-kraken-api-key
+KRAKEN_API_SECRET=your-kraken-api-secret
 
 # Crypto APIs (for BCH and other blockchains - https://cryptoapis.io/)
-CRYPTO_APIS_KEY=your-crypto-apis-key-here
-CRYPTOAPIS_API_KEY=your-crypto-apis-key-here
+CRYPTO_APIS_KEY=your-cryptoapis-key
+CRYPTOAPIS_API_KEY=your-cryptoapis-key
 
 # Block Explorers (for indexing and finalizing transactions)
 ETHERSCAN_API_KEY=your-etherscan-api-key
 POLYGONSCAN_API_KEY=your-polygonscan-api-key
 BSCSCAN_API_KEY=your-bscscan-api-key
-BLOCKFROST_API_KEY=your-blockfrost-api-key-here
+BLOCKFROST_API_KEY=your-blockfrost-api-key
 
 # ChangeNOW (Swaps)
 CHANGENOW_API_KEY=your-changenow-api-key
 
-# Mailgun / Resend (Email Notifications)
+# Mailgun / Resend (Email Notifications — pick one)
 MAILGUN_API_KEY=your-mailgun-api-key
-MAILGUN_DOMAIN=mg.example.com
-FROM_EMAIL=noreply@example.com
-REPLY_TO_EMAIL=support@example.com
+MAILGUN_DOMAIN=mg.your-domain.com
+FROM_EMAIL=no-reply@your-domain.com
+REPLY_TO_EMAIL=support@your-domain.com
 RESEND_API_KEY=your-resend-api-key
 
 # ------------------------------------------
 # WEBHOOKS & INTERNAL APIS
 # ------------------------------------------
 # Generate with: openssl rand -hex 32
-WEBHOOK_SECRET=your-webhook-secret
-WEBHOOK_SIGNING_SECRET=your-webhook-signing-secret
-COINPAY_WEBHOOK_SECRET=your-coinpay-webhook-secret
+WEBHOOK_SECRET=changeme-generate-with-openssl-rand-hex-32
+WEBHOOK_SIGNING_SECRET=changeme-generate-with-openssl-rand-base64-32
+COINPAY_WEBHOOK_SECRET=changeme-generate-with-openssl-rand-hex-32
 
 # Internal APIs and Cron
-INTERNAL_API_KEY=your-internal-api-key-here
-CRON_SECRET=your-cron-secret-here
+INTERNAL_API_KEY=changeme-generate-with-openssl-rand-hex-32
+CRON_SECRET=changeme-generate-with-openssl-rand-hex-32
+
+# ------------------------------------------
+# MONITORING
+# ------------------------------------------
+# Set to "true" to start the background payment monitor loop.
+# Disable in local dev to avoid RPC burn; enable on the server that
+# owns the cron / worker role.
+ENABLE_BACKGROUND_MONITOR=false
 
 # ------------------------------------------
 # MISCELLANEOUS & OPTIONAL
@@ -150,22 +200,62 @@ CRON_SECRET=your-cron-secret-here
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your-walletconnect-project-id
 
 # Stripe (Optional for Card Payments)
-STRIPE_SECRET_KEY=sk_live_xxx
-STRIPE_WEBHOOK_SECRET=whsec_xxx
-STRIPE_CONNECT_WEBHOOK_SECRET=whsec_xxx
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret
+STRIPE_PUBLISHABLE_KEY=pk_test_your-stripe-publishable-key
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your-stripe-publishable-key
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
+STRIPE_CONNECT_WEBHOOK_SECRET=whsec_your-stripe-connect-webhook-secret
+# Stripe Connect organization id (platform account)
+STRIPE_ORG_ID=acct_your-stripe-org-id
 
 # WebAuthn (Optional)
-WEBAUTHN_RP_ID=localhost
-WEBAUTHN_ORIGIN=http://localhost:3000
+WEBAUTHN_RP_ID=your-domain.com
+WEBAUTHN_ORIGIN=https://your-domain.com
 
-# LNbits (Optional Lightning Network)
-LNBITS_URL=https://legend.lnbits.com
-LNBITS_ADMIN_KEY=your-admin-key
-LNBITS_INVOICE_KEY=your-invoice-key
+# ------------------------------------------
+# LIGHTNING NETWORK (Optional)
+# ------------------------------------------
+# LNbits — hosted Lightning accounts
+LNBITS_URL=https://your-lnbits-instance.com
+LNBITS_ADMIN_KEY=your-lnbits-admin-key
+LNBITS_INVOICE_KEY=your-lnbits-invoice-key
+# Optional: self-hosted LNbits droplet provisioning
+LNBITS_DROPLET_HOST=your-droplet-host
+LNBITS_DROPLET_USER=your-droplet-user
 
-# SideShift (Optional integration)
-SIDESHIFT_AFFILIATE_ID=your-affiliate-id
+# Greenlight (Blockstream's hosted Lightning node service)
+# Credentials are typically multi-line PEM — keep on one line with
+# \n separators or use a secret manager (Doppler / 1Password) to
+# inject the real PEM at runtime.
+GL_NOBODY_CRT=-----BEGIN CERTIFICATE-----\nyour-pem-body-here\n-----END CERTIFICATE-----
+GL_NOBODY_KEY=-----BEGIN PRIVATE KEY-----\nyour-pem-body-here\n-----END PRIVATE KEY-----
+# bitcoin | testnet
+GL_NETWORK=bitcoin
+GL_WEBHOOK_SECRET=changeme-generate-with-openssl-rand-hex-32
+
+# Blockstream API (Optional — for auxiliary explorer / broadcast paths)
+BLOCKSTREAM_CLIENT_ID=your-blockstream-client-id
+BLOCKSTREAM_CLIENT_SECRET=your-blockstream-client-secret
+
+# ------------------------------------------
+# SWAPS (Optional)
+# ------------------------------------------
+# SideShift integration
+SIDESHIFT_AFFILIATE_ID=your-sideshift-affiliate-id
 SIDESHIFT_SECRET=your-sideshift-secret
 
-# Developer tokens
-NPM_TOKEN=your-npm-token-here
+# ------------------------------------------
+# DEVELOPER TOKENS (Optional)
+# ------------------------------------------
+# For publishing private packages (e.g., @profullstack/*)
+NPM_TOKEN=your-npm-token
+
+# ------------------------------------------
+# DOPPLER (Optional — for teams using Doppler secrets manager)
+# ------------------------------------------
+# If you use Doppler to inject env vars at build/run time, these
+# values are picked up by the Doppler CLI. Not required if you're
+# injecting env another way.
+DOPPLER_PROJECT=coinpayportal
+DOPPLER_CONFIG=prod
+DOPPLER_ENVIRONMENT=prod

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
 import { getFeePercentage } from '@/lib/payments/fees';
@@ -12,7 +12,7 @@ import { isApiKey, getBusinessByApiKey } from '@/lib/auth/apikey';
  * or { merchantId, businessId: null } for JWT auth (caller must resolve businessId).
  */
 async function resolveMerchant(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   authHeader: string | null
 ): Promise<
   | { merchantId: string; apiKeyBusinessId: string | null }


### PR DESCRIPTION
## Summary

A selfhoster reported that the `.env.example` in the repo is incomplete — the app reads ~95 environment variables at runtime but only ~80 were listed in the example, so booting a fresh deployment surfaces missing vars only after the process is already running.

This PR re-syncs `.env.example` to the full schema.

## Keys covered

**121 total** (95 from prod + 26 existing optionals), grouped by section:

- Supabase alignment — now includes the new publishable/secret/secretmat key style alongside legacy anon/service_role, plus db password, JWT secret, and access token for migrations
- Encryption & auth — all six signing/encryption keys with `openssl rand` generation hints
- Application URLs & CORS
- RPC provider URLs — core chains (BTC/ETH/POL/SOL) + alt chains (BCH, BNB, ADA, XRP, DOGE, Base, Arb, AVAX, Optimism)
- **Platform fee wallets** — now includes all stablecoin per-chain variants (USDC/USDT on ETH, POL, SOL) plus ADA, BNB, DOGE, XRP that were previously missing
- **System HD mnemonics** — adds the per-chain stablecoin variants (USDC_ETH, USDC_POL, USDC_SOL, USDT_ETH, USDT_POL, USDT_SOL)
- Third-party APIs — **now includes Kraken API credentials** used for POL exchange rates
- Webhooks & internal APIs
- **Monitoring** — new `ENABLE_BACKGROUND_MONITOR` flag so selfhosters know to turn it off in dev
- Stripe — **now includes** `STRIPE_ORG_ID`, `STRIPE_PUBLISHABLE_KEY`, and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
- WebAuthn
- **Greenlight Lightning** — entirely new section with `GL_NOBODY_CRT`, `GL_NOBODY_KEY`, `GL_NETWORK`, `GL_WEBHOOK_SECRET`
- LNbits — now also documents optional droplet host/user
- **Blockstream** — new section
- SideShift
- Developer tokens (`NPM_TOKEN`)
- **Doppler** — new section for teams using the Doppler secrets manager

## Placeholder style

Every value is a placeholder — NO real values were read into this diff (verified by grepping the output for real-looking tokens before commit):

- URLs → `https://your-domain.com` or the public mainnet endpoint
- Secrets → `changeme-generate-with-openssl-rand-*`
- Mnemonics → `"word1 word2 ... word12"` (12-word BIP39 placeholder)
- PEM certs → literal `-----BEGIN...` placeholder body
- Platform-fee addresses → `your-<chain>-platform-fee-address`

## Drive-by fix

This branch also carries the same 2-line `SupabaseClient` type fix from PR #90 (`src/app/api/invoices/route.ts`). Without it the branch's pre-commit gate rejects the commit because `pnpm build` fails on master's TS error. If #90 lands first this diff becomes a no-op on merge. If this lands first #90 can rebase and drop the invoices hunk.

## Test plan

- [x] `pnpm build` green
- [x] Full pre-commit vitest suite passes (3,198 tests, ~5 min)
- [x] All 95 `.env.prod` keys present in `.env.example` (verified with `comm`)
- [x] No real values leaked (grep sweep for UUIDs / hex blobs / real domains)
- [ ] Selfhoster verifies they can boot against the new example

🤖 Generated with [Claude Code](https://claude.com/claude-code)