### PR TITLE
fix(reputation): bind claimed DID to supplied public key (prevents DID hijacking)

### DIFF
--- a/src/app/api/reputation/did/claim/claim.test.ts
+++ b/src/app/api/reputation/did/claim/claim.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { generateKeyPairSync, sign } from 'crypto';
+
+// ── did:key helpers (mirror of route.ts, ed25519 multicodec 0xed01) ──
+
+function base58btcEncode(bytes: Uint8Array): string {
+  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  let num = BigInt('0x' + Buffer.from(bytes).toString('hex'));
+  const result: string[] = [];
+  while (num > 0n) {
+    result.unshift(ALPHABET[Number(num % 58n)]);
+    num = num / 58n;
+  }
+  for (const b of bytes) {
+    if (b === 0) result.unshift('1');
+    else break;
+  }
+  return result.join('');
+}
+
+function deriveDidKey(pubRaw: Buffer): string {
+  return `did:key:z${base58btcEncode(Buffer.concat([Buffer.from([0xed, 0x01]), pubRaw]))}`;
+}
+
+function edKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const pubRaw = Buffer.from(publicKey.export({ type: 'spki', format: 'der' })).subarray(-32);
+  return { privateKey, pubRaw, pubB64url: Buffer.from(pubRaw).toString('base64url') };
+}
 
 // ── Mock state ─────────────────────────────────────────────────────
 
@@ -121,5 +149,54 @@ describe('POST /api/reputation/did/claim', () => {
     const { POST } = await import('./route');
     const res = await POST(makeRequest());
     expect(res.status).toBe(500);
+  });
+
+  it('rejects a link whose did does not match the supplied public_key', async () => {
+    // Attacker signs the claim message with their OWN key (so the signature is
+    // valid) but supplies a did:key they do not own. Must be rejected.
+    const { privateKey, pubB64url } = edKeypair();
+    const victimDid = 'did:key:z6MkVictimNotOwnedByTheCaller';
+    const signature = sign(
+      null,
+      Buffer.from(`claim-did:${victimDid}:merchant-123`),
+      privateKey
+    ).toString('base64url');
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest({
+      did: victimDid,
+      public_key: pubB64url,
+      signature,
+      did_kind: 'agent',
+    }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/did does not match/i);
+  });
+
+  it('links an existing DID when did matches the supplied public_key', async () => {
+    const { privateKey, pubRaw, pubB64url } = edKeypair();
+    const did = deriveDidKey(Buffer.from(pubRaw));
+    const signature = sign(
+      null,
+      Buffer.from(`claim-did:${did}:merchant-123`),
+      privateKey
+    ).toString('base64url');
+    mockInsertResult = {
+      data: { did, public_key: pubB64url, verified: true, created_at: '2026-01-01T00:00:00Z' },
+      error: null,
+    };
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest({
+      did,
+      public_key: pubB64url,
+      signature,
+      did_kind: 'agent',
+    }));
+
+    expect(res.status).toBe(201);
+    expect((mockInsertedData as Record<string, unknown>).did).toBe(did);
   });
 });

--- a/src/app/api/reputation/did/claim/route.ts
+++ b/src/app/api/reputation/did/claim/route.ts
@@ -120,6 +120,18 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // Bind the claimed DID to the supplied public key. The signature above
+      // only proves the caller controls `public_key` — not that they own
+      // `body.did`. Without this check a caller could sign with their own key
+      // yet pass ANY did (e.g. another party's did:key) and have it stored as
+      // verified under their merchant. Require did == did:key(public_key).
+      if (body.did !== publicKeyToDidKey(pubKeyBytes)) {
+        return NextResponse.json(
+          { error: 'did does not match public_key' },
+          { status: 400 }
+        );
+      }
+
       did = body.did;
       publicKey = body.public_key;
     } else {


### PR DESCRIPTION
## Problem

`POST /api/reputation/did/claim` (link path) verifies `body.signature` against the **caller-supplied** `body.public_key`, then stores `body.did` verbatim — without checking that `body.did` is the `did:key` derived from that public key.

So an attacker can generate their own keypair, sign `claim-did:<victimDid>:<merchantId>` with it, and pass **any** victim `did:key` as `body.did`. The signature verifies (against the attacker's own key) and the arbitrary DID is inserted into `merchant_dids` as `verified: true` under the attacker's merchant — enabling DID hijacking / impersonation (see #152; `delegate/route.ts` mints signed delegations from the merchant's principal DID).

## Fix

After the signature check, require:

```ts
if (body.did !== publicKeyToDidKey(pubKeyBytes)) {
  return NextResponse.json({ error: 'did does not match public_key' }, { status: 400 });
}
```

This binds the proven key to the identity being claimed. The auto-generate branch (which already derives `did` from the freshly generated key) is unchanged, and non-`did:key` values on the link path are now correctly rejected.

## Tests

Added two regression tests to `claim.test.ts` (the link branch was previously untested):
- mismatched `did` with a valid signature over the attacker's own key → **400** `did does not match public_key`
- `did` that matches the supplied key → **201** and stored

`verify` uses real crypto (unmocked). I also verified the Ed25519 sign/verify + `did:key` derivation standalone: attack case blocked, legit link allowed.

Fixes #152.
