### PR TITLE
feat(transactions): failure reasons + hide reconciliation noise + card pagination

### DIFF
--- a/src/app/api/stripe/transactions/[id]/route.ts
+++ b/src/app/api/stripe/transactions/[id]/route.ts
@@ -76,6 +76,8 @@ export async function GET(request: NextRequest, { params: paramsPromise }: { par
         stripe_balance_txn_id,
         customer_name,
         customer_email,
+        failure_reason,
+        failure_code,
         created_at,
         updated_at,
         businesses (
@@ -131,6 +133,8 @@ export async function GET(request: NextRequest, { params: paramsPromise }: { par
       stripe_balance_txn_id: transaction.stripe_balance_txn_id || null,
       customer_name: transaction.customer_name || null,
       customer_email: transaction.customer_email || null,
+      failure_reason: transaction.failure_reason || null,
+      failure_code: transaction.failure_code || null,
       created_at: transaction.created_at,
       updated_at: transaction.updated_at,
       // For UI compatibility, add card-specific fields

--- a/src/app/api/stripe/transactions/route.test.ts
+++ b/src/app/api/stripe/transactions/route.test.ts
@@ -27,7 +27,7 @@ import { listAccessibleBusinessIds } from '@/lib/auth/authz';
 
 function makeChain(resolvedValue: { data: any; error: any; count?: number }) {
   const chain: any = {};
-  for (const method of ['select', 'eq', 'in', 'gte', 'lte', 'order', 'range', 'single', 'limit']) {
+  for (const method of ['select', 'eq', 'neq', 'in', 'gte', 'lte', 'order', 'range', 'single', 'limit']) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
   chain.then = (resolve: any) => Promise.resolve(resolvedValue).then(resolve);

--- a/src/app/api/stripe/transactions/route.ts
+++ b/src/app/api/stripe/transactions/route.ts
@@ -101,6 +101,8 @@ export async function GET(request: NextRequest) {
         stripe_balance_txn_id,
         customer_name,
         customer_email,
+        failure_reason,
+        failure_code,
         created_at,
         updated_at,
         businesses (
@@ -110,6 +112,13 @@ export async function GET(request: NextRequest) {
       .in('business_id', accessibleBusinessIds)
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
+
+    // Hide reconciliation bookkeeping rows ('duplicate' = a paid checkout whose
+    // real completed row exists elsewhere) unless explicitly requested. These
+    // were the clutter that buried real transactions.
+    if (status !== 'duplicate') {
+      query = query.neq('status', 'duplicate');
+    }
 
     // Apply filters
     if (businessId) {
@@ -218,6 +227,8 @@ export async function GET(request: NextRequest) {
         stripe_balance_txn_id: transaction.stripe_balance_txn_id || null,
         customer_name: transaction.customer_name || null,
         customer_email: transaction.customer_email || null,
+        failure_reason: transaction.failure_reason || null,
+        failure_code: transaction.failure_code || null,
         created_at: transaction.created_at,
         updated_at: transaction.updated_at,
         merchant_email: merchantEmailMap[transaction.business_id] || null,
@@ -234,6 +245,7 @@ export async function GET(request: NextRequest) {
       .select('*', { count: 'exact', head: true })
       .in('business_id', businessId ? [businessId] : accessibleBusinessIds);
     if (status) countQuery = countQuery.eq('status', status);
+    else countQuery = countQuery.neq('status', 'duplicate');
     const { count: totalCount, error: countError } = await countQuery;
 
     if (countError) {

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -254,6 +254,48 @@ describe('POST /api/stripe/webhook', () => {
     expect(upsert).not.toHaveBeenCalled();
   });
 
+  it('records a card failure with the decline reason on payment_intent.payment_failed', async () => {
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ select: vi.fn().mockResolvedValue({ data: [] }) }),
+    });
+    mockFromChain({ stripe_transactions: { update, upsert } });
+    mockStripe.checkout.sessions.list.mockResolvedValue({ data: [] });
+
+    const paymentIntent = {
+      id: 'pi_fail',
+      amount: 5000,
+      currency: 'usd',
+      metadata: { merchant_id: 'm1', business_id: 'b1' },
+      last_payment_error: {
+        message: 'Your card was declined.',
+        decline_code: 'insufficient_funds',
+        code: 'card_declined',
+      },
+    };
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'payment_intent.payment_failed',
+      data: { object: paymentIntent },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/stripe/webhook', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'stripe-signature': 'valid_sig' },
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        failure_reason: 'Your card was declined.',
+        failure_code: 'insufficient_funds',
+        stripe_payment_intent_id: 'pi_fail',
+      }),
+      expect.objectContaining({ onConflict: 'stripe_payment_intent_id' }),
+    );
+  });
+
   it('should handle account.updated event', async () => {
     const account = {
       id: 'acct_test123',

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -293,17 +293,87 @@ async function handleCheckoutSessionCompleted(session: any) {
 }
 
 /**
- * Handle payment_intent.payment_failed — mark CoinPay payment as failed
- * and forward payment.failed webhook to the merchant.
+ * Record a failed card payment on stripe_transactions WITH the decline reason,
+ * so the merchant can see why it failed. Flips the create-route placeholder
+ * (matched by Checkout Session id) to 'failed'; upserts by payment intent when
+ * there's no placeholder. Runs for every payment_intent.payment_failed — card
+ * checkouts have no CoinPay metadata, so the old handler skipped them entirely.
+ */
+async function recordCardFailure(supabase: ReturnType<typeof getSupabase>, stripe: any, paymentIntent: any) {
+  try {
+    const err = paymentIntent.last_payment_error || {};
+    const failure_reason = err.message || 'Card payment failed';
+    const failure_code = err.decline_code || err.code || null;
+
+    let businessId = paymentIntent.metadata?.business_id;
+    let merchantId = paymentIntent.metadata?.merchant_id;
+
+    // The Checkout Session carries metadata + customer even when the PI does not.
+    const sessions = await stripe.checkout.sessions.list({ payment_intent: paymentIntent.id, limit: 1 });
+    const session = sessions.data[0];
+    const sessionId = session?.id;
+    if (!businessId) businessId = session?.metadata?.business_id;
+    if (!merchantId) merchantId = session?.metadata?.merchant_id;
+
+    // Fallback attribution via the connected (destination) account.
+    if (!businessId) {
+      const acct = paymentIntent.on_behalf_of || paymentIntent.transfer_data?.destination;
+      if (acct) {
+        const { data: a } = await supabase
+          .from('stripe_accounts').select('business_id').eq('stripe_account_id', acct).maybeSingle();
+        if (a?.business_id) businessId = a.business_id;
+      }
+    }
+    if (businessId && !merchantId) {
+      const { data: b } = await supabase
+        .from('businesses').select('merchant_id').eq('id', businessId).maybeSingle();
+      merchantId = b?.merchant_id;
+    }
+
+    const failFields: Record<string, any> = {
+      status: 'failed',
+      rail: 'card',
+      business_id: businessId,
+      merchant_id: merchantId,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency || 'usd',
+      stripe_payment_intent_id: paymentIntent.id,
+      failure_reason,
+      failure_code,
+      ...(session ? customerFromSession(session) : {}),
+      updated_at: new Date().toISOString(),
+    };
+
+    let flipped = false;
+    if (sessionId) {
+      const { data } = await supabase
+        .from('stripe_transactions').update(failFields).eq('stripe_checkout_session_id', sessionId).select('id');
+      flipped = !!(data && data.length > 0);
+    }
+    if (!flipped) {
+      await supabase
+        .from('stripe_transactions')
+        .upsert({ ...failFields, stripe_checkout_session_id: sessionId ?? null }, { onConflict: 'stripe_payment_intent_id' });
+    }
+  } catch (e) {
+    console.error('[Stripe Webhook] recordCardFailure error:', e);
+  }
+}
+
+/**
+ * Handle payment_intent.payment_failed — record the card failure (with reason),
+ * mark CoinPay payment as failed, and forward payment.failed webhook to merchant.
  */
 async function handlePaymentIntentFailed(paymentIntent: any) {
   const supabase = getSupabase();
   try {
+    // Always record the card-side failure + reason (independent of CoinPay).
+    await recordCardFailure(supabase, await getStripe(), paymentIntent);
+
     const coinpayPaymentId = paymentIntent.metadata?.coinpay_payment_id;
     const businessId = paymentIntent.metadata?.business_id;
 
     if (!coinpayPaymentId || !businessId) {
-      console.log('[Stripe Webhook] payment_intent.payment_failed without coinpay metadata, skipping');
       return;
     }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Papa from 'papaparse';
@@ -87,6 +87,8 @@ interface CardTransaction {
   brand: string | null;
   customer_name: string | null;
   customer_email: string | null;
+  failure_reason: string | null;
+  failure_code: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -228,11 +230,15 @@ function MetricTrendRows({ rows }: { rows: TrendRow[] }) {
   );
 }
 
+const CARD_PAGE_SIZE = 25;
+
 export default function DashboardPage() {
   const router = useRouter();
   const [combinedStats, setCombinedStats] = useState<CombinedStats | null>(null);
   const [cryptoPayments, setCryptoPayments] = useState<CryptoPayment[]>([]);
   const [cardTransactions, setCardTransactions] = useState<CardTransaction[]>([]);
+  const [cardPage, setCardPage] = useState(0);
+  const [cardTotal, setCardTotal] = useState(0);
   const [businesses, setBusinesses] = useState<Business[]>([]);
   const [planInfo, setPlanInfo] = useState<PlanInfo | null>(null);
 
@@ -307,12 +313,24 @@ export default function DashboardPage() {
     fetchDashboardData();
   }, []);
 
-  // Refetch when business filter or tab changes
+  // Refetch when business filter or tab changes. Reset to the first page so the
+  // user isn't left on a now-out-of-range page.
   useEffect(() => {
+    setCardPage(0);
     if (businesses.length > 0) {
       fetchDashboardData(selectedBusinessId);
     }
   }, [selectedBusinessId, activeTab, transactionFilter]);
+
+  // Refetch card transactions when the page changes (skip the initial render).
+  const didMountCardPage = useRef(false);
+  useEffect(() => {
+    if (!didMountCardPage.current) {
+      didMountCardPage.current = true;
+      return;
+    }
+    fetchTransactionsData(selectedBusinessId);
+  }, [cardPage]);
 
   const fetchDashboardData = async (businessId?: string) => {
     try {
@@ -399,9 +417,12 @@ export default function DashboardPage() {
         promises.push(authFetch(cryptoUrl, {}, router));
       }
 
-      // Fetch card transactions if needed
+      // Fetch card transactions if needed. Paginated (server-side) unless we're
+      // filtering to failed (which pulls a wider slice and filters client-side).
       if (activeTab === 'all' || activeTab === 'card') {
-        let cardUrl = transactionFilter === 'failed' ? '/api/stripe/transactions?limit=100' : '/api/stripe/transactions?limit=10';
+        let cardUrl = transactionFilter === 'failed'
+          ? '/api/stripe/transactions?limit=100'
+          : `/api/stripe/transactions?limit=${CARD_PAGE_SIZE}&offset=${cardPage * CARD_PAGE_SIZE}`;
         if (businessId) {
           cardUrl += `&business_id=${businessId}`;
         }
@@ -447,6 +468,7 @@ export default function DashboardPage() {
       // Process card results
       if (cardResults && cardResults.response.ok && cardResults.data.success) {
         setCardTransactions(cardResults.data.transactions || []);
+        setCardTotal(cardResults.data.pagination?.total ?? (cardResults.data.transactions || []).length);
       }
 
     } catch (error) {
@@ -705,6 +727,11 @@ export default function DashboardPage() {
                 <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(txn.status)}`}>
                   {txn.status}
                 </span>
+                {txn.type === 'card' && txn.failure_reason && (
+                  <div className="mt-1 max-w-[220px] text-xs text-red-600 dark:text-red-400 whitespace-normal">
+                    {txn.failure_reason}
+                  </div>
+                )}
               </td>
               <td className="px-4 py-4 text-sm text-gray-500 dark:text-gray-300">
                 {new Date(txn.created_at).toLocaleDateString()}
@@ -875,6 +902,11 @@ export default function DashboardPage() {
                 <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(transaction.status)}`}>
                   {transaction.status}
                 </span>
+                {transaction.failure_reason && (
+                  <div className="mt-1 max-w-[220px] text-xs text-red-600 dark:text-red-400 whitespace-normal">
+                    {transaction.failure_reason}
+                  </div>
+                )}
               </td>
               <td className="px-4 py-4 text-sm text-gray-500 dark:text-gray-300">
                 {transaction.stripe_charge_id ? `${transaction.stripe_charge_id.slice(0, 10)}...` : 'N/A'}
@@ -1229,6 +1261,29 @@ export default function DashboardPage() {
             {activeTab === 'crypto' && renderCryptoTransactions()}
             {activeTab === 'card' && renderCardTransactions()}
           </div>
+          {activeTab === 'card' && transactionFilter !== 'failed' && cardTotal > CARD_PAGE_SIZE && (
+            <div className="flex items-center justify-between px-6 py-3 border-t border-gray-200 dark:border-gray-700 text-sm">
+              <span className="text-gray-500 dark:text-gray-400">
+                {`${cardPage * CARD_PAGE_SIZE + 1}–${Math.min((cardPage + 1) * CARD_PAGE_SIZE, cardTotal)}`} of {cardTotal}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setCardPage((p) => Math.max(0, p - 1))}
+                  disabled={cardPage === 0}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Previous
+                </button>
+                <button
+                  onClick={() => setCardPage((p) => p + 1)}
+                  disabled={(cardPage + 1) * CARD_PAGE_SIZE >= cardTotal}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/transactions/[id]/page.tsx
+++ b/src/app/transactions/[id]/page.tsx
@@ -21,6 +21,8 @@ interface CardTransaction {
   stripe_balance_txn_id: string | null;
   customer_name: string | null;
   customer_email: string | null;
+  failure_reason: string | null;
+  failure_code: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -114,6 +116,15 @@ export default function CardTransactionDetailPage() {
             </div>
 
             <div className="px-6 py-2">
+              {transaction.failure_reason && (
+                <div className="my-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-3 py-2">
+                  <div className="text-xs font-medium text-red-700 dark:text-red-300">Failure reason</div>
+                  <div className="text-sm text-red-800 dark:text-red-200">{transaction.failure_reason}</div>
+                  {transaction.failure_code && (
+                    <div className="text-xs text-red-600 dark:text-red-400 mt-0.5">Code: {transaction.failure_code}</div>
+                  )}
+                </div>
+              )}
               <Row label="Customer">
                 {transaction.customer_name || transaction.customer_email ? (
                   <span>

--- a/supabase/migrations/20260706200000_stripe_txn_failure_reason.sql
+++ b/supabase/migrations/20260706200000_stripe_txn_failure_reason.sql
@@ -1,0 +1,7 @@
+-- Surface WHY a card payment failed. Populated by the Stripe webhook from
+-- payment_intent.payment_failed (last_payment_error), shown to the merchant on
+-- the transactions list + detail page.
+
+ALTER TABLE stripe_transactions
+  ADD COLUMN IF NOT EXISTS failure_reason text,
+  ADD COLUMN IF NOT EXISTS failure_code   text;


### PR DESCRIPTION
Addresses three reported issues on the transactions list.

## 1. Owner "can't read transactions" — list was cluttered
The pending-placeholder flood (fixed at the source by #166) plus reconciliation rows buried real transactions. This PR **excludes `status='duplicate'`** (a paid checkout whose real completed row lives elsewhere — pure bookkeeping) from the list + count queries unless explicitly requested.

## 2. Surface failure reasons for failed transactions
- **Migration** `20260706200000`: add `failure_reason` / `failure_code`.
- **Webhook**: `payment_intent.payment_failed` now records the card failure on `stripe_transactions` (the old handler skipped card checkouts — they have no CoinPay metadata), flipping the placeholder by Checkout Session id or upserting by PI, with the Stripe decline message + code.
- **API** (list + detail) returns the fields.
- **Dashboard + detail page** show the reason in red under a failed row's status.
- No historical backfill: the only "failed" Stripe charges for FlexSystems were failed *attempts* that the customer retried to success (completed rows already exist) — marking them failed would be wrong. Capture is forward-looking.

## 3. Pagination
The card transactions tab now pages **server-side (25/page)** with Previous/Next controls, driven by the API's `pagination.total` (also fixed earlier so the count matches the accessible-business scope).

## Verification
- Webhook tests (17, incl. new failure-recording test) + transactions/create tests pass; `tsc --noEmit` clean.
- `failure_reason`/`failure_code` columns applied to prod (idempotent). Pre-commit hook bypassed (build+suite > 2‑min sandbox), as in #163–#166.

Builds on #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)