### PR TITLE
Fix: replace raw database error messages with generic errors

### DIFF
--- a/src/app/api/businesses/[id]/calendar-events/[eventId]/route.ts
+++ b/src/app/api/businesses/[id]/calendar-events/[eventId]/route.ts
@@ -82,7 +82,8 @@ export async function PUT(
       .single();
 
     if (error) {
-      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+      console.error('Update calendar event error:', error.message);
+      return NextResponse.json({ success: false, error: 'Failed to update calendar event' }, { status: 400 });
     }
 
     return NextResponse.json({ success: true, event });
@@ -131,7 +132,8 @@ export async function DELETE(
       .eq('business_id', businessId);
 
     if (error) {
-      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+      console.error('Delete calendar event error:', error.message);
+      return NextResponse.json({ success: false, error: 'Failed to delete calendar event' }, { status: 400 });
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/businesses/[id]/calendar-events/route.ts
+++ b/src/app/api/businesses/[id]/calendar-events/route.ts
@@ -70,7 +70,8 @@ export async function GET(
       .order('start_at', { ascending: true });
 
     if (error) {
-      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+      console.error('Fetch calendar events error:', error.message);
+      return NextResponse.json({ success: false, error: 'Failed to fetch calendar events' }, { status: 400 });
     }
 
     return NextResponse.json({ success: true, events: events || [] });

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -104,7 +104,8 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (error) {
-      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+      console.error('Create client DB error:', error.message);
+      return NextResponse.json({ success: false, error: 'Failed to create client' }, { status: 400 });
     }
 
     return NextResponse.json({ success: true, client }, { status: 201 });


### PR DESCRIPTION
## Summary
Fixes #137

Multiple endpoints leak raw Supabase `error.message` to clients, potentially exposing database schema details.

## Changes
- `src/app/api/clients/route.ts`: Generic "Failed to create client"
- `src/app/api/businesses/[id]/calendar-events/route.ts`: Generic "Failed to fetch calendar events"
- `src/app/api/businesses/[id]/calendar-events/[eventId]/route.ts`: Generic errors for update and delete
- All: Added `console.error()` for server-side debugging

## Test plan
- [ ] Create client with invalid data: returns generic error (not DB details)
- [ ] Calendar operations with errors: return generic errors
- [ ] Normal operations: unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)