### PR TITLE
fix: make git hook setup cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "generate-wallet": "node scripts/generate-hd-wallets.mjs",
     "decrypt-wallet": "node scripts/decrypt-wallet-backup.mjs",
     "coinpay-wallet": "node --import tsx scripts/coinpay-wallet.mjs",
-    "postinstall": "git config core.hooksPath hooks 2>/dev/null || true",
+    "postinstall": "node scripts/configure-git-hooks.mjs",
     "version:patch": "node scripts/version-bump.js patch",
     "version:minor": "node scripts/version-bump.js minor",
     "version:major": "node scripts/version-bump.js major",

--- a/scripts/configure-git-hooks.mjs
+++ b/scripts/configure-git-hooks.mjs
@@ -1,0 +1,19 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+if (!existsSync('.git')) {
+  process.exit(0);
+}
+
+const result = spawnSync('git', ['config', 'core.hooksPath', 'hooks'], {
+  stdio: 'inherit',
+});
+
+if (result.error?.code === 'ENOENT') {
+  console.warn('Git is unavailable; skipping hook configuration.');
+  process.exit(0);
+}
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary

- replace the shell-specific `postinstall` command with a Node script
- skip hook setup when the package is installed outside a Git checkout
- configure `core.hooksPath` with `spawnSync` argument arrays
- handle environments where Git is unavailable

Fixes #141.

## Validation

- `corepack pnpm@10.15.1 postinstall`
- `corepack pnpm@10.15.1 build`

The production build completed successfully. The repository-wide pre-commit test command still reports failures already present on `master`, unrelated to this change.