### PR TITLE
Fix: add ownership check to usage credit deduction endpoint

### DIFF
--- a/src/app/api/businesses/[id]/usage/deduct/route.ts
+++ b/src/app/api/businesses/[id]/usage/deduct/route.ts
@@ -53,6 +53,17 @@ export async function POST(
       return NextResponse.json({ success: false, error: 'Server configuration error' }, { status: 500 });
     }
 
+    // Verify the authenticated merchant owns this business
+    const { data: business } = await supabase
+      .from('businesses')
+      .select('merchant_id')
+      .eq('id', id)
+      .single();
+
+    if (!business || business.merchant_id !== auth.merchantId) {
+      return NextResponse.json({ success: false, error: 'Business not found' }, { status: 404 });
+    }
+
     const body = await request.json();
     const { user_email, action_type, quantity, metadata } = body;
 


### PR DESCRIPTION
## Summary
Fixes #135

The usage credit deduction endpoint does not verify that the authenticated merchant owns the business specified in the URL. Any merchant can deduct credits from any other merchant's business.

## Changes
- `src/app/api/businesses/[id]/usage/deduct/route.ts`: Add ownership check — query `businesses` table to verify `merchant_id` matches authenticated merchant before allowing deduction

## Test plan
- [ ] Merchant deducting from own business: succeeds normally
- [ ] Merchant deducting from another merchant's business: returns 404
- [ ] Unauthenticated request: returns 401 (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)