### PR TITLE
chore(db): restore remove_transaction_limits migration on master

### DIFF
--- a/supabase/migrations/20260624113709_remove_transaction_limits.sql
+++ b/supabase/migrations/20260624113709_remove_transaction_limits.sql
@@ -1,0 +1,8 @@
+-- Remove monthly transaction limits for all subscription plans.
+-- NULL means unlimited (handled by can_create_transaction() and the
+-- entitlements service/middleware). Previously the 'starter' plan was
+-- capped at 100 transactions/month, which blocked merchants once they hit
+-- the cap with a 429 "Monthly transaction limit reached" error.
+UPDATE subscription_plans
+SET monthly_transaction_limit = NULL
+WHERE monthly_transaction_limit IS NOT NULL;


### PR DESCRIPTION
## Summary

The `20260624113709_remove_transaction_limits.sql` migration was applied to production long ago but its file only ever lived on feature branches (`fix/remove-transaction-limits`, `feat/tor-hidden-service`) — it never landed on `master`. That left `master`'s migration history out of sync with the remote DB and blocked `supabase db push`.

This restores the file to `master` so local migration history matches production. The migration itself is a one-line, idempotent data update (`monthly_transaction_limit = NULL`) and is already applied on prod — this PR is bookkeeping only, no schema/behavior change.

Surfaced while applying the PayPal invoices migration (#154), which required repairing this drift to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)