### PR TITLE
fix(team): admins can manage API keys, webhook secrets, and wallets

### DIFF
--- a/src/app/api/businesses/[id]/api-key/route.ts
+++ b/src/app/api/businesses/[id]/api-key/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { regenerateApiKey } from '@/lib/business/service';
+import { authorizeBusinessOwner } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -68,7 +69,13 @@ export async function POST(
       );
     }
 
-    const result = await regenerateApiKey(supabase, id, auth.merchantId!);
+    // Team-aware gate: API key management is an admin capability, not owner-only.
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'apikey.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
+    const result = await regenerateApiKey(supabase, id, authz.ownerId);
 
     if (!result.success) {
       return NextResponse.json(

--- a/src/app/api/businesses/[id]/wallets/[cryptocurrency]/route.ts
+++ b/src/app/api/businesses/[id]/wallets/[cryptocurrency]/route.ts
@@ -8,6 +8,7 @@ import {
   type Cryptocurrency,
   type UpdateWalletInput,
 } from '@/lib/wallets/service';
+import { authorizeBusinessOwner } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -74,11 +75,16 @@ export async function GET(
       );
     }
 
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'business.read');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
     const result = await getWallet(
       supabase,
       id,
       cryptocurrency as Cryptocurrency,
-      auth.merchantId!
+      authz.ownerId
     );
 
     if (!result.success) {
@@ -133,11 +139,16 @@ export async function PATCH(
       );
     }
 
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'wallet.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
     const result = await updateWallet(
       supabase,
       id,
       cryptocurrency as Cryptocurrency,
-      auth.merchantId!,
+      authz.ownerId,
       input
     );
 
