### PR TITLE
Add Tor hidden service to Railway deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# Coinpay + Tor hidden service in one container (Railway deploys this Dockerfile).
+# Mirrors the qrypt.chat pattern: Next.js app on $PORT, Tor exposes it as a .onion.
+FROM node:24-bookworm-slim
+
+# System deps: tor + tini for clean PID 1 + gettext for envsubst
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tor ca-certificates tini gettext-base \
+ && rm -rf /var/lib/apt/lists/*
+
+# Prepare Tor dirs (Railway volume mounts at /var/lib/tor to keep a stable .onion)
+RUN mkdir -p /var/lib/tor/hidden_service /var/log/tor \
+ && chown -R debian-tor:debian-tor /var/lib/tor /var/log/tor \
+ && chmod 700 /var/lib/tor/hidden_service
+
+# Build-time public env vars (inlined into the Next.js bundle at `pnpm build`)
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_APP_URL
+ARG NEXT_PUBLIC_APP_VERSION
+ARG NEXT_PUBLIC_DOMAIN
+ARG NEXT_PUBLIC_LNBITS_URL
+ARG NEXT_PUBLIC_SOLANA_RPC_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_ONION_URL
+ARG NODE_ENV
+
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
+ENV NEXT_PUBLIC_DOMAIN=$NEXT_PUBLIC_DOMAIN
+ENV NEXT_PUBLIC_LNBITS_URL=$NEXT_PUBLIC_LNBITS_URL
+ENV NEXT_PUBLIC_SOLANA_RPC_URL=$NEXT_PUBLIC_SOLANA_RPC_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_ONION_URL=$NEXT_PUBLIC_ONION_URL
+
+# App build
+WORKDIR /app
+# Copy lockfiles first for better caching
+COPY pnpm-lock.yaml* package.json pnpm-workspace.yaml ./
+# Pin pnpm to a known-good version (avoid `pnpm@latest` surprises on Railway).
+RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
+# Coinpay's Railway build uses --no-frozen-lockfile (the lockfile drifts); match it.
+RUN pnpm install --no-frozen-lockfile
+
+# Copy the rest and build
+COPY . .
+RUN pnpm build
+
+# Runtime env
+ENV HOST=0.0.0.0
+ENV PORT=8080
+
+# Entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8080
+# Tor requires root at startup (chown /var/lib/tor, run tor daemon); entrypoint
+# drops to debian-tor for the tor process. A non-root USER here would break it.
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
+ENTRYPOINT ["/usr/bin/tini","--"]
+# nosemgrep: dockerfile.security.missing-user.missing-user
+CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Next.js-friendly defaults
+export HOST="${HOST:-0.0.0.0}"
+export PORT="${PORT:-8080}"
+export NODE_ENV=production
+
+echo "Environment configured for production mode (HOST=${HOST} PORT=${PORT})"
+
+# Write tor config (points onion:80 -> your local app on $PORT)
+cat >/etc/tor/torrc <<EOF
+DataDirectory /var/lib/tor
+Log notice file /var/log/tor/notices.log
+User debian-tor
+
+HiddenServiceDir /var/lib/tor/hidden_service
+HiddenServicePort 80 127.0.0.1:${PORT}
+
+SocksPort 0
+ORPort 0
+ExitPolicy reject *:*
+EOF
+
+# Perms for mounted volume
+mkdir -p /var/lib/tor/hidden_service /var/log/tor
+chown -R debian-tor:debian-tor /var/lib/tor /var/log/tor
+chmod 700 /var/lib/tor/hidden_service || true
+
+# Start Tor
+echo "Starting Tor daemon..."
+tor -f /etc/tor/torrc &
+TOR_PID=$!
+
+sleep 2
+if ! kill -0 $TOR_PID 2>/dev/null; then
+  echo "ERROR: Tor failed to start" >&2
+  cat /var/log/tor/notices.log 2>/dev/null || echo "No Tor logs found" >&2
+  exit 1
+fi
+echo "Tor started successfully (PID: $TOR_PID)"
+
+# Wait for onion hostname (first run generates keys)
+echo "Waiting for Tor to generate hidden service keys..."
+for i in $(seq 1 60); do
+  if [ -s /var/lib/tor/hidden_service/hostname ]; then
+    break
+  fi
+  if [ $i -eq 10 ] || [ $i -eq 30 ]; then
+    ls -la /var/lib/tor/hidden_service/ 2>/dev/null || echo "Directory not accessible"
+    tail -5 /var/log/tor/notices.log 2>/dev/null || echo "No logs available"
+  fi
+  sleep 1
+done
+
+if [ -s /var/lib/tor/hidden_service/hostname ]; then
+  ONION_URL="$(cat /var/lib/tor/hidden_service/hostname)"
+  echo "🧅 TOR HIDDEN SERVICE READY!"
+  echo "ONION_URL=${ONION_URL}"
+  echo "Your site is accessible at: http://${ONION_URL}"
+  echo ""
+  echo "📋 To surface the Tor link in the UI, set this Railway variable:"
+  echo "   NEXT_PUBLIC_ONION_URL=${ONION_URL}"
+  export ONION_URL="${ONION_URL}"
+  export NEXT_PUBLIC_ONION_URL="${ONION_URL}"
+else
+  echo "❌ Failed to generate onion hostname" >&2
+  tail -10 /var/log/tor/notices.log 2>/dev/null || echo "No logs available"
+fi
+
+# Sanity-check Next.js build artifacts
+if [ ! -d "/app/.next" ] || [ ! -f "/app/.next/BUILD_ID" ]; then
+  echo "❌ ERROR: Next.js build artifacts missing in /app/.next" >&2
+  ls -la /app/.next/ 2>/dev/null || ls -la /app/
+  exit 1
+fi
+echo "✅ Next.js build artifacts found (BUILD_ID: $(cat /app/.next/BUILD_ID))"
+
+# Start the app (limit heap like scripts/start.sh does)
+echo "Starting Next.js on ${HOST}:${PORT}..."
+NODE_OPTIONS="--max-old-space-size=512 --unhandled-rejections=warn" \
+  NODE_ENV=production HOST="${HOST}" PORT="${PORT}" pnpm start &
+APP_PID=$!
+
+# Exit if either process dies, then clean up both
+wait -n $APP_PID $TOR_PID
+echo "Shutting down services..."
+kill $APP_PID $TOR_PID 2>/dev/null || true
+wait $APP_PID $TOR_PID 2>/dev/null || true

--- a/railway.json
+++ b/railway.json
@@ -1,12 +1,10 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "RAILPACK",
-    "dockerfilePath": null,
-    "buildCommand": "pnpm install --no-frozen-lockfile && pnpm run build"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "sh scripts/start.sh",
     "healthcheckPath": "/",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
Adds a Tor hidden service to the coinpay Railway deploy, using the same single-container pattern as qrypt.chat.

## What
- **`Dockerfile`** (new, repo root) — `node:24-bookworm-slim` that installs `tor` + `tini`, builds the Next.js app, and runs both in one container. Build ARGs cover coinpay's `NEXT_PUBLIC_*` vars; uses `--no-frozen-lockfile` to match the existing Railway build.
- **`entrypoint.sh`** (new) — writes `torrc` (`HiddenServicePort 80 → 127.0.0.1:$PORT`), boots tor, waits for the `.onion` hostname, sanity-checks `.next`, then starts the app with the 512MB heap cap. Kills both processes if either dies.
- **`railway.json`** — switch builder `RAILPACK` → `DOCKERFILE`; drop `startCommand` (container CMD handles it).

## Required Railway steps (post-merge)
1. Attach a **persistent volume mounted at `/var/lib/tor`** so the `.onion` address stays stable across deploys.
2. After first deploy, read `ONION_URL=...` from logs and optionally set **`NEXT_PUBLIC_ONION_URL`** to surface a Tor link in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)