### PR TITLE
Fix invoice API key auth compatibility

### DIFF
--- a/src/app/api/invoices/route.test.ts
+++ b/src/app/api/invoices/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/jwt', () => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock('@/lib/secrets', () => ({
+  getJwtSecret: vi.fn(() => 'test-secret'),
+}));
+
+vi.mock('@/lib/payments/fees', () => ({
+  getFeePercentage: vi.fn(() => 0.01),
+}));
+
+vi.mock('@/lib/entitlements/service', () => ({
+  isBusinessPaidTier: vi.fn(async () => false),
+}));
+
+vi.mock('@/lib/auth/apikey', () => ({
+  isApiKey: vi.fn((token: string) => token?.startsWith('cp_live_') || token?.startsWith('cp_test_')),
+  getBusinessByApiKey: vi.fn(),
+}));
+
+import { createClient } from '@supabase/supabase-js';
+import { getBusinessByApiKey } from '@/lib/auth/apikey';
+import { POST } from './route';
+
+const API_KEY = 'cp_test_' + 'a'.repeat(32);
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/invoices', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': API_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/invoices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts a CoinPay API key from X-API-Key when creating invoices', async () => {
+    const businessSelect = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 'biz-1' }, error: null }),
+    };
+
+    const invoiceInsert = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: 'inv-1',
+          business_id: 'biz-1',
+          invoice_number: 'INV-006',
+          amount: 200,
+          currency: 'USD',
+        },
+        error: null,
+      }),
+    };
+
+    const invoiceTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { invoice_number: 'INV-005' }, error: null }),
+      insert: vi.fn().mockReturnValue(invoiceInsert),
+    };
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'businesses') return businessSelect;
+        if (table === 'invoices') return invoiceTable;
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+
+    (createClient as any).mockReturnValue(supabase);
+    (getBusinessByApiKey as any).mockResolvedValue({
+      success: true,
+      business: {
+        id: 'biz-1',
+        merchant_id: 'merchant-1',
+        name: 'Test Business',
+        active: true,
+      },
+    });
+
+    const response = await POST(
+      postRequest({
+        amount: 200,
+        currency: 'USD',
+        notes: 'UGig invoice smoke test',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        invoice: expect.objectContaining({ id: 'inv-1' }),
+      })
+    );
+    expect(getBusinessByApiKey).toHaveBeenCalledWith(supabase, API_KEY);
+    expect(invoiceTable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'merchant-1',
+        business_id: 'biz-1',
+        invoice_number: 'INV-006',
+        amount: 200,
+        currency: 'USD',
+      })
+    );
+  });
+});

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -7,7 +7,7 @@ import { resolveMerchant } from '@/lib/auth/merchant';
 /**
  * GET /api/invoices
  * List all invoices for authenticated merchant.
- * Accepts either a JWT Bearer token or a cp_live_ API key.
+ * Accepts either a JWT Bearer token or a CoinPay API key.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
 /**
  * POST /api/invoices
  * Create a new invoice.
- * Accepts either a JWT Bearer token or a cp_live_ API key.
+ * Accepts either a JWT Bearer token or a CoinPay API key.
  * When authenticated via API key the business is already resolved from the key;
  * the caller may still pass business_id but it must match the key's business.
  */

--- a/src/lib/auth/apikey.test.ts
+++ b/src/lib/auth/apikey.test.ts
@@ -53,6 +53,13 @@ describe('API Key Service', () => {
       expect(result.error).toBeUndefined();
     });
 
