### PR TITLE
Fix: use configured domain instead of Host header in LNURL callback

### DIFF
--- a/src/app/.well-known/lnurlp/[username]/route.ts
+++ b/src/app/.well-known/lnurlp/[username]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 const LNBITS_URL = process.env.LNBITS_URL || 'https://ln.coinpayportal.com';
+const PUBLIC_DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'coinpayportal.com';
 
 /**
  * Proxy /.well-known/lnurlp/<username> to LNbits
@@ -44,7 +45,7 @@ export async function GET(
     if (data.callback && data.callback.includes(LNBITS_URL)) {
       data.callback = data.callback.replace(
         LNBITS_URL,
-        `https://${request.headers.get('host') || 'coinpayportal.com'}`
+        `https://${PUBLIC_DOMAIN}`
       );
     }
 


### PR DESCRIPTION
## Summary
Fixes #133

The LNURL-pay proxy uses the client-supplied `Host` header to construct the callback URL. An attacker can spoof this to redirect Lightning payment callbacks to their domain.

## Changes
- `src/app/.well-known/lnurlp/[username]/route.ts`: 
  - Add `PUBLIC_DOMAIN` constant from `NEXT_PUBLIC_DOMAIN` env var (falls back to `coinpayportal.com`)
  - Replace `request.headers.get('host')` with `PUBLIC_DOMAIN`

## Test plan
- [ ] Lightning Address lookup returns callback URL with `coinpayportal.com` domain
- [ ] Spoofed Host header does not affect callback URL
- [ ] LNURL-pay flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)