### PR TITLE
Add card-payment visibility to invoices

### DIFF
--- a/src/app/api/invoices/[id]/enable-card/route.test.ts
+++ b/src/app/api/invoices/[id]/enable-card/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/jwt', () => ({
+  verifyToken: vi.fn().mockReturnValue({ userId: 'user-1' }),
+}));
+
+vi.mock('@/lib/secrets', () => ({
+  getJwtSecret: vi.fn().mockReturnValue('test-secret'),
+}));
+
+vi.mock('@/lib/entitlements/service', () => ({
+  isBusinessPaidTier: vi.fn().mockResolvedValue(false),
+}));
+
+const mockStripeCreate = vi.fn().mockResolvedValue({
+  id: 'cs_test_123',
+  url: 'https://checkout.stripe.com/pay/cs_test_123',
+});
+
+vi.mock('@/lib/server/optional-deps', () => ({
+  getStripe: vi.fn().mockResolvedValue({
+    checkout: { sessions: { create: (...args: any[]) => mockStripeCreate(...args) } },
+  }),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { POST } from './route';
+
+const baseInvoice = {
+  id: 'inv-1',
+  invoice_number: 'INV-001',
+  status: 'sent',
+  currency: 'USD',
+  amount: '100.00',
+  crypto_currency: 'SOL',
+  fee_rate: '0.01',
+  business_id: 'biz-1',
+  stripe_checkout_url: null,
+  businesses: { id: 'biz-1', name: 'Acme', merchant_id: 'merch-1' },
+};
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/invoices/inv-1/enable-card', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer test-token' },
+  });
+}
+
+function setupMocks(overrides: { invoice?: any; stripeAccount?: any } = {}) {
+  const invoice = overrides.invoice || baseInvoice;
+  const stripeAccount = overrides.stripeAccount !== undefined ? overrides.stripeAccount : null;
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'invoices') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
+            }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { ...invoice, stripe_checkout_url: 'https://checkout.stripe.com/pay/cs_test_123' },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === 'stripe_accounts') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: stripeAccount, error: stripeAccount ? null : { code: 'PGRST116' } }),
+          }),
+        }),
+      };
+    }
+    return {
+      select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: null, error: null }) }) }),
+    };
+  });
+}
+
+describe('POST /api/invoices/[id]/enable-card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://coinpayportal.com';
+  });
+
+  it('generates a Stripe checkout URL when the business has cards enabled', async () => {
+    setupMocks({ stripeAccount: { stripe_account_id: 'acct_test123', charges_enabled: true } });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockStripeCreate).toHaveBeenCalledTimes(1);
+    expect(body.invoice.stripe_checkout_url).toBe('https://checkout.stripe.com/pay/cs_test_123');
+  });
+
+  it('returns 409 needsStripeOnboarding when business has no enabled Stripe account', async () => {
+    setupMocks({ stripeAccount: null });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(body.needsStripeOnboarding).toBe(true);
+    expect(mockStripeCreate).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when a checkout URL already exists', async () => {
+    setupMocks({
+      invoice: { ...baseInvoice, stripe_checkout_url: 'https://checkout.stripe.com/pay/existing' },
+      stripeAccount: { stripe_account_id: 'acct_test123', charges_enabled: true },
+    });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.alreadyEnabled).toBe(true);
+    expect(mockStripeCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects invoices that are not sent/overdue', async () => {
+    setupMocks({
+      invoice: { ...baseInvoice, status: 'draft' },
+      stripeAccount: { stripe_account_id: 'acct_test123', charges_enabled: true },
+    });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(mockStripeCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/invoices/[id]/enable-card/route.ts
+++ b/src/app/api/invoices/[id]/enable-card/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { resolveMerchant } from '@/lib/auth/merchant';
+import { isBusinessPaidTier } from '@/lib/entitlements/service';
+import { createInvoiceStripeCheckout } from '@/lib/payments/invoice-stripe';
+
+/**
+ * POST /api/invoices/[id]/enable-card
+ * Generate (or regenerate) the Stripe Connect checkout URL for an already-sent
+ * invoice. Use after a merchant finishes Stripe onboarding so the card option
+ * appears on the payment page without having to re-send the invoice.
+ *
+ * Idempotent: if a checkout URL already exists it is returned unchanged.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const authResult = await resolveMerchant(supabase, request);
+    if ('error' in authResult) {
+      return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
+    }
+    const { merchantId } = authResult;
+
+    const { data: invoice, error: fetchError } = await supabase
+      .from('invoices')
+      .select(`*, businesses (id, name, merchant_id)`)
+      .eq('id', id)
+      .eq('user_id', merchantId)
+      .single();
+
+    if (fetchError || !invoice) {
+      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+    }
+
+    // Only meaningful once the invoice is live for payment.
+    if (!['sent', 'overdue'].includes(invoice.status)) {
+      return NextResponse.json(
+        { success: false, error: `Cannot enable card payments for an invoice with status: ${invoice.status}` },
+        { status: 400 }
+      );
+    }
+
+    // Already enabled — return the existing URL (idempotent).
+    if (invoice.stripe_checkout_url) {
+      return NextResponse.json({ success: true, invoice, alreadyEnabled: true });
+    }
+
+    const isPaidTier = await isBusinessPaidTier(supabase, invoice.business_id);
+
+    let checkout;
+    try {
+      checkout = await createInvoiceStripeCheckout(supabase, invoice, isPaidTier);
+    } catch (stripeError) {
+      console.error('Failed to create Stripe checkout session for invoice:', stripeError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to create Stripe checkout session' },
+        { status: 502 }
+      );
+    }
+
+    if (!checkout) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'This business has no Stripe Connect account with card charges enabled. Connect Stripe first.',
+          needsStripeOnboarding: true,
+        },
+        { status: 409 }
+      );
+    }
+
+    const { data: updatedInvoice, error: updateError } = await supabase
+      .from('invoices')
+      .update({
+        stripe_checkout_url: checkout.stripeCheckoutUrl,
+        stripe_session_id: checkout.stripeSessionId,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select(`*, clients (id, name, email, company_name), businesses (id, name)`)
+      .single();
+
+    if (updateError) {
+      return NextResponse.json({ success: false, error: 'Failed to update invoice' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, invoice: updatedInvoice });
+  } catch (error) {
+    console.error('Enable card payments error:', error);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/invoices/[id]/send/route.ts
+++ b/src/app/api/invoices/[id]/send/route.ts
@@ -5,7 +5,7 @@ import { createPayment, type Blockchain } from '@/lib/payments/service';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { sendEmail } from '@/lib/email';
 import { invoiceSentTemplate } from '@/lib/email/invoice-templates';
-import { getStripe } from '@/lib/server/optional-deps';
+import { createInvoiceStripeCheckout } from '@/lib/payments/invoice-stripe';
 
 /**
  * POST /api/invoices/[id]/send
@@ -92,54 +92,10 @@ export async function POST(
     let stripeSessionId: string | null = null;
 
     try {
-      const { data: stripeAccount } = await supabase
-        .from('stripe_accounts')
-        .select('stripe_account_id, charges_enabled')
-        .eq('business_id', invoice.business_id)
-        .single();
-
-      if (stripeAccount?.stripe_account_id && stripeAccount.charges_enabled) {
-        const amountCents = Math.round(parseFloat(invoice.amount) * 100);
-        const platformFeeRate = isPaidTier ? 0.005 : 0.01;
-        const platformFeeAmount = Math.round(amountCents * platformFeeRate);
-
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://coinpayportal.com';
-        const stripe = await getStripe();
-        const session = await stripe.checkout.sessions.create({
-          line_items: [
-            {
-              price_data: {
-                currency: 'usd',
-                product_data: { name: `Invoice ${invoice.invoice_number}` },
-                unit_amount: amountCents,
-              },
-              quantity: 1,
-            },
-          ],
-          mode: 'payment',
-          payment_intent_data: {
-            application_fee_amount: platformFeeAmount,
-            transfer_data: {
-              destination: stripeAccount.stripe_account_id,
-            },
-            metadata: {
-              coinpay_invoice_id: invoice.id,
-              business_id: invoice.business_id,
-              merchant_id: invoice.businesses?.merchant_id,
-            },
-          },
-          success_url: `${appUrl}/invoices/${invoice.id}/pay?status=success`,
-          cancel_url: `${appUrl}/invoices/${invoice.id}/pay`,
-          metadata: {
-            coinpay_invoice_id: invoice.id,
-            business_id: invoice.business_id,
-            merchant_id: invoice.businesses?.merchant_id,
-            platform_fee_amount: platformFeeAmount.toString(),
-          },
-        });
-
-        stripeCheckoutUrl = session.url!;
-        stripeSessionId = session.id;
+      const checkout = await createInvoiceStripeCheckout(supabase, invoice, isPaidTier);
+      if (checkout) {
+        stripeCheckoutUrl = checkout.stripeCheckoutUrl;
+        stripeSessionId = checkout.stripeSessionId;
       }
     } catch (stripeError) {
       // Stripe session creation is optional - don't fail the entire send

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -14,6 +14,8 @@ interface Invoice {
   crypto_currency: string | null;
   crypto_amount: string | null;
   payment_address: string | null;
+  stripe_checkout_url: string | null;
+  stripe_session_id: string | null;
   merchant_wallet_address: string | null;
   fee_rate: string;
   fee_amount: string | null;
@@ -48,6 +50,9 @@ export default function InvoiceDetailPage() {
   const [actionLoading, setActionLoading] = useState('');
   const [error, setError] = useState('');
   const [copiedLink, setCopiedLink] = useState(false);
+  // null = unknown/loading. cardsEnabled reflects whether the invoice's business
+  // has a Stripe Connect account with card charges enabled.
+  const [cardsEnabled, setCardsEnabled] = useState<boolean | null>(null);
 
   const handleCopyShareLink = async () => {
     if (!invoice) return;
@@ -68,10 +73,38 @@ export default function InvoiceDetailPage() {
     if (!result) return;
     if (result.data.success) {
       setInvoice(result.data.invoice);
+      fetchCardStatus(result.data.invoice.businesses?.id);
     } else {
       setError(result.data.error || 'Invoice not found');
     }
     setLoading(false);
+  };
+
+  // Determine whether the business can accept card payments via Stripe Connect.
+  const fetchCardStatus = async (businessId?: string) => {
+    if (!businessId) { setCardsEnabled(false); return; }
+    try {
+      const result = await authFetch(`/api/stripe/connect/status/${businessId}`, {}, router);
+      if (!result) return;
+      setCardsEnabled(!!(result.data.success && result.data.charges_enabled));
+    } catch {
+      setCardsEnabled(false);
+    }
+  };
+
+  const handleEnableCard = async () => {
+    setActionLoading('enable-card');
+    setError('');
+    const result = await authFetch(`/api/invoices/${invoiceId}/enable-card`, { method: 'POST' }, router);
+    if (result?.data.success) {
+      setInvoice(result.data.invoice);
+    } else if (result?.data.needsStripeOnboarding) {
+      setCardsEnabled(false);
+      setError(result.data.error || 'Connect Stripe to accept card payments.');
+    } else {
+      setError(result?.data.error || 'Failed to enable card payments');
+    }
+    setActionLoading('');
   };
 
   const handleSend = async () => {
@@ -330,6 +363,72 @@ export default function InvoiceDetailPage() {
                 </button>
               )}
             </div>
+
+            {/* Payment Methods */}
+            {invoice.status !== 'cancelled' && (
+              <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-6 space-y-3">
+                <h3 className="text-sm font-semibold text-gray-400 uppercase mb-1">Payment Methods</h3>
+
+                {/* Crypto — always offered when a currency is set */}
+                <div className="flex items-center gap-2 text-sm">
+                  <span className={invoice.crypto_currency ? 'text-green-400' : 'text-gray-500'}>
+                    {invoice.crypto_currency ? '✓' : '—'}
+                  </span>
+                  <span className="text-gray-300">
+                    Crypto{invoice.crypto_currency ? ` (${invoice.crypto_currency})` : ' — set a currency before sending'}
+                  </span>
+                </div>
+
+                {/* Card via Stripe Connect */}
+                <div className="flex items-center gap-2 text-sm">
+                  <span className={invoice.stripe_checkout_url || cardsEnabled ? 'text-green-400' : 'text-gray-500'}>
+                    {invoice.stripe_checkout_url ? '✓' : cardsEnabled ? '✓' : '—'}
+                  </span>
+                  <span className="text-gray-300">Credit card (Stripe Connect)</span>
+                </div>
+
+                {/* Pre-send hint: cards are off, only crypto will be offered */}
+                {invoice.status === 'draft' && cardsEnabled === false && (
+                  <div className="mt-1 p-3 bg-yellow-900/20 border border-yellow-800 rounded-lg text-xs text-yellow-300">
+                    Only crypto will be offered to your client. Connect Stripe to also accept credit cards.
+                    {invoice.businesses?.id && (
+                      <Link
+                        href={`/businesses/${invoice.businesses.id}`}
+                        className="block mt-2 text-yellow-200 underline hover:text-yellow-100"
+                      >
+                        Connect Stripe →
+                      </Link>
+                    )}
+                  </div>
+                )}
+
+                {/* Post-send: business is connected but this invoice has no card URL yet */}
+                {['sent', 'overdue'].includes(invoice.status) && !invoice.stripe_checkout_url && cardsEnabled === true && (
+                  <button
+                    onClick={handleEnableCard}
+                    disabled={actionLoading === 'enable-card'}
+                    className="mt-1 w-full px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium disabled:opacity-50 transition-colors text-sm"
+                  >
+                    {actionLoading === 'enable-card' ? 'Enabling...' : '💳 Enable card payments'}
+                  </button>
+                )}
+
+                {/* Post-send: business not connected, only crypto on this invoice */}
+                {['sent', 'overdue'].includes(invoice.status) && !invoice.stripe_checkout_url && cardsEnabled === false && (
+                  <div className="mt-1 p-3 bg-yellow-900/20 border border-yellow-800 rounded-lg text-xs text-yellow-300">
+                    This invoice only offers crypto. Connect Stripe, then return here to enable card payments.
+                    {invoice.businesses?.id && (
+                      <Link
+                        href={`/businesses/${invoice.businesses.id}`}
+                        className="block mt-2 text-yellow-200 underline hover:text-yellow-100"
+                      >
+                        Connect Stripe →
+                      </Link>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Dates */}
             <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-6">

--- a/src/lib/payments/invoice-stripe.ts
+++ b/src/lib/payments/invoice-stripe.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getStripe } from '@/lib/server/optional-deps';
+
+/**
+ * Minimal shape of an invoice needed to build a Stripe Connect checkout session.
+ */
+export interface InvoiceForStripe {
+  id: string;
+  invoice_number: string;
+  amount: string | number;
+  business_id: string;
+  businesses?: { merchant_id?: string | null } | null;
+}
+
+export interface InvoiceStripeCheckout {
+  stripeCheckoutUrl: string;
+  stripeSessionId: string;
+}
+
+/**
+ * Create a Stripe Connect checkout session for an invoice and route the funds to
+ * the business's connected account, taking the CoinPay platform fee as an
+ * application fee. Returns `null` when the business has no usable Stripe Connect
+ * account (not connected, or charges not yet enabled) — callers decide whether
+ * that is fatal.
+ *
+ * Shared by the invoice "send" flow (initial creation) and the "enable-card"
+ * flow (regenerating the card option on an already-sent invoice once the
+ * merchant finishes Stripe onboarding).
+ */
+export async function createInvoiceStripeCheckout(
+  supabase: SupabaseClient,
+  invoice: InvoiceForStripe,
+  isPaidTier: boolean
+): Promise<InvoiceStripeCheckout | null> {
+  const { data: stripeAccount } = await supabase
+    .from('stripe_accounts')
+    .select('stripe_account_id, charges_enabled')
+    .eq('business_id', invoice.business_id)
+    .single();
+
+  if (!stripeAccount?.stripe_account_id || !stripeAccount.charges_enabled) {
+    return null;
+  }
+
+  const amountCents = Math.round(parseFloat(String(invoice.amount)) * 100);
+  const platformFeeRate = isPaidTier ? 0.005 : 0.01;
+  const platformFeeAmount = Math.round(amountCents * platformFeeRate);
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://coinpayportal.com';
+  const stripe = await getStripe();
+  const session = await stripe.checkout.sessions.create({
+    line_items: [
+      {
+        price_data: {
+          currency: 'usd',
+          product_data: { name: `Invoice ${invoice.invoice_number}` },
+          unit_amount: amountCents,
+        },
+        quantity: 1,
+      },
+    ],
+    mode: 'payment',
+    payment_intent_data: {
+      application_fee_amount: platformFeeAmount,
+      transfer_data: {
+        destination: stripeAccount.stripe_account_id,
+      },
+      metadata: {
+        coinpay_invoice_id: invoice.id,
+        business_id: invoice.business_id,
+        merchant_id: invoice.businesses?.merchant_id,
+      },
+    },
+    success_url: `${appUrl}/invoices/${invoice.id}/pay?status=success`,
+    cancel_url: `${appUrl}/invoices/${invoice.id}/pay`,
+    metadata: {
+      coinpay_invoice_id: invoice.id,
+      business_id: invoice.business_id,
+      merchant_id: invoice.businesses?.merchant_id,
+      platform_fee_amount: platformFeeAmount.toString(),
+    },
+  });
+
+  return { stripeCheckoutUrl: session.url!, stripeSessionId: session.id };
+}


### PR DESCRIPTION
Let invoice creators see and control whether card payments (Stripe Connect) are offered alongside crypto on an invoice.

- Extract shared createInvoiceStripeCheckout() helper; reuse it in the invoice send flow (DRY).
- Add POST /api/invoices/[id]/enable-card to (re)generate the Stripe checkout URL on an already-sent invoice after the merchant connects Stripe — idempotent, returns 409 needsStripeOnboarding when the business has no card-enabled Stripe account.
- Invoice detail page: add a Payment Methods panel that warns before send when only crypto will be offered, and surfaces an "Enable card payments" action after send once Stripe is connected.