+    it('should validate a correctly formatted test API key', () => {
+      const validKey = 'cp_test_' + 'b'.repeat(32);
+      const result = validateApiKeyFormat(validKey);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
     it('should reject empty API key', () => {
       const result = validateApiKeyFormat('');
       expect(result.valid).toBe(false);
@@ -68,7 +75,7 @@ describe('API Key Service', () => {
     it('should reject API key without correct prefix', () => {
       const result = validateApiKeyFormat('invalid_' + 'a'.repeat(32));
       expect(result.valid).toBe(false);
-      expect(result.error).toContain('must start with cp_live_');
+      expect(result.error).toContain('must start with cp_live_ or cp_test_');
     });
 
     it('should reject API key with incorrect length', () => {
@@ -291,6 +298,10 @@ describe('API Key Service', () => {
 
     it('should return true for any string starting with cp_live_', () => {
       expect(isApiKey('cp_live_anything')).toBe(true);
+    });
+
+    it('should return true for any string starting with cp_test_', () => {
+      expect(isApiKey('cp_test_anything')).toBe(true);
     });
 
     it('should return false for JWT token', () => {

--- a/src/lib/auth/apikey.ts
+++ b/src/lib/auth/apikey.ts
@@ -4,7 +4,8 @@ import { randomBytes } from 'crypto';
 /**
  * API Key Configuration
  */
-const API_KEY_PREFIX = 'cp_live_';
+const API_KEY_PREFIXES = ['cp_live_', 'cp_test_'] as const;
+const API_KEY_PREFIX = API_KEY_PREFIXES[0];
 const API_KEY_LENGTH = 32; // 32 random characters after prefix
 const TOTAL_KEY_LENGTH = API_KEY_PREFIX.length + API_KEY_LENGTH;
 
@@ -57,14 +58,15 @@ export function validateApiKeyFormat(apiKey: string): ApiKeyValidation {
     };
   }
 
-  if (!apiKey.startsWith(API_KEY_PREFIX)) {
+  const prefix = API_KEY_PREFIXES.find(candidate => apiKey.startsWith(candidate));
+  if (!prefix) {
     return {
       valid: false,
-      error: `API key must start with ${API_KEY_PREFIX}`,
+      error: `API key must start with ${API_KEY_PREFIXES.join(' or ')}`,
     };
   }
 
-  if (apiKey.length !== TOTAL_KEY_LENGTH) {
+  if (apiKey.length !== prefix.length + API_KEY_LENGTH) {
     return {
       valid: false,
       error: `API key must be ${TOTAL_KEY_LENGTH} characters long`,
@@ -72,7 +74,7 @@ export function validateApiKeyFormat(apiKey: string): ApiKeyValidation {
   }
 
   // Validate that the part after prefix is hexadecimal (case-insensitive)
-  const keyPart = apiKey.substring(API_KEY_PREFIX.length);
+  const keyPart = apiKey.substring(prefix.length);
   if (!/^[a-fA-F0-9]{32}$/.test(keyPart)) {
     return {
       valid: false,
@@ -197,5 +199,5 @@ export async function regenerateApiKey(
  * @returns {boolean} True if token is an API key
  */
 export function isApiKey(token: string): boolean {
-  return token?.startsWith(API_KEY_PREFIX) ?? false;
+  return API_KEY_PREFIXES.some(prefix => token?.startsWith(prefix)) ?? false;
 }

--- a/src/lib/oauth/auth.ts
+++ b/src/lib/oauth/auth.ts
@@ -1,11 +1,11 @@
 /**
  * Shared OAuth authentication utility
- * Supports both JWT Bearer tokens and CoinPay API keys (cp_live_*)
+ * Supports both JWT Bearer tokens and CoinPay API keys (cp_live_* / cp_test_*)
  */
 import { NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
-import { isApiKey, validateApiKeyFormat, getBusinessByApiKey } from '@/lib/auth/apikey';
+import { isApiKey, getBusinessByApiKey } from '@/lib/auth/apikey';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -69,10 +69,9 @@ export async function getAuthUser(request: NextRequest): Promise<{ id: string } 
  * Uses the same getBusinessByApiKey as the main auth module for consistency.
  */
 async function resolveApiKey(apiKey: string): Promise<{ id: string } | null> {
-  // Quick format check — accept any string starting with cp_live_
-  // (the full validation happens in getBusinessByApiKey)
-  if (!apiKey || !apiKey.startsWith('cp_live_')) {
-    console.warn('[OAuth Auth] API key does not start with cp_live_');
+  // Quick format check; the full validation happens in getBusinessByApiKey.
+  if (!isApiKey(apiKey)) {
+    console.warn('[OAuth Auth] API key does not use a CoinPay prefix');
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fixes #96.

- Accept `cp_test_*` API keys anywhere the shared API-key helper detects or validates CoinPay business keys, while keeping `cp_live_*` generation unchanged.
- Let `GET /api/invoices` and `POST /api/invoices` authenticate via `X-API-Key` by normalizing it to the existing Bearer-token resolver.
- Keep OAuth API-key auth aligned with the shared helper and remove its stale `cp_live_*`-only check.
- Add regression coverage for creating an invoice via `X-API-Key` and for recognizing `cp_test_*` keys.

## Validation

- `corepack pnpm@10.14.0 vitest run src/lib/auth/apikey.test.ts src/app/api/invoices/route.test.ts`
- `corepack pnpm@10.14.0 type-check`
- `corepack pnpm@10.14.0 exec eslint src/lib/auth/apikey.ts src/lib/auth/apikey.test.ts src/lib/oauth/auth.ts src/app/api/invoices/route.ts src/app/api/invoices/route.test.ts`
- Commit hook: `next build --webpack` plus full `vitest run` suite: 216 test files passed, 3257 tests passed, 12 skipped.