### PR TITLE
fix: use string-based conversion for toTokenUnits (replaces Math.floor / Math.round)

### DIFF
--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -169,7 +169,10 @@ function isSolanaToken(chain: BlockchainType): chain is keyof typeof SOLANA_TOKE
 }
 
 function toTokenUnits(amount: number, decimals: number): bigint {
-  return BigInt(Math.floor(amount * 10 ** decimals));
+  // String-based conversion avoids IEEE-754 floating point precision issues entirely
+  const [whole, fraction = ""] = amount.toString().split(".");
+  const padded = fraction.padEnd(decimals, "0").slice(0, decimals);
+  return BigInt(whole + padded);
 }
 
 async function forwardEVMTokenSplit(


### PR DESCRIPTION
## Problem

`toTokenUnits` used `Math.floor(amount * 10 ** decimals)` which due to IEEE-754 floating point can truncate values, causing 1-unit underpayment on fractional amounts.

## Approach

Per Greptile review suggestion on earlier PR that used `Math.round` — the string-based conversion (`amount.toString().split(".")` + `padEnd` + `BigInt()`) avoids floating-point multiplication entirely, eliminating both underpayment and overpayment edge cases.

## Test cases
- `toTokenUnits(1.234567, 6)` → `1234567n`
- `toTokenUnits(0.000001, 6)` → `1n`
- `toTokenUnits(1234.567890, 6)` → `1234567890n`
- No floating point operations, no rounding edge cases.

Fixes #123