### PR TITLE
fix: protect wallet service routes

### DIFF
--- a/src/app/api/cron/monitor-payments/route.test.ts
+++ b/src/app/api/cron/monitor-payments/route.test.ts
@@ -133,13 +133,12 @@ describe('Monitor Payments - Authentication', () => {
     expect(response.status).toBe(200);
   });
 
-  it('should accept Vercel cron requests', async () => {
-    setupMocks({});
+  it('should reject spoofed Vercel cron headers', async () => {
     const request = new NextRequest('http://localhost:3000/api/cron/monitor-payments', {
       headers: { 'x-vercel-cron': '1' },
     });
     const response = await GET(request);
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(401);
   });
 });
 

--- a/src/app/api/cron/monitor-payments/route.ts
+++ b/src/app/api/cron/monitor-payments/route.ts
@@ -6,8 +6,7 @@
  * Background job to monitor pending payments and escrows.
  * Should be called by an external cron service every 15 seconds.
  *
- * Authentication: CRON_SECRET or INTERNAL_API_KEY in Authorization header,
- * or x-vercel-cron header for Vercel Cron.
+ * Authentication: CRON_SECRET or INTERNAL_API_KEY in Authorization header.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -46,11 +45,6 @@ function getCronSecret(): string | undefined {
  * Authenticate the cron request
  */
 function authenticateRequest(request: NextRequest): boolean {
-  // Allow Vercel Cron requests
-  if (request.headers.get('x-vercel-cron') === '1') {
-    return true;
-  }
-
   const cronSecret = getCronSecret();
   if (!cronSecret) {
     console.error('CRON_SECRET or INTERNAL_API_KEY not configured');

--- a/src/app/api/lightning/address/route.test.ts
+++ b/src/app/api/lightning/address/route.test.ts
@@ -5,6 +5,7 @@ const mockCreatePayLink = vi.fn();
 const mockCreateUserWallet = vi.fn();
 const mockGetPayLink = vi.fn();
 const mockFrom = vi.fn();
+const mockAuthenticateWalletRequest = vi.fn();
 
 vi.mock('@/lib/lightning/lnbits', () => ({
   createPayLink: (...args: unknown[]) => mockCreatePayLink(...args),
@@ -18,11 +19,16 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
+vi.mock('@/lib/web-wallet/auth', () => ({
+  authenticateWalletRequest: (...args: unknown[]) => mockAuthenticateWalletRequest(...args),
+}));
+
 describe('/api/lightning/address', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'http://localhost:54321');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-key');
+    mockAuthenticateWalletRequest.mockResolvedValue({ success: true, walletId: 'w1' });
 
     mockFrom.mockImplementation((table: string) => {
       const state: {
@@ -121,6 +127,7 @@ describe('/api/lightning/address', () => {
   });
 
   it('returns 404 when wallet does not exist', async () => {
+    mockAuthenticateWalletRequest.mockResolvedValue({ success: true, walletId: 'missing' });
     mockFrom.mockImplementation(() => {
       const query = {
         select: vi.fn(() => query),

--- a/src/app/api/lightning/address/route.test.ts
+++ b/src/app/api/lightning/address/route.test.ts
@@ -154,6 +154,22 @@ describe('/api/lightning/address', () => {
     expect(body.error).toBe('Wallet not found');
   });
 
+  it('authenticates before validating a requested username', async () => {
+    mockAuthenticateWalletRequest.mockResolvedValue({ success: false, error: 'Missing signature' });
+
+    const { POST } = await import('./route');
+    const req = new NextRequest('http://localhost:3000/api/lightning/address', {
+      method: 'POST',
+      body: JSON.stringify({ wallet_id: 'w1', username: 'INVALID' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(mockAuthenticateWalletRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('self-heals LNbits wallet linkage on GET when username exists', async () => {
     mockFrom.mockImplementation((table: string) => {
       const state: { selectCols?: string; eqMap: Record<string, unknown> } = { eqMap: {} };

--- a/src/app/api/lightning/address/route.ts
+++ b/src/app/api/lightning/address/route.ts
@@ -126,6 +126,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
+    if (authError) return authError;
+
     // Validate username format
     if (!LIGHTNING_USERNAME_REGEX.test(username)) {
       return NextResponse.json(
@@ -133,9 +136,6 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-
-    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
-    if (authError) return authError;
 
     // Check if username is already taken
     const { data: existing } = await supabase

--- a/src/app/api/lightning/address/route.ts
+++ b/src/app/api/lightning/address/route.ts
@@ -2,6 +2,7 @@ import { encryptLnKey, decryptLnKey } from '@/lib/lightning/key-encryption';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { createPayLink, createUserWallet, getPayLink } from '@/lib/lightning/lnbits';
+import { authorizeWalletRequest } from '../wallet-auth';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -115,7 +116,8 @@ async function ensureLightningAddressBackend(supabase: ReturnType<typeof getSupa
 export async function POST(request: NextRequest) {
   try {
     const supabase = getSupabase();
-    const { wallet_id, username } = await request.json();
+    const rawBody = await request.text();
+    const { wallet_id, username } = JSON.parse(rawBody);
 
     if (!wallet_id || !username) {
       return NextResponse.json(
@@ -131,6 +133,9 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
+    if (authError) return authError;
 
     // Check if username is already taken
     const { data: existing } = await supabase
@@ -255,6 +260,9 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   }
+
+  const authError = await authorizeWalletRequest(supabase, request, walletId);
+  if (authError) return authError;
 
   let wallet: any = null;
   let walletLookupError: any = null;

--- a/src/app/api/lightning/invoices/route.ts
+++ b/src/app/api/lightning/invoices/route.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { createInvoice as createLnbitsInvoice } from '@/lib/lightning/lnbits';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeWalletRequest } from '../wallet-auth';
 
 function getSupabase() {
   return createClient(
@@ -17,7 +18,8 @@ function getSupabase() {
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const rawBody = await request.text();
+    const body = JSON.parse(rawBody);
     const { wallet_id, amount_sats, description } = body;
 
     if (!wallet_id) {
@@ -31,6 +33,9 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = getSupabase();
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
+    if (authError) return authError;
+
     const { data: wallet } = await supabase
       .from('wallets')
       .select('ln_wallet_inkey, ln_wallet_adminkey')

--- a/src/app/api/lightning/lightning-routes.test.ts
+++ b/src/app/api/lightning/lightning-routes.test.ts
@@ -52,9 +52,16 @@ vi.mock('@/lib/lightning/lightning-service', () => ({
 
 const mockCreateUserWallet = vi.fn();
 const mockWaitForExtensions = vi.fn().mockResolvedValue(true);
+const mockPayInvoice = vi.fn();
 vi.mock('@/lib/lightning/lnbits', () => ({
   createUserWallet: (...args: any[]) => mockCreateUserWallet(...args),
   waitForExtensions: (...args: any[]) => mockWaitForExtensions(...args),
+  payInvoice: (...args: any[]) => mockPayInvoice(...args),
+}));
+
+const mockAuthenticateWalletRequest = vi.fn();
+vi.mock('@/lib/web-wallet/auth', () => ({
+  authenticateWalletRequest: (...args: any[]) => mockAuthenticateWalletRequest(...args),
 }));
 
 // ──────────────────────────────────────────────
@@ -83,6 +90,7 @@ describe('Lightning Route Handlers', () => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'http://localhost:54321');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-key');
+    mockAuthenticateWalletRequest.mockResolvedValue({ success: true, walletId: 'w-1' });
   });
 
   // ────────────────────────────────────
@@ -168,10 +176,10 @@ describe('Lightning Route Handlers', () => {
   describe('GET /api/lightning/nodes/:id', () => {
     it('should return node on success', async () => {
       const { GET } = await import('./nodes/[id]/route');
-      const fakeNode = { id: 'node-1', status: 'active' };
+      const fakeNode = { id: 'node-1', wallet_id: 'w-1', status: 'active' };
       mockGetNode.mockResolvedValue(fakeNode);
 
-      const req = makeRequest('http://localhost:3000/api/lightning/nodes/node-1');
+      const req = makeRequest('http://localhost:3000/api/lightning/nodes/node-1?wallet_id=w-1');
       const res = await GET(req, { params: Promise.resolve({ id: 'node-1' }) });
       const body = await res.json();
 
@@ -184,12 +192,22 @@ describe('Lightning Route Handlers', () => {
       const { GET } = await import('./nodes/[id]/route');
       mockGetNode.mockResolvedValue(null);
 
-      const req = makeRequest('http://localhost:3000/api/lightning/nodes/bad');
+      const req = makeRequest('http://localhost:3000/api/lightning/nodes/bad?wallet_id=w-1');
       const res = await GET(req, { params: Promise.resolve({ id: 'bad' }) });
       const body = await res.json();
 
       expect(res.status).toBe(404);
       expect(body.success).toBe(false);
+    });
+
+    it('should not return another wallet node', async () => {
+      const { GET } = await import('./nodes/[id]/route');
+      mockGetNode.mockResolvedValue({ id: 'node-2', wallet_id: 'w-2', status: 'active' });
+
+      const req = makeRequest('http://localhost:3000/api/lightning/nodes/node-2?wallet_id=w-1');
+      const res = await GET(req, { params: Promise.resolve({ id: 'node-2' }) });
+
+      expect(res.status).toBe(404);
     });
   });
 
@@ -277,19 +295,15 @@ describe('Lightning Route Handlers', () => {
   // ────────────────────────────────────
 
   describe('GET /api/lightning/payments', () => {
-    it('should list payments by node_id without requiring wallet_id', async () => {
+    it('should require wallet_id before listing payments', async () => {
       const { GET } = await import('./payments/route');
-      mockListPayments.mockResolvedValue({
-        payments: [{ id: 'p-1', status: 'settled' }],
-        total: 1,
-      });
 
       const req = makeRequest('http://localhost:3000/api/lightning/payments?node_id=n1');
       const res = await GET(req);
       const body = await res.json();
 
-      expect(res.status).toBe(200);
-      expect(body.data.payments).toHaveLength(1);
+      expect(res.status).toBe(400);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('should list payments', async () => {
@@ -298,9 +312,9 @@ describe('Lightning Route Handlers', () => {
         payments: [{ id: 'p-1', status: 'settled' }],
         total: 1,
       });
-      mockGetNode.mockResolvedValue({ id: 'n1', wallet_id: 'w1' } as any);
+      mockGetNode.mockResolvedValue({ id: 'n1', wallet_id: 'w-1' } as any);
 
-      const req = makeRequest('http://localhost:3000/api/lightning/payments?node_id=n1&wallet_id=w1');
+      const req = makeRequest('http://localhost:3000/api/lightning/payments?node_id=n1&wallet_id=w-1');
       const res = await GET(req);
       const body = await res.json();
 
@@ -312,11 +326,48 @@ describe('Lightning Route Handlers', () => {
       const { GET } = await import('./payments/route');
       mockListPayments.mockResolvedValue({ payments: [], total: 0 });
 
-      const req = makeRequest('http://localhost:3000/api/lightning/payments');
+      const req = makeRequest('http://localhost:3000/api/lightning/payments?wallet_id=w-1');
       const res = await GET(req);
       const body = await res.json();
 
       expect(body.data.payments).toHaveLength(0);
+    });
+  });
+
+  describe('GET /api/lightning/nodes', () => {
+    it('should reject unauthenticated node lookups before querying node data', async () => {
+      const { GET } = await import('./nodes/route');
+      mockAuthenticateWalletRequest.mockResolvedValue({
+        success: false,
+        error: 'Missing authorization header',
+      });
+
+      const req = makeRequest('http://localhost:3000/api/lightning/nodes?wallet_id=w-1');
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(mockChain.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/lightning/payments', () => {
+    it('should reject unauthenticated payment requests before loading wallet keys', async () => {
+      const { POST } = await import('./payments/route');
+      mockAuthenticateWalletRequest.mockResolvedValue({
+        success: false,
+        error: 'Missing authorization header',
+      });
+
+      const req = makeRequest('http://localhost:3000/api/lightning/payments', {
+        method: 'POST',
+        body: JSON.stringify({ wallet_id: 'w-1', bolt12: 'lnbc1invoice' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      expect(mockChain.select).not.toHaveBeenCalled();
+      expect(mockPayInvoice).not.toHaveBeenCalled();
     });
   });
 
@@ -327,10 +378,11 @@ describe('Lightning Route Handlers', () => {
   describe('GET /api/lightning/payments/:hash', () => {
     it('should return payment by hash', async () => {
       const { GET } = await import('./payments/[hash]/route');
-      const fakePayment = { id: 'p-1', payment_hash: 'abc123', status: 'settled' };
+      const fakePayment = { id: 'p-1', node_id: 'node-1', payment_hash: 'abc123', status: 'settled' };
       mockGetPaymentStatus.mockResolvedValue(fakePayment);
+      mockGetNode.mockResolvedValue({ id: 'node-1', wallet_id: 'w-1' });
 
-      const req = makeRequest('http://localhost:3000/api/lightning/payments/abc123');
+      const req = makeRequest('http://localhost:3000/api/lightning/payments/abc123?wallet_id=w-1');
       const res = await GET(req, { params: Promise.resolve({ hash: 'abc123' }) });
       const body = await res.json();
 
@@ -342,8 +394,24 @@ describe('Lightning Route Handlers', () => {
       const { GET } = await import('./payments/[hash]/route');
       mockGetPaymentStatus.mockResolvedValue(null);
 
-      const req = makeRequest('http://localhost:3000/api/lightning/payments/bad');
+      const req = makeRequest('http://localhost:3000/api/lightning/payments/bad?wallet_id=w-1');
       const res = await GET(req, { params: Promise.resolve({ hash: 'bad' }) });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should not return another wallet payment', async () => {
+      const { GET } = await import('./payments/[hash]/route');
+      mockGetPaymentStatus.mockResolvedValue({
+        id: 'p-2',
+        node_id: 'node-2',
+        payment_hash: 'other',
+        status: 'settled',
+      });
+      mockGetNode.mockResolvedValue({ id: 'node-2', wallet_id: 'w-2' });
+
+      const req = makeRequest('http://localhost:3000/api/lightning/payments/other?wallet_id=w-1');
+      const res = await GET(req, { params: Promise.resolve({ hash: 'other' }) });
 
       expect(res.status).toBe(404);
     });

--- a/src/app/api/lightning/nodes/[id]/route.ts
+++ b/src/app/api/lightning/nodes/[id]/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { getLightningService } from '@/lib/lightning/lightning-service';
+import { authorizeWalletRequest } from '../../wallet-auth';
+
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase not configured');
+  return createClient(url, key);
+}
 
 /**
  * GET /api/lightning/nodes/:id
@@ -12,10 +21,18 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
+    const walletId = request.nextUrl.searchParams.get('wallet_id');
+    if (!walletId) {
+      return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');
+    }
+
+    const authError = await authorizeWalletRequest(getSupabase(), request, walletId);
+    if (authError) return authError;
+
     const service = getLightningService();
     const node = await service.getNode(id);
 
-    if (!node) {
+    if (!node || node.wallet_id !== walletId) {
       return WalletErrors.notFound('node');
     }
 

--- a/src/app/api/lightning/nodes/route.ts
+++ b/src/app/api/lightning/nodes/route.ts
@@ -3,7 +3,8 @@ import { NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { createUserWallet, waitForExtensions } from '@/lib/lightning/lnbits';
-import { mnemonicToSeed, isValidMnemonic } from '@/lib/web-wallet/keys';
+import { isValidMnemonic } from '@/lib/web-wallet/keys';
+import { authorizeWalletRequest } from '../wallet-auth';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -26,6 +27,9 @@ export async function GET(request: NextRequest) {
     }
 
     const supabase = getSupabase();
+    const authError = await authorizeWalletRequest(supabase, request, walletId);
+    if (authError) return authError;
+
     const { data: node, error } = await supabase
       .from('ln_nodes')
       .select('id, wallet_id, lnbits_wallet_id, node_pubkey, status, created_at')
@@ -55,7 +59,8 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const rawBody = await request.text();
+    const body = JSON.parse(rawBody);
     const { wallet_id, business_id, mnemonic } = body;
 
     if (!wallet_id) {
@@ -66,6 +71,8 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = getSupabase();
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
+    if (authError) return authError;
 
     // Check if node already exists for this wallet (idempotent)
     const { data: existing } = await supabase

--- a/src/app/api/lightning/payments/[hash]/route.ts
+++ b/src/app/api/lightning/payments/[hash]/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { getLightningService } from '@/lib/lightning/lightning-service';
+import { authorizeWalletRequest } from '../../wallet-auth';
+
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase not configured');
+  return createClient(url, key);
+}
 
 /**
  * GET /api/lightning/payments/:hash
@@ -12,10 +21,23 @@ export async function GET(
 ) {
   try {
     const { hash } = await params;
+    const walletId = request.nextUrl.searchParams.get('wallet_id');
+    if (!walletId) {
+      return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');
+    }
+
+    const authError = await authorizeWalletRequest(getSupabase(), request, walletId);
+    if (authError) return authError;
+
     const service = getLightningService();
     const payment = await service.getPaymentStatus(hash);
 
     if (!payment) {
+      return WalletErrors.notFound('payment');
+    }
+
+    const node = await service.getNode(payment.node_id);
+    if (!node || node.wallet_id !== walletId) {
       return WalletErrors.notFound('payment');
     }
 

--- a/src/app/api/lightning/payments/route.ts
+++ b/src/app/api/lightning/payments/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { getLightningService } from '@/lib/lightning/lightning-service';
 import { listPayments as listLnbitsPayments, payInvoice } from '@/lib/lightning/lnbits';
+import { authorizeWalletRequest } from '../wallet-auth';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -19,7 +20,8 @@ function getSupabase() {
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const rawBody = await request.text();
+    const body = JSON.parse(rawBody);
     const { wallet_id, bolt12, amount_sats } = body;
 
     if (!wallet_id) {
@@ -30,6 +32,9 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = getSupabase();
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id, rawBody);
+    if (authError) return authError;
+
     const { data: walletRow } = await supabase
       .from('wallets')
       .select('ln_wallet_adminkey')
@@ -115,9 +120,17 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get('limit') || '50', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
 
+    if (!wallet_id) {
+      return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');
+    }
+
+    const supabase = getSupabase();
+    const authError = await authorizeWalletRequest(supabase, request, wallet_id);
+    if (authError) return authError;
+
     const service = getLightningService();
 
-    if (node_id && wallet_id) {
+    if (node_id) {
       const node = await service.getNode(node_id);
       if (!node) return WalletErrors.notFound('node');
       if (node.wallet_id !== wallet_id) {
@@ -143,7 +156,6 @@ export async function GET(request: NextRequest) {
 
     if (wallet_id) {
       try {
-        const supabase = getSupabase();
         const { data: walletRow } = await supabase
           .from('wallets')
           .select('ln_wallet_inkey')

--- a/src/app/api/lightning/wallet-auth.ts
+++ b/src/app/api/lightning/wallet-auth.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+import { authenticateWalletRequest } from '@/lib/web-wallet/auth';
+import { WalletErrors } from '@/lib/web-wallet/response';
+
+export async function authorizeWalletRequest(
+  supabase: SupabaseClient,
+  request: NextRequest,
+  walletId: string,
+  body?: string
+) {
+  const auth = await authenticateWalletRequest(
+    supabase,
+    request.headers.get('authorization'),
+    request.method,
+    request.nextUrl.pathname,
+    body
+  );
+
+  if (!auth.success) {
+    return WalletErrors.unauthorized(auth.error);
+  }
+
+  if (auth.walletId !== walletId) {
+    return WalletErrors.forbidden('Cannot access another wallet');
+  }
+
+  return null;
+}

--- a/src/app/api/stripe/connect/onboard/route.test.ts
+++ b/src/app/api/stripe/connect/onboard/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // Use vi.hoisted so mocks are available in vi.mock factories
-const { mockStripe, mockSupabase } = vi.hoisted(() => {
+const { mockStripe, mockSupabase, mockResolveMerchant, mockVerifyBusinessAccess } = vi.hoisted(() => {
   const mockStripe = {
     accounts: {
       create: vi.fn().mockResolvedValue({
@@ -26,7 +26,12 @@ const { mockStripe, mockSupabase } = vi.hoisted(() => {
     from: vi.fn(),
   };
 
-  return { mockStripe, mockSupabase };
+  return {
+    mockStripe,
+    mockSupabase,
+    mockResolveMerchant: vi.fn(),
+    mockVerifyBusinessAccess: vi.fn(),
+  };
 });
 
 vi.mock('stripe', () => ({
@@ -35,6 +40,14 @@ vi.mock('stripe', () => ({
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn().mockReturnValue(mockSupabase),
+}));
+
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: (...args: unknown[]) => mockResolveMerchant(...args),
+}));
+
+vi.mock('@/lib/wallets/supported-coins', () => ({
+  verifyBusinessAccess: (...args: unknown[]) => mockVerifyBusinessAccess(...args),
 }));
 
 import { POST } from './route';
@@ -97,6 +110,8 @@ describe('POST /api/stripe/connect/onboard', () => {
       country: 'US',
       email: 'test@example.com',
     });
+    mockResolveMerchant.mockResolvedValue({ merchantId: 'merchant_uuid_123', apiKeyBusinessId: null });
+    mockVerifyBusinessAccess.mockResolvedValue({ ok: true });
     setupSupabase();
   });
 
@@ -248,6 +263,36 @@ describe('POST /api/stripe/connect/onboard', () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toBe('businessId is required');
+  });
+
+  it('should reject unauthenticated onboarding before calling Stripe', async () => {
+    mockResolveMerchant.mockResolvedValue({ error: 'Missing authorization header', status: 401 });
+    const request = new NextRequest('http://localhost:3000/api/stripe/connect/onboard', {
+      method: 'POST',
+      body: JSON.stringify({ business_id: 'biz_123', country: 'US' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    expect(mockStripe.accounts.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject businesses outside the authenticated merchant scope', async () => {
+    mockVerifyBusinessAccess.mockResolvedValue({
+      ok: false,
+      error: 'Business not found or access denied',
+      status: 404,
+    });
+    const request = new NextRequest('http://localhost:3000/api/stripe/connect/onboard', {
+      method: 'POST',
+      body: JSON.stringify({ business_id: 'other_business', country: 'US' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    expect(mockStripe.accounts.create).not.toHaveBeenCalled();
   });
 
   it('should handle Stripe errors gracefully', async () => {

--- a/src/app/api/stripe/connect/onboard/route.ts
+++ b/src/app/api/stripe/connect/onboard/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getStripe } from '@/lib/server/optional-deps';
 import { normalizeCountryCode } from '@/lib/stripe/connect-countries';
+import { resolveMerchant } from '@/lib/auth/merchant';
+import { verifyBusinessAccess } from '@/lib/wallets/supported-coins';
 
 function getSupabase() {
   return createClient(
@@ -20,6 +22,18 @@ export async function POST(request: NextRequest) {
 
     if (!businessId) {
       return NextResponse.json({ error: 'businessId is required' }, { status: 400 });
+    }
+
+    const authResult = await resolveMerchant(supabase, request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== businessId) {
+      return NextResponse.json({ error: 'businessId does not match API key scope' }, { status: 403 });
+    }
+    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status ?? 404 });
     }
 
     // Look up the merchant_id and any previously-stored country from the business

--- a/src/app/api/stripe/connect/status/[accountId]/route.test.ts
+++ b/src/app/api/stripe/connect/status/[accountId]/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const { mockStripe, mockSupabase } = vi.hoisted(() => {
+const { mockStripe, mockSupabase, mockResolveMerchant, mockVerifyBusinessAccess } = vi.hoisted(() => {
   const mockStripe = {
     accounts: {
       retrieve: vi.fn().mockResolvedValue({
@@ -23,7 +23,12 @@ const { mockStripe, mockSupabase } = vi.hoisted(() => {
     from: vi.fn(),
   };
 
-  return { mockStripe, mockSupabase };
+  return {
+    mockStripe,
+    mockSupabase,
+    mockResolveMerchant: vi.fn(),
+    mockVerifyBusinessAccess: vi.fn(),
+  };
 });
 
 vi.mock('stripe', () => ({
@@ -32,6 +37,14 @@ vi.mock('stripe', () => ({
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn().mockReturnValue(mockSupabase),
+}));
+
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: (...args: unknown[]) => mockResolveMerchant(...args),
+}));
+
+vi.mock('@/lib/wallets/supported-coins', () => ({
+  verifyBusinessAccess: (...args: unknown[]) => mockVerifyBusinessAccess(...args),
 }));
 
 import { GET } from './route';
@@ -62,6 +75,8 @@ describe('GET /api/stripe/connect/status/[accountId]', () => {
     process.env.STRIPE_SECRET_KEY = 'sk_test_123';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockResolveMerchant.mockResolvedValue({ merchantId: 'merchant_uuid_123', apiKeyBusinessId: null });
+    mockVerifyBusinessAccess.mockResolvedValue({ ok: true });
     mockFromChain();
   });
 
@@ -99,6 +114,20 @@ describe('GET /api/stripe/connect/status/[accountId]', () => {
 
     expect(response.status).toBe(404);
     expect(data.error).toBe('Stripe account not found');
+  });
+
+  it('should reject status lookups outside the authenticated merchant scope', async () => {
+    mockVerifyBusinessAccess.mockResolvedValue({
+      ok: false,
+      error: 'Business not found or access denied',
+      status: 404,
+    });
+    const request = new NextRequest('http://localhost:3000/api/stripe/connect/status/other_business');
+
+    const response = await GET(request, { params: Promise.resolve({ accountId: 'other_business' }) });
+
+    expect(response.status).toBe(404);
+    expect(mockStripe.accounts.retrieve).not.toHaveBeenCalled();
   });
 
   it('should report incomplete onboarding', async () => {

--- a/src/app/api/stripe/connect/status/[accountId]/route.ts
+++ b/src/app/api/stripe/connect/status/[accountId]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getStripe } from '@/lib/server/optional-deps';
+import { resolveMerchant } from '@/lib/auth/merchant';
+import { verifyBusinessAccess } from '@/lib/wallets/supported-coins';
 
 function getSupabase() {
   return createClient(
@@ -16,6 +18,18 @@ export async function GET(
   const supabase = getSupabase();
   try {
     const { accountId } = await params;
+
+    const authResult = await resolveMerchant(supabase, request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== accountId) {
+      return NextResponse.json({ error: 'businessId does not match API key scope' }, { status: 403 });
+    }
+    const access = await verifyBusinessAccess(supabase, accountId, authResult.merchantId);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status ?? 404 });
+    }
 
     // accountId here is actually the businessId — look up Stripe account by business_id
     // Get Stripe account from database

--- a/src/app/web-wallet/asset/[chain]/page.tsx
+++ b/src/app/web-wallet/asset/[chain]/page.tsx
@@ -173,13 +173,14 @@ function LightningAssetView() {
   useEffect(() => {
     if (!wallet) return;
     // Check if LN node exists for this wallet
-    fetch(`/api/lightning/nodes?wallet_id=${wallet.walletId}`, {
-      headers: { 'Authorization': `Bearer ${wallet.walletId}` },
-    })
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.success && data.data?.node) {
-          setLnNode(data.data.node);
+    wallet.getLightningNode()
+      .then((node) => {
+        if (node) {
+          setLnNode({
+            id: node.id,
+            status: node.status,
+            node_pubkey: node.node_pubkey ?? null,
+          });
         }
       })
       .catch(() => {})
@@ -215,7 +216,7 @@ function LightningAssetView() {
             onSetupComplete={(node) => setLnNode(node)}
           />
         ) : (
-          <LightningDashboard lnNode={lnNode} mnemonic={wallet?.getMnemonic() || ''} walletId={wallet?.walletId || ''} />
+          <LightningDashboard lnNode={lnNode} walletId={wallet?.walletId || ''} />
         )}
       </div>
     </>
@@ -224,7 +225,7 @@ function LightningAssetView() {
 
 // ── Lightning Dashboard ──
 
-function LightningDashboard({ lnNode, mnemonic, walletId }: { lnNode: { id: string; status: string; node_pubkey: string | null }; mnemonic: string; walletId: string }) {
+function LightningDashboard({ lnNode, walletId }: { lnNode: { id: string; status: string; node_pubkey: string | null }; walletId: string }) {
   const { wallet } = useWebWallet();
   const [activeTab, setActiveTab] = useState<'receive' | 'send' | 'payments'>('receive');
   const [lnBalance, setLnBalance] = useState<{ sats: number; usd: number } | null>(null);
@@ -291,26 +292,12 @@ function LightningDashboard({ lnNode, mnemonic, walletId }: { lnNode: { id: stri
     // Create BOLT11 invoice (one-time, works with all wallets)
     if (amountSats > 0) {
       try {
-        const resp = await fetch('/api/lightning/invoices', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            node_id: lnNode.id,
-            wallet_id: walletId,
-            amount_sats: amountSats,
-            description: newDesc,
-            mnemonic,
-          }),
-        });
-        const data = await resp.json();
-        if (data.success) {
-          results.push('BOLT11 invoice created');
-          setLastInvoice(data.data.invoice.bolt11);
-        } else {
-          errors.push(`BOLT11: ${data.error?.message || 'failed'}`);
-        }
-      } catch {
-        errors.push('BOLT11: network error');
+        if (!wallet) throw new Error('Wallet is locked');
+        const invoice = await wallet.createLightningInvoice(amountSats, newDesc);
+        results.push('BOLT11 invoice created');
+        setLastInvoice(invoice.payment_request);
+      } catch (error) {
+        errors.push(`BOLT11: ${error instanceof Error ? error.message : 'network error'}`);
       }
     }
 
@@ -477,27 +464,16 @@ function LightningDashboard({ lnNode, mnemonic, walletId }: { lnNode: { id: stri
               setPayLoading(true);
               setMessage(null);
               try {
-                const resp = await fetch('/api/lightning/payments', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    node_id: lnNode.id,
-                    wallet_id: walletId,
-                    bolt12: payBolt12,
-                    amount_sats: payAmount ? parseInt(payAmount) : undefined,
-                    mnemonic,
-                  }),
-                });
-                const data = await resp.json();
-                if (data.success) {
-                  setMessage({ type: 'success', text: 'Payment sent!' });
-                  setPayBolt12('');
-                  setPayAmount('');
-                } else {
-                  setMessage({ type: 'error', text: data.error?.message || 'Payment failed' });
-                }
-              } catch {
-                setMessage({ type: 'error', text: 'Network error' });
+                if (!wallet) throw new Error('Wallet is locked');
+                await wallet.payLightningInvoice(
+                  payBolt12,
+                  payAmount ? parseInt(payAmount) : undefined
+                );
+                setMessage({ type: 'success', text: 'Payment sent!' });
+                setPayBolt12('');
+                setPayAmount('');
+              } catch (error) {
+                setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Network error' });
               } finally {
                 setPayLoading(false);
               }

--- a/src/components/lightning/LightningAddress.tsx
+++ b/src/components/lightning/LightningAddress.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useWebWallet } from '@/components/web-wallet/WalletContext';
 
 interface LightningAddressProps {
   walletId: string;
 }
 
 export function LightningAddress({ walletId }: LightningAddressProps) {
+  const { wallet } = useWebWallet();
   const [username, setUsername] = useState('');
   const [currentAddress, setCurrentAddress] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -18,8 +20,11 @@ export function LightningAddress({ walletId }: LightningAddressProps) {
 
   // Check existing Lightning Address
   useEffect(() => {
-    fetch(`/api/lightning/address?wallet_id=${walletId}`)
-      .then((r) => r.json())
+    if (!wallet || wallet.walletId !== walletId) {
+      setChecking(false);
+      return;
+    }
+    wallet.getLightningAddress()
       .then((data) => {
         if (data.lightning_address) {
           setCurrentAddress(data.lightning_address);
@@ -28,7 +33,7 @@ export function LightningAddress({ walletId }: LightningAddressProps) {
       })
       .catch(() => {})
       .finally(() => setChecking(false));
-  }, [walletId]);
+  }, [wallet, walletId]);
 
   useEffect(() => {
     if (currentAddress) return;
@@ -79,22 +84,12 @@ export function LightningAddress({ walletId }: LightningAddressProps) {
     setMessage(null);
 
     try {
-      const res = await fetch('/api/lightning/address', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ wallet_id: walletId, username: username.trim().toLowerCase() }),
-      });
-
-      const data = await res.json();
-
-      if (res.ok && data.success) {
-        setCurrentAddress(data.lightning_address);
-        setMessage({ type: 'success', text: 'Lightning Address registered!' });
-      } else {
-        setMessage({ type: 'error', text: data.error || 'Failed to register' });
-      }
-    } catch {
-      setMessage({ type: 'error', text: 'Network error' });
+      if (!wallet || wallet.walletId !== walletId) throw new Error('Wallet is locked');
+      const data = await wallet.setLightningAddress(username.trim().toLowerCase());
+      setCurrentAddress(data.lightning_address);
+      setMessage({ type: 'success', text: 'Lightning Address registered!' });
+    } catch (error) {
+      setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Network error' });
     } finally {
       setLoading(false);
     }

--- a/src/components/lightning/LightningPayments.tsx
+++ b/src/components/lightning/LightningPayments.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { LnPayment } from '@/lib/lightning/types';
+import { useWebWallet } from '@/components/web-wallet/WalletContext';
 
 interface LightningPaymentsProps {
   nodeId?: string;
@@ -14,39 +15,27 @@ interface LightningPaymentsProps {
  * Lists Lightning payments (incoming + outgoing) with status and amount.
  */
 export function LightningPayments({ nodeId, walletId, businessId, offerId }: LightningPaymentsProps) {
+  const { wallet } = useWebWallet();
   const [payments, setPayments] = useState<LnPayment[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchPayments();
-  }, [nodeId, walletId, businessId, offerId]);
-
-  const fetchPayments = async () => {
+  const fetchPayments = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      if (nodeId) params.set('node_id', nodeId);
-      if (walletId) params.set('wallet_id', walletId);
-      if (businessId) params.set('business_id', businessId);
-      if (offerId) params.set('offer_id', offerId);
-      // Show all directions (incoming + outgoing)
-
-      const res = await fetch(`/api/lightning/payments?${params}`);
-      const json = await res.json();
-
-      if (json.success) {
-        setPayments(json.data.payments);
-      } else {
-        setError(json.error?.message || 'Failed to load payments');
-      }
+      if (!wallet || (walletId && wallet.walletId !== walletId)) throw new Error('Wallet is locked');
+      setPayments(await wallet.listLightningPayments(20, { nodeId, businessId, offerId }));
     } catch (err) {
-      setError('Network error');
+      setError(err instanceof Error ? err.message : 'Network error');
     } finally {
       setLoading(false);
     }
-  };
+  }, [businessId, nodeId, offerId, wallet, walletId]);
+
+  useEffect(() => {
+    fetchPayments();
+  }, [fetchPayments]);
 
   if (loading) {
     return (

--- a/src/components/lightning/LightningSetup.tsx
+++ b/src/components/lightning/LightningSetup.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { LnNode } from '@/lib/lightning/types';
+import { useWebWallet } from '@/components/web-wallet/WalletContext';
 
 interface LightningSetupProps {
   walletId: string;
@@ -20,6 +21,7 @@ export function LightningSetup({
   mnemonic,
   onSetupComplete,
 }: LightningSetupProps) {
+  const { wallet } = useWebWallet();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [node, setNode] = useState<LnNode | null>(null);
@@ -29,26 +31,12 @@ export function LightningSetup({
     setError(null);
 
     try {
-      const res = await fetch('/api/lightning/nodes', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          wallet_id: walletId,
-          business_id: businessId,
-          mnemonic,
-        }),
-      });
-
-      const json = await res.json();
-
-      if (json.success) {
-        setNode(json.data.node);
-        onSetupComplete?.(json.data.node);
-      } else {
-        setError(json.error?.message || 'Failed to enable Lightning');
-      }
+      if (!wallet || wallet.walletId !== walletId) throw new Error('Wallet is locked');
+      const nextNode = await wallet.enableLightning(mnemonic, businessId);
+      setNode(nextNode as LnNode);
+      onSetupComplete?.(nextNode as LnNode);
     } catch (err) {
-      setError('Network error. Please try again.');
+      setError(err instanceof Error ? err.message : 'Network error. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/src/components/lightning/__tests__/LightningAddress.test.tsx
+++ b/src/components/lightning/__tests__/LightningAddress.test.tsx
@@ -2,8 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { LightningAddress } from '../LightningAddress';
 
+const { mockGetLightningAddress, mockSetLightningAddress, mockWallet } = vi.hoisted(() => {
+  const mockGetLightningAddress = vi.fn();
+  const mockSetLightningAddress = vi.fn();
+  return {
+    mockGetLightningAddress,
+    mockSetLightningAddress,
+    mockWallet: {
+      walletId: 'w1',
+      getLightningAddress: (...args: unknown[]) => mockGetLightningAddress(...args),
+      setLightningAddress: (...args: unknown[]) => mockSetLightningAddress(...args),
+    },
+  };
+});
+
 vi.mock('@/components/web-wallet/WalletContext', () => ({
   useWebWallet: () => ({
+    wallet: mockWallet,
     resyncWalletFromSeed: vi.fn().mockResolvedValue({ walletId: 'w1' }),
   }),
 }));
@@ -13,14 +28,13 @@ global.fetch = mockFetch;
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockGetLightningAddress.mockReset();
+  mockSetLightningAddress.mockReset();
 });
 
 describe('LightningAddress', () => {
   it('shows input when no address registered', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ lightning_address: null }),
-    });
+    mockGetLightningAddress.mockResolvedValueOnce({ lightning_address: null });
 
     render(<LightningAddress walletId="w1" />);
 
@@ -31,12 +45,9 @@ describe('LightningAddress', () => {
   });
 
   it('shows existing address with copy button', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({
-        lightning_address: 'alice@coinpayportal.com',
-        username: 'alice',
-      }),
+    mockGetLightningAddress.mockResolvedValueOnce({
+      lightning_address: 'alice@coinpayportal.com',
+      username: 'alice',
     });
 
     render(<LightningAddress walletId="w1" />);
@@ -49,10 +60,7 @@ describe('LightningAddress', () => {
 
   it('registers a new username', async () => {
     // Initial check — no address
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ lightning_address: null }),
-    });
+    mockGetLightningAddress.mockResolvedValueOnce({ lightning_address: null });
 
     render(<LightningAddress walletId="w1" />);
 
@@ -76,13 +84,9 @@ describe('LightningAddress', () => {
     });
 
     // Mock registration
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({
-        success: true,
-        lightning_address: 'bob@coinpayportal.com',
-        username: 'bob',
-      }),
+    mockSetLightningAddress.mockResolvedValueOnce({
+      lightning_address: 'bob@coinpayportal.com',
+      username: 'bob',
     });
 
     fireEvent.click(screen.getByText('Claim Lightning Address'));
@@ -93,10 +97,7 @@ describe('LightningAddress', () => {
   });
 
   it('shows unavailable state for duplicate username and blocks submit', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ lightning_address: null }),
-    });
+    mockGetLightningAddress.mockResolvedValueOnce({ lightning_address: null });
 
     render(<LightningAddress walletId="w1" />);
 
@@ -122,10 +123,7 @@ describe('LightningAddress', () => {
   });
 
   it('filters invalid characters from username input', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ lightning_address: null }),
-    });
+    mockGetLightningAddress.mockResolvedValueOnce({ lightning_address: null });
 
     render(<LightningAddress walletId="w1" />);
 

--- a/src/components/lightning/__tests__/LightningPayments.test.tsx
+++ b/src/components/lightning/__tests__/LightningPayments.test.tsx
@@ -2,6 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { LightningPayments } from '../LightningPayments';
 
+const { mockListLightningPayments } = vi.hoisted(() => ({
+  mockListLightningPayments: vi.fn(),
+}));
+vi.mock('@/components/web-wallet/WalletContext', () => ({
+  useWebWallet: () => ({
+    wallet: {
+      walletId: 'w-1',
+      listLightningPayments: (...args: unknown[]) => mockListLightningPayments(...args),
+    },
+  }),
+}));
+
 const mockPayments = [
   {
     id: 'p-1',
@@ -39,19 +51,17 @@ beforeEach(() => {
 
 describe('LightningPayments', () => {
   it('should show loading state initially', () => {
-    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
-    render(<LightningPayments nodeId="n-1" />);
+    mockListLightningPayments.mockReturnValue(new Promise(() => {}));
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
     // Pulse animation divs are rendered during loading
     const container = document.querySelector('.animate-pulse');
     expect(container).toBeTruthy();
   });
 
   it('should display payments on success', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { payments: mockPayments } }),
-    });
+    mockListLightningPayments.mockResolvedValue(mockPayments);
 
-    render(<LightningPayments nodeId="n-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('+100 sats')).toBeDefined();
@@ -60,11 +70,9 @@ describe('LightningPayments', () => {
   });
 
   it('should display payer notes', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { payments: mockPayments } }),
-    });
+    mockListLightningPayments.mockResolvedValue(mockPayments);
 
-    render(<LightningPayments nodeId="n-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('Thanks for the coffee!')).toBeDefined();
@@ -72,11 +80,9 @@ describe('LightningPayments', () => {
   });
 
   it('should show empty state when no payments', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { payments: [] } }),
-    });
+    mockListLightningPayments.mockResolvedValue([]);
 
-    render(<LightningPayments nodeId="n-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('No Lightning payments yet')).toBeDefined();
@@ -84,15 +90,9 @@ describe('LightningPayments', () => {
   });
 
   it('should show error state on failure', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          success: false,
-          error: { message: 'Something went wrong' },
-        }),
-    });
+    mockListLightningPayments.mockRejectedValue(new Error('Something went wrong'));
 
-    render(<LightningPayments nodeId="n-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('Something went wrong')).toBeDefined();
@@ -100,27 +100,26 @@ describe('LightningPayments', () => {
   });
 
   it('should show error on network failure', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    mockListLightningPayments.mockRejectedValue(new Error('Network error'));
 
-    render(<LightningPayments nodeId="n-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeDefined();
     });
   });
 
-  it('should pass query params for filtering', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { payments: [] } }),
-    });
+  it('should load payments through the signed wallet SDK', async () => {
+    mockListLightningPayments.mockResolvedValue([]);
 
-    render(<LightningPayments nodeId="n-1" businessId="b-1" offerId="o-1" />);
+    render(<LightningPayments nodeId="n-1" walletId="w-1" businessId="b-1" offerId="o-1" />);
 
     await waitFor(() => {
-      const url = (global.fetch as any).mock.calls[0][0];
-      expect(url).toContain('node_id=n-1');
-      expect(url).toContain('business_id=b-1');
-      expect(url).toContain('offer_id=o-1');
+      expect(mockListLightningPayments).toHaveBeenCalledWith(20, {
+        nodeId: 'n-1',
+        businessId: 'b-1',
+        offerId: 'o-1',
+      });
     });
   });
 });

--- a/src/components/lightning/__tests__/LightningSetup.test.tsx
+++ b/src/components/lightning/__tests__/LightningSetup.test.tsx
@@ -2,6 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { LightningSetup } from '../LightningSetup';
 
+const { mockEnableLightning } = vi.hoisted(() => ({
+  mockEnableLightning: vi.fn(),
+}));
+vi.mock('@/components/web-wallet/WalletContext', () => ({
+  useWebWallet: () => ({
+    wallet: {
+      walletId: 'w-1',
+      enableLightning: (...args: unknown[]) => mockEnableLightning(...args),
+    },
+  }),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -27,7 +39,7 @@ describe('LightningSetup', () => {
   });
 
   it('should show loading state on click', async () => {
-    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    mockEnableLightning.mockReturnValue(new Promise(() => {}));
 
     render(<LightningSetup {...defaultProps} />);
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
@@ -43,9 +55,7 @@ describe('LightningSetup', () => {
       node_pubkey: '02abcdef1234567890abcdef1234567890',
       status: 'active',
     };
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { node: fakeNode } }),
-    });
+    mockEnableLightning.mockResolvedValue(fakeNode);
 
     render(<LightningSetup {...defaultProps} />);
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
@@ -58,9 +68,7 @@ describe('LightningSetup', () => {
 
   it('should call onSetupComplete callback', async () => {
     const fakeNode = { id: 'node-1', node_pubkey: '02abc', status: 'active' };
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ success: true, data: { node: fakeNode } }),
-    });
+    mockEnableLightning.mockResolvedValue(fakeNode);
     const onComplete = vi.fn();
 
     render(<LightningSetup {...defaultProps} onSetupComplete={onComplete} />);
@@ -72,13 +80,7 @@ describe('LightningSetup', () => {
   });
 
   it('should show error on API failure', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          success: false,
-          error: { message: 'Node limit reached' },
-        }),
-    });
+    mockEnableLightning.mockRejectedValue(new Error('Node limit reached'));
 
     render(<LightningSetup {...defaultProps} />);
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
@@ -89,33 +91,24 @@ describe('LightningSetup', () => {
   });
 
   it('should show error on network failure', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('Failed'));
+    mockEnableLightning.mockRejectedValue(new Error('Failed'));
 
     render(<LightningSetup {...defaultProps} />);
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
 
     await waitFor(() => {
-      expect(screen.getByText('Network error. Please try again.')).toBeDefined();
+      expect(screen.getByText('Failed')).toBeDefined();
     });
   });
 
-  it('should send correct payload to API', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({ success: true, data: { node: { id: 'n1' } } }),
-    });
+  it('should call the signed wallet SDK with provisioning details', async () => {
+    mockEnableLightning.mockResolvedValue({ id: 'n1' });
 
     render(<LightningSetup {...defaultProps} />);
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
 
     await waitFor(() => {
-      const [url, opts] = (global.fetch as any).mock.calls[0];
-      expect(url).toBe('/api/lightning/nodes');
-      expect(opts.method).toBe('POST');
-      const body = JSON.parse(opts.body);
-      expect(body.wallet_id).toBe('w-1');
-      expect(body.business_id).toBe('b-1');
-      expect(body.mnemonic).toBe('test mnemonic phrase');
+      expect(mockEnableLightning).toHaveBeenCalledWith('test mnemonic phrase', 'b-1');
     });
   });
 });

--- a/src/lib/wallet-sdk/lightning.test.ts
+++ b/src/lib/wallet-sdk/lightning.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLightningMethods } from './lightning';
+
+describe('createLightningMethods', () => {
+  it('lists wallet payments without resolving a Lightning node', async () => {
+    const request = vi.fn(async () => ({ payments: [] }));
+    const lightning = createLightningMethods({ request } as any, 'wallet-1', () => null);
+
+    await lightning.listLightningPayments();
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      method: 'GET',
+      path: '/api/lightning/payments',
+      query: {
+        wallet_id: 'wallet-1',
+        node_id: undefined,
+        business_id: undefined,
+        offer_id: undefined,
+        limit: '20',
+      },
+      authenticated: true,
+    });
+  });
+
+  it('reuses a node fetched by getLightningNode', async () => {
+    const request = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/lightning/nodes') return { node: { id: 'node-1' } };
+      return { invoice: { payment_hash: 'hash-1', bolt11: 'lnbc1' } };
+    });
+    const lightning = createLightningMethods({ request } as any, 'wallet-1', () => 'mnemonic');
+
+    await lightning.getLightningNode();
+    await lightning.createLightningInvoice(100);
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses a node created by enableLightning', async () => {
+    const request = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/lightning/nodes') return { node: { id: 'node-1' } };
+      return { payment_hash: 'hash-1', status: 'paid' };
+    });
+    const lightning = createLightningMethods({ request } as any, 'wallet-1', () => 'mnemonic');
+
+    await lightning.enableLightning('mnemonic');
+    await lightning.payLightningInvoice('lnbc1');
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/wallet-sdk/lightning.ts
+++ b/src/lib/wallet-sdk/lightning.ts
@@ -9,9 +9,11 @@ import type { WalletAPIClient } from './client';
 import type {
   LightningAddress,
   LightningInvoice,
+  LightningNode,
   LightningPayment,
   LightningPaymentStatus,
 } from './types';
+import type { LnPayment } from '@/lib/lightning/types';
 
 /**
  * Add Lightning methods to a wallet instance.
@@ -45,6 +47,36 @@ export function createLightningMethods(
 
   return {
     /**
+     * Get the Lightning node for this wallet.
+     */
+    async getLightningNode(): Promise<LightningNode | null> {
+      const data = await client.request<any>({
+        method: 'GET',
+        path: '/api/lightning/nodes',
+        query: { wallet_id: walletId },
+        authenticated: true,
+      });
+      return data?.data?.node || data?.node || null;
+    },
+
+    /**
+     * Provision a Lightning node for this wallet.
+     */
+    async enableLightning(mnemonic: string, businessId?: string): Promise<LightningNode> {
+      const data = await client.request<any>({
+        method: 'POST',
+        path: '/api/lightning/nodes',
+        body: {
+          wallet_id: walletId,
+          business_id: businessId,
+          mnemonic,
+        },
+        authenticated: true,
+      });
+      return data?.data?.node || data?.node;
+    },
+
+    /**
      * Get the Lightning Address for this wallet.
      */
     async getLightningAddress(): Promise<LightningAddress> {
@@ -52,7 +84,7 @@ export function createLightningMethods(
         method: 'GET',
         path: '/api/lightning/address',
         query: { wallet_id: walletId },
-        authenticated: false,
+        authenticated: true,
       });
       return {
         lightning_address: data.lightning_address || null,
@@ -94,16 +126,16 @@ export function createLightningMethods(
         authenticated: true,
       });
       return {
-        payment_hash: data.data?.payment_hash || data.payment_hash,
-        payment_request: data.data?.invoice?.bolt11 || data.payment_request,
-        checking_id: data.data?.checking_id || data.checking_id,
+        payment_hash: data.data?.payment_hash || data.invoice?.payment_hash || data.payment_hash,
+        payment_request: data.data?.invoice?.bolt11 || data.invoice?.bolt11 || data.payment_request,
+        checking_id: data.data?.checking_id || data.invoice?.payment_hash || data.checking_id,
       };
     },
 
     /**
      * Pay a Lightning invoice (BOLT11).
      */
-    async payLightningInvoice(bolt11: string): Promise<LightningPayment> {
+    async payLightningInvoice(bolt11: string, amountSats?: number): Promise<LightningPayment> {
       const nodeId = await resolveNodeId();
       const data = await client.request<any>({
         method: 'POST',
@@ -113,6 +145,7 @@ export function createLightningMethods(
           node_id: nodeId,
           bolt11,
           bolt12: bolt11,
+          amount_sats: amountSats,
           mnemonic: getMnemonic(),
         },
         authenticated: true,
@@ -127,6 +160,7 @@ export function createLightningMethods(
       const data = await client.request<any>({
         method: 'GET',
         path: `/api/lightning/payments/${paymentHash}`,
+        query: { wallet_id: walletId },
         authenticated: true,
       });
       return { paid: data.paid ?? data.data?.paid ?? false };
@@ -135,12 +169,21 @@ export function createLightningMethods(
     /**
      * List Lightning payments.
      */
-    async listLightningPayments(limit: number = 20): Promise<LightningPayment[]> {
-      const nodeId = await resolveNodeId();
+    async listLightningPayments(
+      limit: number = 20,
+      filters: { nodeId?: string; businessId?: string; offerId?: string } = {}
+    ): Promise<LnPayment[]> {
+      const nodeId = filters.nodeId || await resolveNodeId();
       const data = await client.request<any>({
         method: 'GET',
         path: '/api/lightning/payments',
-        query: { wallet_id: walletId, node_id: nodeId, limit: String(limit) },
+        query: {
+          wallet_id: walletId,
+          node_id: nodeId,
+          business_id: filters.businessId,
+          offer_id: filters.offerId,
+          limit: String(limit),
+        },
         authenticated: true,
       });
       return data.data?.payments || data.payments || [];

--- a/src/lib/wallet-sdk/lightning.ts
+++ b/src/lib/wallet-sdk/lightning.ts
@@ -56,7 +56,9 @@ export function createLightningMethods(
         query: { wallet_id: walletId },
         authenticated: true,
       });
-      return data?.data?.node || data?.node || null;
+      const node = data?.data?.node || data?.node || null;
+      if (node?.id) cachedNodeId = node.id;
+      return node;
     },
 
     /**
@@ -73,7 +75,9 @@ export function createLightningMethods(
         },
         authenticated: true,
       });
-      return data?.data?.node || data?.node;
+      const node = data?.data?.node || data?.node;
+      if (node?.id) cachedNodeId = node.id;
+      return node;
     },
 
     /**
@@ -173,13 +177,12 @@ export function createLightningMethods(
       limit: number = 20,
       filters: { nodeId?: string; businessId?: string; offerId?: string } = {}
     ): Promise<LnPayment[]> {
-      const nodeId = filters.nodeId || await resolveNodeId();
       const data = await client.request<any>({
         method: 'GET',
         path: '/api/lightning/payments',
         query: {
           wallet_id: walletId,
-          node_id: nodeId,
+          node_id: filters.nodeId,
           business_id: filters.businessId,
           offer_id: filters.offerId,
           limit: String(limit),

--- a/src/lib/wallet-sdk/types.ts
+++ b/src/lib/wallet-sdk/types.ts
@@ -319,6 +319,13 @@ export interface LightningAddress {
   username?: string;
 }
 
+export interface LightningNode {
+  id: string;
+  wallet_id: string;
+  status: string;
+  node_pubkey?: string | null;
+}
+
 export interface LightningInvoice {
   payment_hash: string;
   payment_request: string;

--- a/src/lib/wallet-sdk/wallet.ts
+++ b/src/lib/wallet-sdk/wallet.ts
@@ -828,12 +828,16 @@ export class Wallet {
     return (this._ln ??= createLightningMethods(this.client, this._walletId, () => this.getMnemonic()));
   }
 
+  getLightningNode() { return this.ln.getLightningNode(); }
+  enableLightning(mnemonic: string, businessId?: string) { return this.ln.enableLightning(mnemonic, businessId); }
   getLightningAddress() { return this.ln.getLightningAddress(); }
   setLightningAddress(username: string) { return this.ln.setLightningAddress(username); }
   createLightningInvoice(amount: number, memo?: string) { return this.ln.createLightningInvoice(amount, memo); }
-  payLightningInvoice(bolt11: string) { return this.ln.payLightningInvoice(bolt11); }
+  payLightningInvoice(bolt11: string, amountSats?: number) { return this.ln.payLightningInvoice(bolt11, amountSats); }
   checkLightningPayment(hash: string) { return this.ln.checkLightningPayment(hash); }
-  listLightningPayments(limit?: number) { return this.ln.listLightningPayments(limit); }
+  listLightningPayments(limit?: number, filters?: { nodeId?: string; businessId?: string; offerId?: string }) {
+    return this.ln.listLightningPayments(limit, filters);
+  }
 }
 
 // ── Mapping Helpers ──


### PR DESCRIPTION
## Summary
- require signed wallet ownership for Lightning node, address, invoice, and payment routes
- scope Stripe Connect onboarding and status lookups to the authenticated merchant
- remove the spoofable `x-vercel-cron` monitor bypass
- route the Lightning wallet UI through signed SDK methods and add regression coverage

## Root cause
Several service-role API routes trusted caller-supplied wallet or business identifiers without proving that the caller owned them. The monitor endpoint also accepted a client-controlled cron header as authentication.

## Validation
- `npx --yes pnpm@10.0.0 exec vitest run src/app/api/lightning/address/route.test.ts src/app/api/lightning/lightning-routes.test.ts src/app/api/cron/monitor-payments/route.test.ts src/app/api/stripe/connect/onboard/route.test.ts 'src/app/api/stripe/connect/status/[accountId]/route.test.ts' src/components/lightning/__tests__/LightningAddress.test.tsx src/components/lightning/__tests__/LightningPayments.test.tsx src/components/lightning/__tests__/LightningSetup.test.tsx`
- `npx --yes pnpm@10.0.0 run type-check`
- `npx --yes pnpm@10.0.0 run build`
- `git diff --check`