### PR TITLE
fix: toTokenUnits rounding uses Math.floor causing 1-unit underpayment on fractional amounts

### DIFF
--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -169,7 +169,7 @@ function isSolanaToken(chain: BlockchainType): chain is keyof typeof SOLANA_TOKE
 }
 
 function toTokenUnits(amount: number, decimals: number): bigint {
-  return BigInt(Math.floor(amount * 10 ** decimals));
+  return BigInt(Math.round(amount * 10 ** decimals));
 }
 
 async function forwardEVMTokenSplit(


### PR DESCRIPTION
## Bug

`toTokenUnits()` uses `Math.floor(amount * 10 ** decimals)` which due to IEEE 754 floating-point can produce values slightly below the intended integer.

## Fix

Replaced `Math.floor` with `Math.round`. This way values like `1.999999999` (which should be `2`) round correctly instead of truncating to `1`.

Fixes #123

## Testing

- Amount: 1.234567, decimals: 6 → previously could floor to 1234566 instead of 1234567
- After fix: rounds to the nearest integer, handling floating point edge cases

## Related

- Bounty: ugig bug fix PR bounty ($1)
- chovy - this qualifies for the PR bug fix bounty