### PR TITLE
fix(swap): reject partially numeric amounts

### DIFF
--- a/src/app/api/swap/create/route.ts
+++ b/src/app/api/swap/create/route.ts
@@ -92,8 +92,8 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate amount
-    const amountNum = parseFloat(amount);
-    if (isNaN(amountNum) || amountNum <= 0) {
+    const amountNum = Number(amount);
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
       return NextResponse.json(
         { error: 'Invalid amount: must be a positive number' },
         { status: 400 }

--- a/src/app/api/swap/quote/route.ts
+++ b/src/app/api/swap/quote/route.ts
@@ -59,8 +59,8 @@ export async function GET(request: NextRequest) {
     }
 
     // Validate amount
-    const amountNum = parseFloat(amount);
-    if (isNaN(amountNum) || amountNum <= 0) {
+    const amountNum = Number(amount);
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
       return NextResponse.json(
         { error: 'Invalid amount: must be a positive number' },
         { status: 400 }

--- a/src/app/api/swap/swap-routes.test.ts
+++ b/src/app/api/swap/swap-routes.test.ts
@@ -103,6 +103,16 @@ describe('Swap API Routes', () => {
       expect(data.error).toContain('Invalid amount');
     });
 
+    it('should reject amounts with trailing characters', async () => {
+      const request = new NextRequest('http://localhost/api/swap/quote?from=BTC&to=ETH&amount=1abc');
+      const response = await getQuote(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain('Invalid amount');
+      expect(changenow.getSwapQuote).not.toHaveBeenCalled();
+    });
+
     it('should return quote on success', async () => {
       vi.mocked(changenow.getSwapQuote).mockResolvedValueOnce({
         depositCoin: 'btc',

--- a/src/lib/swap/changenow.test.ts
+++ b/src/lib/swap/changenow.test.ts
@@ -73,6 +73,18 @@ describe('ChangeNOW Client (v2 API)', () => {
   });
 
   describe('getSwapQuote (v2 API)', () => {
+    it('should reject partially numeric amounts before calling the provider', async () => {
+      await expect(
+        getSwapQuote({
+          from: 'BTC',
+          to: 'ETH',
+          amount: '1abc',
+        })
+      ).rejects.toThrow('Amount must be a positive number');
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
     it('should get a quote for BTC to ETH swap', async () => {
       vi.mocked(fetch)
         // First call: v2 estimate
@@ -171,6 +183,20 @@ describe('ChangeNOW Client (v2 API)', () => {
   });
 
   describe('createSwap (v2 API)', () => {
+    it('should reject partially numeric amounts before creating an exchange', async () => {
+      await expect(
+        createSwap({
+          from: 'BTC',
+          to: 'ETH',
+          amount: '1abc',
+          settleAddress: '0xpayout...',
+          quoteId: '',
+        })
+      ).rejects.toThrow('Amount must be a positive number');
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
     it('should create an exchange with v2 API', async () => {
       vi.mocked(fetch).mockResolvedValueOnce({
         ok: true,

--- a/src/lib/swap/changenow.ts
+++ b/src/lib/swap/changenow.ts
@@ -110,6 +110,14 @@ export function isSwapSupported(coin: string): coin is SwapCoin {
   return SWAP_SUPPORTED_COINS.includes(coin as SwapCoin);
 }
 
+function parsePositiveAmount(value: string): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('Amount must be a positive number');
+  }
+  return amount;
+}
+
 class ChangeNowClient {
   private apiKey: string;
 
@@ -343,7 +351,7 @@ export async function getSwapQuote(params: SwapQuoteParams): Promise<QuoteRespon
   const fromMapping = CN_COIN_MAP[params.from];
   const toMapping = CN_COIN_MAP[params.to];
 
-  const amount = parseFloat(params.amount);
+  const amount = parsePositiveAmount(params.amount);
   
   // Get estimate and min amount (v2 API requires network info)
   const [estimate, minAmount] = await Promise.all([
@@ -392,7 +400,7 @@ export async function createSwap(params: SwapCreateParams & {
     to: toMapping.ticker,
     fromNetwork: fromMapping.network,
     toNetwork: toMapping.network,
-    amount: parseFloat(params.amount),
+    amount: parsePositiveAmount(params.amount),
     address: params.settleAddress,
     refundAddress: params.refundAddress,
   });


### PR DESCRIPTION
## Summary

- parse swap amounts with strict numeric conversion
- reject non-finite and non-positive values
- apply the same validation in the API and ChangeNOW helper
- add regression coverage ensuring `1abc` never reaches the provider

Fixes #142.

## Validation

- `corepack pnpm@10.15.1 exec vitest run src/app/api/swap/swap-routes.test.ts -t "trailing characters"`
- `corepack pnpm@10.15.1 exec vitest run src/lib/swap/changenow.test.ts -t "partially numeric"`
- `corepack pnpm@10.15.1 type-check`

Result: 3 focused tests passed and typecheck completed successfully.