@@ -187,11 +198,16 @@ export async function DELETE(
       );
     }
 
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'wallet.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
     const result = await deleteWallet(
       supabase,
       id,
       cryptocurrency as Cryptocurrency,
-      auth.merchantId!
+      authz.ownerId
     );
 
     if (!result.success) {

--- a/src/app/api/businesses/[id]/wallets/import/route.ts
+++ b/src/app/api/businesses/[id]/wallets/import/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { importWalletsToBusiness } from '@/lib/wallets/merchant-service';
 import type { Cryptocurrency } from '@/lib/wallets/service';
+import { authorizeBusinessOwner } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -80,9 +81,14 @@ export async function POST(
       ? undefined
       : (body.cryptocurrencies as Cryptocurrency[] | undefined);
 
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, businessId, 'wallet.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
     const result = await importWalletsToBusiness(
       supabase,
-      auth.merchantId!,
+      authz.ownerId,
       businessId,
       cryptocurrencies
     );

--- a/src/app/api/businesses/[id]/wallets/route.ts
+++ b/src/app/api/businesses/[id]/wallets/route.ts
@@ -6,6 +6,7 @@ import {
   listWallets,
   type CreateWalletInput,
 } from '@/lib/wallets/service';
+import { authorizeBusinessOwner } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -72,7 +73,12 @@ export async function GET(
       );
     }
 
-    const result = await listWallets(supabase, id, auth.merchantId!);
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'business.read');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
+    const result = await listWallets(supabase, id, authz.ownerId);
 
     if (!result.success) {
       return NextResponse.json(
@@ -127,7 +133,12 @@ export async function POST(
       );
     }
 
-    const result = await createWallet(supabase, id, auth.merchantId!, input);
+    const authz = await authorizeBusinessOwner(supabase, auth.merchantId!, id, 'wallet.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
+    const result = await createWallet(supabase, id, authz.ownerId, input);
 
     if (!result.success) {
       return NextResponse.json(

--- a/src/app/api/businesses/[id]/webhook-secret/route.ts
+++ b/src/app/api/businesses/[id]/webhook-secret/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getWebhookSecret, regenerateWebhookSecret } from '@/lib/business/service';
 import { verifyToken } from '@/lib/auth/jwt';
+import { authorizeBusinessOwner } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -58,7 +59,11 @@ export async function GET(
     const supabase = createClient(supabaseUrl, supabaseKey);
 
     // Get webhook secret
-    const result = await getWebhookSecret(supabase, id, decoded.userId);
+    const authzGet = await authorizeBusinessOwner(supabase, decoded.userId, id, 'webhook.manage');
+    if (!authzGet.ok) {
+      return NextResponse.json({ success: false, error: authzGet.error }, { status: authzGet.status });
+    }
+    const result = await getWebhookSecret(supabase, id, authzGet.ownerId);
 
     if (!result.success) {
       return NextResponse.json(
@@ -133,8 +138,14 @@ export async function POST(
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    // Regenerate webhook secret
-    const result = await regenerateWebhookSecret(supabase, id, decoded.userId);
+    // Team-aware gate: webhook secret management is an admin capability.
+    const authz = await authorizeBusinessOwner(supabase, decoded.userId, id, 'webhook.manage');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
+    // Regenerate webhook secret (owner-scoped service; caller is authorized above)
+    const result = await regenerateWebhookSecret(supabase, id, authz.ownerId);
 
     if (!result.success) {
       return NextResponse.json(

--- a/src/lib/auth/authz.ts
+++ b/src/lib/auth/authz.ts
@@ -103,6 +103,29 @@ export async function authorizeBusiness(
   return { ok: true, role };
 }
 
+/**
+ * Authorize a capability on a business AND resolve the business owner's merchant
+ * id. Many service functions are still owner-scoped (`.eq('merchant_id', …)`);
+ * once the caller (owner OR a sufficiently-privileged team member) is authorized,
+ * routes run those services against the owner id.
+ */
+export async function authorizeBusinessOwner(
+  supabase: SupabaseClient,
+  userId: string,
+  businessId: string,
+  capability: Capability,
+): Promise<{ ok: true; role: Role; ownerId: string } | AuthzErr> {
+  const authz = await authorizeBusiness(supabase, userId, businessId, capability);
+  if (!authz.ok) return authz;
+  const { data } = await supabase
+    .from('businesses')
+    .select('merchant_id')
+    .eq('id', businessId)
+    .maybeSingle();
+  if (!data?.merchant_id) return { ok: false, status: 404, error: 'Business not found' };
+  return { ok: true, role: authz.role, ownerId: data.merchant_id };
+}
+
 /** Gate a capability on an organization. */
 export async function authorizeOrg(
   supabase: SupabaseClient,

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -35,6 +35,7 @@ export type Capability =
   | 'webhook.manage'
   | 'settings.manage'
   | 'billing.manage'
+  | 'wallet.manage'
   // owner-only
   | 'business.delete'
   | 'funds.move';
@@ -65,6 +66,9 @@ const ADMIN_CAPS: Capability[] = [
   'webhook.manage',
   'settings.manage',
   'billing.manage',
+  // Managing which wallet addresses a business RECEIVES to (import/add/remove).
+  // Note: 'funds.move' (withdrawals / moving funds OUT) stays owner-only.
+  'wallet.manage',
 ];
 
 const OWNER_CAPS: Capability[] = [...ADMIN_CAPS, 'business.delete', 'funds.move'];


### PR DESCRIPTION
As an **admin** team member of a business (e.g. anthony on FlexSystems) you couldn't generate API keys/tokens, rotate the webhook secret, or set/paste receiving wallets. #163 fixed read paths, but these WRITE routes still ran owner-only service functions (`.eq('merchant_id', caller)`), so team members were rejected.

## Fix
- **`authorizeBusinessOwner()`** (new helper): authorize a capability for the caller (owner *or* team member), then resolve the business owner's merchant id that the still-owner-scoped services expect. Routes call the service with that owner id once the caller is authorized.
- **API key** (`POST /businesses/[id]/api-key`) → `apikey.manage` (admin).
- **Webhook secret** (`GET`/`POST /businesses/[id]/webhook-secret`) → `webhook.manage` (admin).
- **Wallets** (`list` / `create` / `import` / `get` / `update` / `delete`): reads → `business.read`; writes → new **`wallet.manage`** capability.
- **permissions**: add `wallet.manage` to the **admin** set.

## Security note (per your decision)
`wallet.manage` covers which addresses a business **receives** to (import/add/remove). Moving funds **out** (`funds.move` — withdrawals/payouts) stays **owner-only**. You chose to let admins set receiving wallets; a rogue admin could redirect incoming funds, so this deliberately widens that boundary to admin.

## Verification
- `tsc --noEmit` clean; permissions + authz tests pass (27). No schema change.

Effective role for anthony on FlexSystems is `admin` → now passes `apikey.manage` / `webhook.manage` / `wallet.manage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)