### PR TITLE
Fix invalid pagination params in payment APIs

### DIFF
--- a/src/app/api/stripe/disputes/route.ts
+++ b/src/app/api/stripe/disputes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * GET /api/stripe/disputes
@@ -65,8 +66,8 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = parsePaginationParam(searchParams.get('limit'), 50, { min: 1, max: 100 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     // Build query
     let query = supabase

--- a/src/app/api/stripe/payouts/route.ts
+++ b/src/app/api/stripe/payouts/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
 import { getStripe } from '@/lib/server/optional-deps';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * GET /api/stripe/payouts
@@ -66,8 +67,8 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = parsePaginationParam(searchParams.get('limit'), 50, { min: 1, max: 100 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     // Build query
     let query = supabase

--- a/src/app/api/stripe/subscriptions/plans/route.ts
+++ b/src/app/api/stripe/subscriptions/plans/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
 import { getStripe } from '@/lib/server/optional-deps';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * GET /api/stripe/subscriptions/plans
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest) {
     const merchantId = decoded.userId;
     const { searchParams } = new URL(request.url);
     const businessId = searchParams.get('businessId');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
+    const limit = parsePaginationParam(searchParams.get('limit'), 20, { min: 1, max: 100 });
     const activeFilter = searchParams.get('active');
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/app/api/stripe/subscriptions/route.ts
+++ b/src/app/api/stripe/subscriptions/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
 import { getStripe } from '@/lib/server/optional-deps';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * GET /api/stripe/subscriptions
@@ -28,8 +29,8 @@ export async function GET(request: NextRequest) {
     const businessId = searchParams.get('businessId');
     const customerId = searchParams.get('customerId');
     const status = searchParams.get('status');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = parsePaginationParam(searchParams.get('limit'), 20, { min: 1, max: 100 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/src/app/api/stripe/transactions/route.ts
+++ b/src/app/api/stripe/transactions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * GET /api/stripe/transactions
@@ -68,8 +69,8 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = parsePaginationParam(searchParams.get('limit'), 50, { min: 1, max: 100 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     // Build query - include business name via join
     let query = supabase

--- a/src/lib/api/pagination.test.ts
+++ b/src/lib/api/pagination.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { parsePaginationParam } from './pagination';
+
+describe('parsePaginationParam', () => {
+  it('uses the default for missing or invalid values', () => {
+    expect(parsePaginationParam(null, 50, { min: 1, max: 100 })).toBe(50);
+    expect(parsePaginationParam('abc', 50, { min: 1, max: 100 })).toBe(50);
+  });
+
+  it('clamps values to the configured range', () => {
+    expect(parsePaginationParam('-10', 50, { min: 0 })).toBe(0);
+    expect(parsePaginationParam('0', 50, { min: 1, max: 100 })).toBe(1);
+    expect(parsePaginationParam('500', 50, { min: 1, max: 100 })).toBe(100);
+  });
+});
+

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,0 +1,16 @@
+export function parsePaginationParam(
+  value: string | null,
+  defaultValue: number,
+  options: { min?: number; max?: number } = {}
+) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  const min = options.min ?? 0;
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+
+  if (!Number.isFinite(parsed)) {
+    return defaultValue;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
+}
+


### PR DESCRIPTION
## Summary
- add a small pagination parser that falls back on invalid query params
- clamp payment API limits to 1..100 and offsets to 0+
- apply it to Stripe transactions, payouts, disputes, subscriptions, and subscription plans

## Testing
- pnpm vitest run src/lib/api/pagination.test.ts src/app/api/stripe/transactions/route.test.ts src/app/api/stripe/payouts/route.test.ts src/app/api/stripe/subscriptions/route.test.ts
- pnpm type-check
- pnpm exec eslint src/lib/api/pagination.ts src/lib/api/pagination.test.ts src/app/api/stripe/transactions/route.ts src/app/api/stripe/payouts/route.ts src/app/api/stripe/disputes/route.ts src/app/api/stripe/subscriptions/route.ts src/app/api/stripe/subscriptions/plans/route.ts

Note: lint completed with existing warnings in the touched route files, but no errors.