### PR TITLE
fix(x402): block Stripe payment replay in /api/x402/verify

### DIFF
--- a/src/app/api/x402/verify/route.test.ts
+++ b/src/app/api/x402/verify/route.test.ts
@@ -137,4 +137,48 @@ describe('POST /api/x402/verify', () => {
     const data = await res.json();
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
+
+  it('should reject a replayed Stripe PaymentIntent (uniqueKey must include paymentIntentId)', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+
+    // 1st single() -> API key lookup (active); 2nd single() -> replay check finds an existing row
+    mockSingle
+      .mockResolvedValueOnce({
+        data: { id: 'key1', business_id: 'biz1', active: true },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 'already-verified-payment' },
+        error: null,
+      });
+
+    // Stripe API reports the PaymentIntent succeeded
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'succeeded' }),
+    }) as any;
+
+    const payment = {
+      scheme: 'stripe-checkout',
+      payload: {
+        network: 'stripe',
+        scheme: 'stripe-checkout',
+        from: '0xBuyer',
+        to: '0xMerchant',
+        amount: '100',
+        paymentIntentId: 'pi_reused_123',
+      },
+    };
+
+    const req = makeRequest({ payment });
+    const res = await POST(req);
+    const data = await res.json();
+
+    // Before the fix uniqueKey was undefined for Stripe, the replay check was
+    // skipped, and this returned 200 valid — allowing unlimited reuse.
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('replay');
+    // The replay lookup must actually run (2nd single() call), i.e. uniqueKey was set
+    expect(mockSingle).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/x402/verify/route.ts
+++ b/src/app/api/x402/verify/route.ts
@@ -226,8 +226,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
 
-    // Check for replay (nonce/txId already used)
-    const uniqueKey = payment.payload.nonce || payment.payload.txId || payment.payload.txSignature || payment.payload.preimage;
+    // Check for replay (nonce/txId already used).
+    // Stripe proofs carry no nonce/txId/txSignature/preimage — their unique
+    // identifier is the PaymentIntent id, so include it here. Without it the
+    // replay check below is skipped for Stripe and a single succeeded
+    // PaymentIntent can be redeemed unlimited times.
+    const uniqueKey =
+      payment.payload.nonce ||
+      payment.payload.txId ||
+      payment.payload.txSignature ||
+      payment.payload.preimage ||
+      payment.payload.paymentIntentId;
     if (uniqueKey) {
       const { data: existingPayment } = await supabase
         .from('x402_payments')


### PR DESCRIPTION
# fix(x402): block Stripe payment replay in `/api/x402/verify`

## Problem

The replay guard in `src/app/api/x402/verify/route.ts` derives its dedupe key from:

```js
const uniqueKey = payment.payload.nonce || payment.payload.txId
  || payment.payload.txSignature || payment.payload.preimage;
```

Stripe proofs contain none of these fields — the identifier is `paymentIntentId`. So for Stripe:

- `uniqueKey` is `undefined`,
- the `if (uniqueKey)` replay lookup is skipped,
- the payment row is stored with `unique_key: null`.

A single `succeeded` Stripe PaymentIntent can therefore be redeemed unlimited times to pass verification. EVM / BTC / Solana / Lightning are unaffected (they each provide a key).

## Fix

Add `payment.payload.paymentIntentId` to the fallback chain so Stripe proofs are deduped by their PaymentIntent id, like every other rail.

## Testing

- Added a regression test in `route.test.ts` that replays a Stripe PaymentIntent and asserts the second attempt is rejected with a replay error (using the route's real `{ payment }` contract).
- Verified the key-selection logic across all five rails with a standalone script: EVM/BTC/SOL/LN keys are unchanged, Stripe goes from `undefined` → `paymentIntentId`.

## Scope

One-line source change + one test. Does not touch the EVM/UTXO/Solana/Lightning paths. Related findings (verify not bound to amount/recipient; stale `proof`-based tests) are written up in the linked issue and can be follow-ups.

Fixes #150.
