### PR TITLE
Tor: persist onion on existing volume + footer status link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tor ca-certificates tini gettext-base \
  && rm -rf /var/lib/apt/lists/*
 
-# Prepare Tor dirs (Railway volume mounts at /var/lib/tor to keep a stable .onion)
-RUN mkdir -p /var/lib/tor/hidden_service /var/log/tor \
- && chown -R debian-tor:debian-tor /var/lib/tor /var/log/tor \
- && chmod 700 /var/lib/tor/hidden_service
+# Prepare Tor dirs. DataDirectory is ephemeral (/var/lib/tor); the hidden
+# service keys live on the existing Railway volume at /mnt/files/tor (created
+# at runtime by entrypoint.sh) so the .onion address stays stable.
+RUN mkdir -p /var/lib/tor /var/log/tor \
+ && chown -R debian-tor:debian-tor /var/lib/tor /var/log/tor
 
 # Build-time public env vars (inlined into the Next.js bundle at `pnpm build`)
 ARG NEXT_PUBLIC_API_URL
@@ -36,15 +37,14 @@ ENV NEXT_PUBLIC_ONION_URL=$NEXT_PUBLIC_ONION_URL
 
 # App build
 WORKDIR /app
-# Copy lockfiles first for better caching
-COPY pnpm-lock.yaml* package.json pnpm-workspace.yaml ./
 # Pin pnpm to a known-good version (avoid `pnpm@latest` surprises on Railway).
 RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
-# Coinpay's Railway build uses --no-frozen-lockfile (the lockfile drifts); match it.
-RUN pnpm install --no-frozen-lockfile
-
-# Copy the rest and build
+# Copy the whole repo before install: the root package.json depends on the
+# workspace package @profullstack/coinpay (packages/*), so pnpm needs those
+# manifests present at install time. Coinpay's Railway build uses
+# --no-frozen-lockfile (the lockfile drifts); match it.
 COPY . .
+RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 
 # Runtime env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ DataDirectory /var/lib/tor
 Log notice file /var/log/tor/notices.log
 User debian-tor
 
-HiddenServiceDir /var/lib/tor/hidden_service
+HiddenServiceDir /mnt/files/tor/hidden_service
 HiddenServicePort 80 127.0.0.1:${PORT}
 
 SocksPort 0
@@ -22,10 +22,11 @@ ORPort 0
 ExitPolicy reject *:*
 EOF
 
-# Perms for mounted volume
-mkdir -p /var/lib/tor/hidden_service /var/log/tor
-chown -R debian-tor:debian-tor /var/lib/tor /var/log/tor
-chmod 700 /var/lib/tor/hidden_service || true
+# Perms. The onion keys live on the existing Railway volume mounted at
+# /mnt/files (coinpay allows only one volume/service) so the .onion is stable.
+mkdir -p /mnt/files/tor/hidden_service /var/lib/tor /var/log/tor
+chown -R debian-tor:debian-tor /mnt/files/tor /var/lib/tor /var/log/tor
+chmod 700 /mnt/files/tor/hidden_service || true
 
 # Start Tor
 echo "Starting Tor daemon..."
@@ -43,18 +44,18 @@ echo "Tor started successfully (PID: $TOR_PID)"
 # Wait for onion hostname (first run generates keys)
 echo "Waiting for Tor to generate hidden service keys..."
 for i in $(seq 1 60); do
-  if [ -s /var/lib/tor/hidden_service/hostname ]; then
+  if [ -s /mnt/files/tor/hidden_service/hostname ]; then
     break
   fi
   if [ $i -eq 10 ] || [ $i -eq 30 ]; then
-    ls -la /var/lib/tor/hidden_service/ 2>/dev/null || echo "Directory not accessible"
+    ls -la /mnt/files/tor/hidden_service/ 2>/dev/null || echo "Directory not accessible"
     tail -5 /var/log/tor/notices.log 2>/dev/null || echo "No logs available"
   fi
   sleep 1
 done
 
-if [ -s /var/lib/tor/hidden_service/hostname ]; then
-  ONION_URL="$(cat /var/lib/tor/hidden_service/hostname)"
+if [ -s /mnt/files/tor/hidden_service/hostname ]; then
+  ONION_URL="$(cat /mnt/files/tor/hidden_service/hostname)"
   echo "🧅 TOR HIDDEN SERVICE READY!"
   echo "ONION_URL=${ONION_URL}"
   echo "Your site is accessible at: http://${ONION_URL}"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const onionUrl = process.env.NEXT_PUBLIC_ONION_URL;
 
   const footerLinks = {
     product: [
@@ -214,6 +215,21 @@ export default function Footer() {
             </div>
             
             <div className="mt-4 md:mt-0 flex items-center space-x-4">
+              {onionUrl && (
+                <a
+                  href={onionUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={onionUrl}
+                  className="inline-flex items-center gap-2 text-xs text-gray-400 hover:text-purple-400 transition-colors"
+                >
+                  <span className="relative flex h-2 w-2" aria-hidden="true">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75"></span>
+                    <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+                  </span>
+                  🧅 Available on Tor network
+                </a>
+              )}
               <p className="text-xs text-gray-400">
                 Non-custodial crypto payment gateway • 0.5% transaction fee
               </p>


### PR DESCRIPTION
Follow-up to #147.

## Why
coinpay's `coinpayportal.com` service already has a Railway volume mounted at `/mnt/files`, and Railway allows **only one volume per service**. #147 wrote the hidden-service keys to `/var/lib/tor/hidden_service`, which is **ephemeral** — the `.onion` address would change on every redeploy.

## Changes
- **entrypoint.sh / Dockerfile** — `HiddenServiceDir` → `/mnt/files/tor/hidden_service` (on the existing volume) so the `.onion` is stable. `DataDirectory` stays ephemeral at `/var/lib/tor`.
- **src/components/Footer.tsx** — footer indicator (live green dot, "🧅 Available on Tor network") linking to `NEXT_PUBLIC_ONION_URL`, gated on that var being set. Mirrors qrypt.chat.

## After merge
Read `ONION_URL=...` from the deploy logs and set `NEXT_PUBLIC_ONION_URL` in Railway to light up the footer link (and pin the stable address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)