### PR TITLE
Fix Stripe Connect country selector cropping

### DIFF
--- a/src/components/business/CountrySelect.tsx
+++ b/src/components/business/CountrySelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { STRIPE_CONNECT_COUNTRIES } from '@/lib/stripe/connect-countries';
 
 interface CountrySelectProps {
@@ -13,7 +14,10 @@ interface CountrySelectProps {
 export function CountrySelect({ value, onChange, disabled, id }: CountrySelectProps) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const selected = useMemo(
@@ -32,7 +36,10 @@ export function CountrySelect({ value, onChange, disabled, id }: CountrySelectPr
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const insideTrigger = containerRef.current?.contains(target);
+      const insideMenu = menuRef.current?.contains(target);
+      if (!insideTrigger && !insideMenu) {
         setOpen(false);
         setFilter('');
       }
@@ -45,6 +52,30 @@ export function CountrySelect({ value, onChange, disabled, id }: CountrySelectPr
     if (open) inputRef.current?.focus();
   }, [open]);
 
+  // Position the portaled menu under the trigger, and keep it aligned on
+  // scroll/resize. Using a portal + fixed positioning lets the dropdown escape
+  // ancestor `overflow-hidden` containers (e.g. the tab card) that would
+  // otherwise crop it.
+  useLayoutEffect(() => {
+    if (!open) {
+      setMenuPos(null);
+      return;
+    }
+    const updatePosition = () => {
+      const rect = buttonRef.current?.getBoundingClientRect();
+      if (rect) {
+        setMenuPos({ top: rect.bottom, left: rect.left, width: rect.width });
+      }
+    };
+    updatePosition();
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [open]);
+
   const handleSelect = (code: string) => {
     onChange(code);
     setOpen(false);
@@ -54,6 +85,7 @@ export function CountrySelect({ value, onChange, disabled, id }: CountrySelectPr
   return (
     <div ref={containerRef} className="relative">
       <button
+        ref={buttonRef}
         id={id}
         type="button"
         disabled={disabled}
@@ -70,8 +102,12 @@ export function CountrySelect({ value, onChange, disabled, id }: CountrySelectPr
         </svg>
       </button>
 
-      {open && (
-        <div className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg shadow-lg">
+      {open && menuPos && typeof document !== 'undefined' && createPortal(
+        <div
+          ref={menuRef}
+          style={{ position: 'fixed', top: menuPos.top + 4, left: menuPos.left, width: menuPos.width }}
+          className="z-50 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg shadow-lg"
+        >
           <div className="p-2 border-b border-gray-200 dark:border-gray-800">
             <input
               ref={inputRef}
@@ -106,7 +142,8 @@ export function CountrySelect({ value, onChange, disabled, id }: CountrySelectPr
               ))
             )}
           </ul>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

The Stripe Connect country selector dropdown on the business detail page (`/businesses/:id`) was cropped by its container.

**Root cause:** The country dropdown in `CountrySelect.tsx` was `position: absolute` inside its `.relative` wrapper, but the nearest clipping ancestor — the tab card at `src/app/businesses/[id]/page.tsx:242` — uses `overflow-hidden` (needed to clip the tab nav's rounded corners). When the dropdown opened, the country list extended beyond the card and got cropped.

## Fix

Render the dropdown menu through a React **portal** into `document.body` with `position: fixed`, so it escapes any ancestor `overflow-hidden`:

- Added a `buttonRef` and a `useLayoutEffect` that measures the trigger's `getBoundingClientRect()` and stores `{top, left, width}`, re-measuring on `scroll`/`resize` so the menu stays aligned.
- Switched the menu from `absolute` to `createPortal(..., document.body)` with `position: fixed` and `z-50`.
- Updated the click-outside handler to also treat clicks inside the now-portaled menu (`menuRef`) as "inside", so selecting a country / typing in the filter no longer closes the dropdown prematurely.

The card's `overflow-hidden` is left intact (tab corners still clip correctly).

## Testing

- Existing `StripeConnectTab.test.tsx` tests pass (they query via `screen`, so the portaled options/filter input remain findable).
- Full vitest suite passed via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)