### PR TITLE
fix: add ownership check to payment forwarding status endpoint

### DIFF
--- a/src/app/api/payments/[id]/forward/route.ts
+++ b/src/app/api/payments/[id]/forward/route.ts
@@ -153,6 +153,29 @@ export async function GET(
     }
 
     const { id: paymentId } = await params;
+    const merchantId = payload.sub || payload.userId;
+
+    // Verify the authenticated user owns this payment
+    const { data: payment, error: paymentError } = await supabaseAdmin
+      .from('payments')
+      .select('business_id, businesses!inner(merchant_id)')
+      .eq('id', paymentId)
+      .single();
+
+    if (paymentError || !payment) {
+      return NextResponse.json(
+        { success: false, error: 'Payment not found' },
+        { status: 404 }
+      );
+    }
+
+    const ownerMerchantId = (payment.businesses as any)?.merchant_id;
+    if (ownerMerchantId !== merchantId) {
+      return NextResponse.json(
+        { success: false, error: 'Payment not found' },
+        { status: 404 }
+      );
+    }
 
     const status = await getForwardingStatus(supabaseAdmin, paymentId);
 


### PR DESCRIPTION
Fixes #129

## Bug

`GET /api/payments/[id]/forward` verifies JWT authentication but does not check that the authenticated merchant owns the requested payment. Any authenticated user can view forwarding details (transaction hashes, merchant amounts, platform fees) of any other merchant's payments by changing the payment ID — a horizontal privilege escalation (IDOR).

## Fix

Added a query to verify the payment's business belongs to the authenticated merchant (via `businesses.merchant_id`) before returning forwarding status. Returns `404 Payment not found` for unauthorized access (avoiding information disclosure about payment existence).