### PR TITLE
fix: use wallet registry instead of legacy storage in send/swap flows

### DIFF
--- a/src/app/web-wallet/__tests__/asset-detail-dual-input.test.tsx
+++ b/src/app/web-wallet/__tests__/asset-detail-dual-input.test.tsx
@@ -75,11 +75,14 @@ vi.mock('qrcode', () => ({
 // ── Crypto mock ──
 
 const mockDecryptWithPassword = vi.fn();
-const mockLoadWalletFromStorage = vi.fn();
+const mockGetActiveWallet = vi.fn();
 
 vi.mock('@/lib/web-wallet/client-crypto', () => ({
   decryptWithPassword: (...args: unknown[]) => mockDecryptWithPassword(...args),
-  loadWalletFromStorage: () => mockLoadWalletFromStorage(),
+}));
+
+vi.mock('@/lib/web-wallet/wallet-registry', () => ({
+  getActiveWallet: () => mockGetActiveWallet(),
 }));
 
 // ── Mock fetch for exchange rates ──
@@ -153,7 +156,7 @@ beforeEach(() => {
   mockPush.mockReset();
   mockReplace.mockReset();
   mockDecryptWithPassword.mockReset();
-  mockLoadWalletFromStorage.mockReset();
+  mockGetActiveWallet.mockReset();
   mockFetch.mockReset();
   
   // Default mock for rates API
@@ -398,7 +401,7 @@ describe('AssetDetailPage - Send Tab - Dual Input System', () => {
     const user = userEvent.setup();
     renderUnlockedPage('BTC');
     
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');
@@ -474,7 +477,7 @@ describe('AssetDetailPage - Send Tab - Dual Input System', () => {
     expect(fiatInput).toBeDisabled();
     
     // Navigate to error state and reset
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');

--- a/src/app/web-wallet/__tests__/asset-detail.test.tsx
+++ b/src/app/web-wallet/__tests__/asset-detail.test.tsx
@@ -102,11 +102,14 @@ vi.mock('qrcode', () => ({
 // ── Crypto mock ──
 
 const mockDecryptWithPassword = vi.fn();
-const mockLoadWalletFromStorage = vi.fn();
+const mockGetActiveWallet = vi.fn();
 
 vi.mock('@/lib/web-wallet/client-crypto', () => ({
   decryptWithPassword: (...args: unknown[]) => mockDecryptWithPassword(...args),
-  loadWalletFromStorage: () => mockLoadWalletFromStorage(),
+}));
+
+vi.mock('@/lib/web-wallet/wallet-registry', () => ({
+  getActiveWallet: () => mockGetActiveWallet(),
 }));
 
 // ── Wallet state ──
@@ -175,7 +178,7 @@ beforeEach(() => {
   mockPush.mockReset();
   mockReplace.mockReset();
   mockDecryptWithPassword.mockReset();
-  mockLoadWalletFromStorage.mockReset();
+  mockGetActiveWallet.mockReset();
   mockParams = { chain: 'BTC' };
   mockState = {
     hasWallet: true,
@@ -650,7 +653,7 @@ describe('AssetDetailPage – Send tab', () => {
   });
 
   it('should show error on incorrect password', async () => {
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue(null);
@@ -686,7 +689,7 @@ describe('AssetDetailPage – Send tab', () => {
   });
 
   it('should show success after successful send', async () => {
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');
@@ -725,7 +728,7 @@ describe('AssetDetailPage – Send tab', () => {
   });
 
   it('should show error state on send failure', async () => {
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');
@@ -763,7 +766,7 @@ describe('AssetDetailPage – Send tab', () => {
   });
 
   it('should show Try Again button on error and reset to form', async () => {
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');
@@ -800,7 +803,7 @@ describe('AssetDetailPage – Send tab', () => {
   });
 
   it('should show Send Another button on success and reset to form', async () => {
-    mockLoadWalletFromStorage.mockReturnValue({
+    mockGetActiveWallet.mockReturnValue({
       encrypted: { salt: 'abc', iv: 'def', ciphertext: 'ghi' },
     });
     mockDecryptWithPassword.mockResolvedValue('decrypted-seed');

--- a/src/app/web-wallet/asset/[chain]/page.tsx
+++ b/src/app/web-wallet/asset/[chain]/page.tsx
@@ -13,10 +13,8 @@ import {
   TransactionList,
   type TransactionItem,
 } from '@/components/web-wallet/TransactionList';
-import {
-  decryptWithPassword,
-  loadWalletFromStorage,
-} from '@/lib/web-wallet/client-crypto';
+import { decryptWithPassword } from '@/lib/web-wallet/client-crypto';
+import { getActiveWallet } from '@/lib/web-wallet/wallet-registry';
 import type { WalletChain } from '@/lib/web-wallet/identity';
 import { isValidChain } from '@/lib/web-wallet/identity';
 import type { TransactionListOptions } from '@/lib/wallet-sdk/types';
@@ -925,12 +923,12 @@ function SendTab({ chain, onSuccess, onSwitchToReceive }: { chain: WalletChain; 
       setPasswordError('Password is required');
       return;
     }
-    const stored = loadWalletFromStorage();
-    if (!stored) {
+    const active = getActiveWallet();
+    if (!active) {
       setPasswordError('Wallet data not found');
       return;
     }
-    const result = await decryptWithPassword(stored.encrypted, password);
+    const result = await decryptWithPassword(active.encrypted, password);
     if (!result) {
       setPasswordError('Incorrect password');
       return;

--- a/src/components/web-wallet/SwapForm.tsx
+++ b/src/components/web-wallet/SwapForm.tsx
@@ -7,8 +7,8 @@ import { useWebWallet } from './WalletContext';
 import { type FiatCurrency, getFiatSymbol } from '@/lib/web-wallet/settings';
 import {
   decryptWithPassword,
-  loadWalletFromStorage,
 } from '@/lib/web-wallet/client-crypto';
+import { getActiveWallet } from '@/lib/web-wallet/wallet-registry';
 import type { WalletChain } from '@/lib/web-wallet/identity';
 
 // All coins supported for swaps (must match changenow.ts SWAP_SUPPORTED_COINS)
@@ -179,13 +179,13 @@ export function SwapForm({ walletId, addresses, balances, displayCurrency = 'USD
     if (!wallet || !quote || !password) return;
     
     // Validate password first
-    const stored = loadWalletFromStorage();
-    if (!stored) {
+    const active = getActiveWallet();
+    if (!active) {
       setPasswordError('Wallet data not found');
       return;
     }
     
-    const decrypted = await decryptWithPassword(stored.encrypted, password);
+    const decrypted = await decryptWithPassword(active.encrypted, password);
     if (!decrypted) {
       setPasswordError('Incorrect password');
       return;


### PR DESCRIPTION
Fixes #113

## Problem
After the multi-wallet migration, wallet data is stored under `coinpay_wallets` (registry) and the old `coinpay_wallet` key is deleted. Both `SendTab` and `SwapForm` were still calling `loadWalletFromStorage()` which reads from the deleted key, always returning `null` and causing the **"Wallet data not found"** error.

## Fix
Replace `loadWalletFromStorage()` with `getActiveWallet()` from `wallet-registry` in both components and update corresponding test mocks.

## Files Changed
- `src/app/web-wallet/asset/[chain]/page.tsx` — Send Tx page
- `src/components/web-wallet/SwapForm.tsx` — Swap form
- `src/app/web-wallet/__tests__/asset-detail.test.tsx` — test mock update
- `src/app/web-wallet/__tests__/asset-detail-dual-input.test.tsx` — test mock update