### PR TITLE
fix: use Math.round in toTokenUnits to prevent 1-unit underpayment

### DIFF
--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -169,7 +169,7 @@ function isSolanaToken(chain: BlockchainType): chain is keyof typeof SOLANA_TOKE
 }
 
 function toTokenUnits(amount: number, decimals: number): bigint {
-  return BigInt(Math.floor(amount * 10 ** decimals));
+  return BigInt(Math.round(amount * 10 ** decimals));
 }
 
 async function forwardEVMTokenSplit(


### PR DESCRIPTION
## Summary

`toTokenUnits()` in `src/lib/wallets/secure-forwarding.ts` uses `Math.floor(amount * 10 ** decimals)` to convert decimal amounts to integer token units. Due to IEEE 754 floating-point representation, the intermediate multiplication can produce a value slightly below the intended integer, and `Math.floor` truncates it to the wrong result.

**Example:** `1.005 * 1_000_000` evaluates to `1_004_999.9999999998`. `Math.floor` produces `1_004_999` instead of `1_005_000` — a 1-unit underpayment.

## Fix

Replace `Math.floor` with `Math.round`. This corrects for the +/-0.5 ULP rounding error that floating-point multiplication introduces.

Fixes #123