### PR TITLE
feat(payments): invoice number + up-front contact capture on checkout creation

### DIFF
--- a/src/app/api/stripe/payments/create/route.test.ts
+++ b/src/app/api/stripe/payments/create/route.test.ts
@@ -51,12 +51,18 @@ function mockFromChain(overrides: Record<string, any> = {}) {
       }),
     },
     stripe_transactions: {
-      insert: vi.fn().mockResolvedValue({ data: [{}] }),
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { id: 'txn_test_1' }, error: null }),
+        }),
+      }),
     },
   };
 
   const merged = { ...defaults, ...overrides };
-  mockSupabase.from.mockImplementation((table: string) => merged[table] || { insert: vi.fn() });
+  mockSupabase.from.mockImplementation((table: string) => merged[table] || {
+    insert: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: null, error: null }) }) }),
+  });
 }
 
 describe('POST /api/stripe/payments/create', () => {

--- a/src/app/api/stripe/payments/create/route.ts
+++ b/src/app/api/stripe/payments/create/route.ts
@@ -12,22 +12,33 @@ function getSupabase() {
 export async function POST(request: NextRequest) {
   const supabase = getSupabase();
   try {
-    const { 
-      businessId, 
-      amount, 
-      currency = 'usd', 
-      description, 
+    const {
+      businessId,
+      amount,
+      currency = 'usd',
+      description,
       metadata = {},
       successUrl,
       cancelUrl,
+      customerEmail,
+      customerName,
+      invoiceNumber: callerInvoiceNumber,
     } = await request.json();
 
     if (!businessId || !amount || !currency) {
       return NextResponse.json(
-        { error: 'businessId, amount, and currency are required' }, 
+        { error: 'businessId, amount, and currency are required' },
         { status: 400 }
       );
     }
+
+    // Stable invoice number returned to the caller now, so an integration can
+    // record it before the customer reaches Stripe. Callers may supply their own.
+    const invoiceNumber =
+      (typeof callerInvoiceNumber === 'string' && callerInvoiceNumber.trim()) ||
+      `INV-${Date.now().toString(36).toUpperCase()}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    const customerEmailValue = typeof customerEmail === 'string' && customerEmail.trim() ? customerEmail.trim() : null;
+    const customerNameValue = typeof customerName === 'string' && customerName.trim() ? customerName.trim() : null;
 
     // Get business info
     const { data: business, error: bizError } = await supabase
@@ -64,6 +75,7 @@ export async function POST(request: NextRequest) {
       business_id: businessId,
       merchant_id: business.merchant_id,
       platform_fee_amount: platformFeeAmount.toString(),
+      invoice_number: invoiceNumber,
     };
 
     // Gateway Mode: destination charge, funds go directly to merchant
@@ -79,6 +91,9 @@ export async function POST(request: NextRequest) {
           },
         ],
         mode: 'payment',
+        // Prefill the buyer's email on Stripe Checkout when the integration
+        // already knows it (also captured on our side below, up front).
+        ...(customerEmailValue ? { customer_email: customerEmailValue } : {}),
         payment_intent_data: {
           application_fee_amount: platformFeeAmount,
           on_behalf_of: stripeAccount.stripe_account_id,
@@ -97,9 +112,10 @@ export async function POST(request: NextRequest) {
       });
 
     // Create the placeholder transaction record. Store the Checkout Session id so
-    // the webhook can flip THIS row to completed (rather than inserting a separate
-    // completed row and leaving this one stuck at 'pending').
-    await supabase
+    // the webhook can flip THIS row to completed. Invoice number + any known
+    // contact are stored NOW so they're captured before the customer completes
+    // (or closes the window).
+    const { data: inserted, error: insertError } = await supabase
       .from('stripe_transactions')
       .insert({
         merchant_id: business.merchant_id,
@@ -111,9 +127,20 @@ export async function POST(request: NextRequest) {
         status: 'pending',
         rail: 'card',
         stripe_checkout_session_id: session.id,
-      });
+        invoice_number: invoiceNumber,
+        customer_email: customerEmailValue,
+        customer_name: customerNameValue,
+      })
+      .select('id')
+      .single();
+
+    if (insertError) {
+      console.error('[payments/create] transaction insert error:', insertError);
+    }
 
     return NextResponse.json({
+      invoice_number: invoiceNumber,
+      transaction_id: inserted?.id ?? null,
       checkout_url: session.url,
       checkout_session_id: session.id,
       amount,

--- a/src/app/api/stripe/transactions/[id]/route.ts
+++ b/src/app/api/stripe/transactions/[id]/route.ts
@@ -78,6 +78,7 @@ export async function GET(request: NextRequest, { params: paramsPromise }: { par
         customer_email,
         failure_reason,
         failure_code,
+        invoice_number,
         created_at,
         updated_at,
         businesses (
@@ -135,6 +136,7 @@ export async function GET(request: NextRequest, { params: paramsPromise }: { par
       customer_email: transaction.customer_email || null,
       failure_reason: transaction.failure_reason || null,
       failure_code: transaction.failure_code || null,
+      invoice_number: transaction.invoice_number || null,
       created_at: transaction.created_at,
       updated_at: transaction.updated_at,
       // For UI compatibility, add card-specific fields

--- a/src/app/api/stripe/transactions/route.ts
+++ b/src/app/api/stripe/transactions/route.ts
@@ -103,6 +103,7 @@ export async function GET(request: NextRequest) {
         customer_email,
         failure_reason,
         failure_code,
+        invoice_number,
         created_at,
         updated_at,
         businesses (
@@ -229,6 +230,7 @@ export async function GET(request: NextRequest) {
         customer_email: transaction.customer_email || null,
         failure_reason: transaction.failure_reason || null,
         failure_code: transaction.failure_code || null,
+        invoice_number: transaction.invoice_number || null,
         created_at: transaction.created_at,
         updated_at: transaction.updated_at,
         merchant_email: merchantEmailMap[transaction.business_id] || null,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -38,18 +38,24 @@ function getWebhookSecrets(): string[] {
 // Paying customer's name/email for the merchant's transactions list. Checkout
 // exposes these on customer_details; direct PaymentIntents on the charge's
 // billing_details (with receipt_email as a fallback).
-function customerFromSession(session: any): { customer_name: string | null; customer_email: string | null } {
-  return {
-    customer_name: session?.customer_details?.name ?? null,
-    customer_email: session?.customer_details?.email ?? session?.customer_email ?? null,
-  };
+// Only include fields we actually have, so flipping a placeholder to completed
+// never nulls out contact that was captured up front (at payments/create).
+function customerFromSession(session: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  const name = session?.customer_details?.name;
+  const email = session?.customer_details?.email ?? session?.customer_email;
+  if (name) out.customer_name = name;
+  if (email) out.customer_email = email;
+  return out;
 }
 
-function customerFromCharge(charge: any, paymentIntent?: any): { customer_name: string | null; customer_email: string | null } {
-  return {
-    customer_name: charge?.billing_details?.name ?? null,
-    customer_email: charge?.billing_details?.email ?? paymentIntent?.receipt_email ?? charge?.receipt_email ?? null,
-  };
+function customerFromCharge(charge: any, paymentIntent?: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  const name = charge?.billing_details?.name;
+  const email = charge?.billing_details?.email ?? paymentIntent?.receipt_email ?? charge?.receipt_email;
+  if (name) out.customer_name = name;
+  if (email) out.customer_email = email;
+  return out;
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/transactions/[id]/page.tsx
+++ b/src/app/transactions/[id]/page.tsx
@@ -23,6 +23,7 @@ interface CardTransaction {
   customer_email: string | null;
   failure_reason: string | null;
   failure_code: string | null;
+  invoice_number: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -125,6 +126,7 @@ export default function CardTransactionDetailPage() {
                   )}
                 </div>
               )}
+              {transaction.invoice_number && <Row label="Invoice #">{transaction.invoice_number}</Row>}
               <Row label="Customer">
                 {transaction.customer_name || transaction.customer_email ? (
                   <span>

--- a/supabase/migrations/20260707000000_stripe_txn_invoice_number.sql
+++ b/supabase/migrations/20260707000000_stripe_txn_invoice_number.sql
@@ -1,0 +1,9 @@
+-- Give every card payment a stable invoice number that we return to the caller
+-- at creation time, so an integration can record it BEFORE the customer reaches
+-- Stripe (and reconcile regardless of whether they complete or close the window).
+
+ALTER TABLE stripe_transactions
+  ADD COLUMN IF NOT EXISTS invoice_number text;
+
+CREATE INDEX IF NOT EXISTS idx_stripe_transactions_invoice_number
+  ON stripe_transactions(invoice_number);


### PR DESCRIPTION
Answers "do we have an invoice number on our payments? … so we can record that before anyone closes a window" and "capture contact before the Stripe callback."

## New `POST /api/stripe/payments/create` contract
**Request (new optional fields):**
- `customerEmail`, `customerName` — stored on the transaction **immediately** (captured up front, not only via the completion webhook) and used to prefill Stripe Checkout's email.
- `invoiceNumber` — optional; supply your own, otherwise we generate one.

**Response (new fields):**
```json
{
  "invoice_number": "INV-XXXX-XXXX",   // record this now
  "transaction_id": "<uuid>",           // stable reference
  "checkout_url": "...",
  "checkout_session_id": "cs_...",
  "amount": 100, "currency": "usd", "platform_fee_amount": 1
}
```
So an integration gets a stable `invoice_number` (and `transaction_id`) back at creation and can persist it before the buyer ever reaches Stripe.

## Details
- Migration `20260707000000`: add `stripe_transactions.invoice_number` (+ index). Applied to prod (idempotent).
- `invoice_number` is written to the row **and** Stripe metadata, and preserved when the webhook flips the placeholder to completed.
- Webhook customer helpers now **omit empty fields**, so completion never nulls out contact captured at creation (previously an incomplete session's null could overwrite it).
- Transactions list + detail APIs return `invoice_number`; the detail page shows an **Invoice #** row.

## Notes / assumptions
- `invoice_number` is a unique reference token (e.g. `INV-<base36>-<rand>`), not a per-business sequential counter. If you need sequential numbering, that's a follow-up (needs a per-business sequence).
- This covers contact the integration already has. Capturing contact a buyer enters *only on Stripe* and then abandons would need a `checkout.session.expired` subscription — separate change if you want it.

## Verification
- `tsc --noEmit` clean; create/webhook/transactions tests pass (30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)