### PR TITLE
feat(business): paginate crypto + card transaction lists on the business page

### DIFF
--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -63,6 +63,12 @@ export async function GET(request: NextRequest) {
     const currency = searchParams.get('currency');
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
+    // Optional pagination. When `limit` is supplied we page the results and
+    // return a total; without it the endpoint keeps its old "return all" behavior.
+    const limitParam = searchParams.get('limit');
+    const paginate = limitParam !== null;
+    const limit = Math.min(Math.max(parseInt(limitParam || '50', 10) || 50, 1), 100);
+    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10) || 0, 0);
 
     // All businesses this user can access — owned plus those granted via org or
     // per-business team membership. Owner-only scoping here hid data from invited
@@ -77,7 +83,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Build query - include business name via join
+    // Build query - include business name via join. count:'exact' returns the
+    // total matching rows (ignoring the range) so we can paginate.
     let query = supabase
       .from('payments')
       .select(`
@@ -105,7 +112,7 @@ export async function GET(request: NextRequest) {
         businesses (
           name
         )
-      `)
+      `, { count: 'exact' })
       .in('business_id', userBusinessIds)
       .order('created_at', { ascending: false });
 
@@ -133,7 +140,30 @@ export async function GET(request: NextRequest) {
       query = query.lt('created_at', endDate.toISOString());
     }
 
-    const { data: payments, error } = await query;
+    if (paginate) {
+      query = query.range(offset, offset + limit - 1);
+    }
+
+    const { data: payments, error, count } = await query;
+
+    // Status summary across ALL matching rows (so paginated UIs can show accurate
+    // totals in their summary cards, not just the current page).
+    let summary: { total: number; successful: number; pending: number; failed: number } | undefined;
+    if (paginate && !error) {
+      let statusQuery = supabase.from('payments').select('status').in('business_id', userBusinessIds);
+      if (businessId && userBusinessIds.includes(businessId)) statusQuery = statusQuery.eq('business_id', businessId);
+      const { data: statusRows } = await statusQuery;
+      const successStatuses = new Set(['completed', 'confirmed', 'forwarded', 'forwarding']);
+      const pendingStatuses = new Set(['pending', 'detected']);
+      const failedStatuses = new Set(['failed', 'expired', 'forwarding_failed', 'settle_failed', 'settlement_failed']);
+      summary = { total: count ?? (statusRows?.length ?? 0), successful: 0, pending: 0, failed: 0 };
+      for (const r of statusRows || []) {
+        const s = String(r.status || '').toLowerCase();
+        if (successStatuses.has(s)) summary.successful++;
+        else if (pendingStatuses.has(s)) summary.pending++;
+        else if (failedStatuses.has(s)) summary.failed++;
+      }
+    }
 
     if (error) {
       console.error('Error fetching payments:', error);
@@ -181,7 +211,16 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { success: true, payments: transformedPayments },
+      {
+        success: true,
+        payments: transformedPayments,
+        ...(paginate
+          ? {
+              pagination: { limit, offset, total: count ?? 0, has_more: offset + limit < (count ?? 0) },
+              summary,
+            }
+          : {}),
+      },
       { status: 200 }
     );
   } catch (error) {

--- a/src/components/business/CryptoTransactionsTab.tsx
+++ b/src/components/business/CryptoTransactionsTab.tsx
@@ -32,19 +32,32 @@ function isFailureStatus(status: string) {
   return FAILURE_STATUSES.has(status.toLowerCase());
 }
 
+const PAGE_SIZE = 20;
+
 export function CryptoTransactionsTab({ businessId }: CryptoTransactionsTabProps) {
   const router = useRouter();
   const [payments, setPayments] = useState<CryptoPayment[]>([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [summary, setSummary] = useState<{ total: number; successful: number; pending: number; failed: number } | null>(null);
 
   const fetchPayments = useCallback(async () => {
     try {
-      const result = await authFetch(`/api/payments?business_id=${businessId}`, {}, router);
+      const result = await authFetch(
+        `/api/payments?business_id=${businessId}&limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`,
+        {},
+        router,
+      );
       if (!result) return;
       const { data } = result;
-      if (data.success) setPayments(data.payments || []);
+      if (data.success) {
+        setPayments(data.payments || []);
+        setTotal(data.pagination?.total ?? (data.payments || []).length);
+        setSummary(data.summary ?? null);
+      }
     } catch { /* ignore */ }
-  }, [businessId, router]);
+  }, [businessId, page, router]);
 
   useEffect(() => {
     const load = async () => {
@@ -110,10 +123,10 @@ export function CryptoTransactionsTab({ businessId }: CryptoTransactionsTabProps
       ) : (
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Crypto payment status summary">
-            <StatusSummaryCard label="Total" value={payments.length} className="border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white" />
-            <StatusSummaryCard label="Successful" value={successfulCount} className="border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300" />
-            <StatusSummaryCard label="Pending" value={pendingCount} className="border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300" />
-            <StatusSummaryCard label="Failures" value={failureCount} className="border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300" />
+            <StatusSummaryCard label="Total" value={summary?.total ?? total} className="border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white" />
+            <StatusSummaryCard label="Successful" value={summary?.successful ?? successfulCount} className="border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300" />
+            <StatusSummaryCard label="Pending" value={summary?.pending ?? pendingCount} className="border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300" />
+            <StatusSummaryCard label="Failures" value={summary?.failed ?? failureCount} className="border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300" />
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -161,6 +174,29 @@ export function CryptoTransactionsTab({ businessId }: CryptoTransactionsTabProps
               </tbody>
             </table>
           </div>
+          {total > PAGE_SIZE && (
+            <div className="flex items-center justify-between pt-3 mt-2 border-t border-gray-100 dark:border-gray-800 text-sm">
+              <span className="text-gray-500 dark:text-gray-400">
+                {`${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, total)}`} of {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Previous
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/business/StripeTransactionsTab.tsx
+++ b/src/components/business/StripeTransactionsTab.tsx
@@ -26,19 +26,30 @@ interface Transaction {
   created_at: string;
 }
 
+const PAGE_SIZE = 20;
+
 export function StripeTransactionsTab({ businessId }: StripeTransactionsTabProps) {
   const router = useRouter();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [total, setTotal] = useState(0);
 
   const fetchTransactions = useCallback(async () => {
     try {
-      const result = await authFetch(`/api/stripe/transactions?business_id=${businessId}&limit=20`, {}, router);
+      const result = await authFetch(
+        `/api/stripe/transactions?business_id=${businessId}&limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`,
+        {},
+        router,
+      );
       if (!result) return;
       const { data } = result;
-      if (data.success) setTransactions(data.transactions || []);
+      if (data.success) {
+        setTransactions(data.transactions || []);
+        setTotal(data.pagination?.total ?? (data.transactions || []).length);
+      }
     } catch { /* ignore */ }
-  }, [businessId, router]);
+  }, [businessId, page, router]);
 
   useEffect(() => {
     const load = async () => {
@@ -144,6 +155,29 @@ export function StripeTransactionsTab({ businessId }: StripeTransactionsTabProps
               ))}
             </tbody>
           </table>
+          {total > PAGE_SIZE && (
+            <div className="flex items-center justify-between pt-3 mt-2 border-t border-gray-100 dark:border-gray-800 text-sm">
+              <span className="text-gray-500 dark:text-gray-400">
+                {`${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, total)}`} of {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Previous
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
The per-business admin page (`/businesses/[id]`) → **Transactions** tabs showed a fixed window (card: 20, crypto: **all**) with no paging. Both now paginate (20/page, Previous/Next).

## Changes
- **`/api/payments`**: added optional `limit`/`offset` pagination — returns `pagination.total` (via `count: 'exact'`) and a `summary` (total/successful/pending/failed across **all** rows). Backward-compatible: with no `limit` it keeps the old "return all" behavior.
- **StripeTransactionsTab** (Credit Card → Transactions): 20/page, Prev/Next driven by `pagination.total` (endpoint already supported offset).
- **CryptoTransactionsTab** (Crypto → Transactions): 20/page, Prev/Next; the status **summary cards use the API's full-set summary** so they stay accurate across pages (not just the current page).

## Notes
- Export CSV still exports the currently-loaded page (unchanged for card, which was already 20; crypto now 20 instead of all). Export-all is a separate follow-up if you want it.

## Verification
- `tsc --noEmit` clean; business page test passes. The 2 failing tests in the run are in `payments/[id]/forward` (untouched here, pre-existing on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)