### PR TITLE
fix(team): Stripe config, invoices/clients, disputes/payouts/subscriptions team-aware

### DIFF
--- a/src/app/api/businesses/[id]/payment-methods/config/route.ts
+++ b/src/app/api/businesses/[id]/payment-methods/config/route.ts
@@ -77,7 +77,7 @@ export async function PUT(
     if ('error' in authResult) {
       return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
     }
-    const access = await verifyBusinessAccess(supabase, id, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, id, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ success: false, error: access.error }, { status: access.status ?? 404 });
     }

--- a/src/app/api/businesses/[id]/payment-methods/manual/import/route.ts
+++ b/src/app/api/businesses/[id]/payment-methods/manual/import/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if ('error' in authResult) {
       return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
     }
-    const access = await verifyBusinessAccess(supabase, id, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, id, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ success: false, error: access.error }, { status: access.status ?? 404 });
     }

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
+import { authorizeBusiness, listAccessibleBusinessIds } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 /**
@@ -26,15 +27,21 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const businessId = searchParams.get('business_id');
 
+    // Team-aware: clients of every business the caller can access (owner + team),
+    // not just ones they personally created.
+    const accessibleIds = await listAccessibleBusinessIds(supabase, decoded.userId);
+    if (accessibleIds.length === 0) {
+      return NextResponse.json({ success: true, clients: [] });
+    }
+    if (businessId && !accessibleIds.includes(businessId)) {
+      return NextResponse.json({ success: false, error: 'Business not found' }, { status: 404 });
+    }
+
     let query = supabase
       .from('clients')
       .select('*')
-      .eq('user_id', decoded.userId)
+      .in('business_id', businessId ? [businessId] : accessibleIds)
       .order('created_at', { ascending: false });
-
-    if (businessId) {
-      query = query.eq('business_id', businessId);
-    }
 
     const { data: clients, error } = await query;
 
@@ -76,22 +83,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'business_id and email are required' }, { status: 400 });
     }
 
-    // Verify business belongs to user
+    // Team-aware: creating a customer is a writer+ capability (writer/admin/owner).
+    const authz = await authorizeBusiness(supabase, decoded.userId, business_id, 'customer.write');
+    if (!authz.ok) {
+      return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+    }
+
+    // Attribute the client to the business owner so owner-scoped views still see
+    // clients a team member created.
     const { data: business } = await supabase
       .from('businesses')
-      .select('id')
+      .select('merchant_id')
       .eq('id', business_id)
-      .eq('merchant_id', decoded.userId)
       .single();
-
-    if (!business) {
-      return NextResponse.json({ success: false, error: 'Business not found' }, { status: 404 });
-    }
+    const clientOwnerId = business?.merchant_id ?? decoded.userId;
 
     const { data: client, error } = await supabase
       .from('clients')
       .insert({
-        user_id: decoded.userId,
+        user_id: clientOwnerId,
         business_id,
         name,
         email,

--- a/src/app/api/paypal/connect/route.ts
+++ b/src/app/api/paypal/connect/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
     if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== businessId) {
       return NextResponse.json({ success: false, error: 'businessId does not match API key scope' }, { status: 403 });
     }
-    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ success: false, error: access.error }, { status: access.status ?? 404 });
     }
@@ -117,7 +117,7 @@ export async function DELETE(request: NextRequest) {
     if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== businessId) {
       return NextResponse.json({ success: false, error: 'businessId does not match API key scope' }, { status: 403 });
     }
-    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ success: false, error: access.error }, { status: access.status ?? 404 });
     }

--- a/src/app/api/stripe/connect/disconnect/route.ts
+++ b/src/app/api/stripe/connect/disconnect/route.ts
@@ -28,7 +28,7 @@ export async function DELETE(request: NextRequest) {
     if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== businessId) {
       return NextResponse.json({ error: 'businessId does not match API key scope' }, { status: 403 });
     }
-    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ error: access.error }, { status: access.status ?? 404 });
     }

--- a/src/app/api/stripe/connect/onboard/route.ts
+++ b/src/app/api/stripe/connect/onboard/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
     if (authResult.apiKeyBusinessId && authResult.apiKeyBusinessId !== businessId) {
       return NextResponse.json({ error: 'businessId does not match API key scope' }, { status: 403 });
     }
-    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId);
+    const access = await verifyBusinessAccess(supabase, businessId, authResult.merchantId, 'settings.manage');
     if (!access.ok) {
       return NextResponse.json({ error: access.error }, { status: access.status ?? 404 });
     }

--- a/src/app/api/stripe/disputes/route.ts
+++ b/src/app/api/stripe/disputes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
+import { listAccessibleOwnerMerchantIds } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 import { parsePaginationParam } from '@/lib/api/pagination';
 
@@ -61,6 +62,8 @@ export async function GET(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+
     // Get query parameters for filtering and pagination
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
@@ -84,7 +87,7 @@ export async function GET(request: NextRequest) {
         created_at,
         updated_at
       `)
-      .eq('merchant_id', merchantId)
+      .in('merchant_id', ownerMerchantIds)
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
 
@@ -133,7 +136,7 @@ export async function GET(request: NextRequest) {
     const { count: totalCount, error: countError } = await supabase
       .from('stripe_disputes')
       .select('*', { count: 'exact', head: true })
-      .eq('merchant_id', merchantId);
+      .in('merchant_id', ownerMerchantIds);
 
     if (countError) {
       console.error('Error getting disputes count:', countError);

--- a/src/app/api/stripe/payouts/route.test.ts
+++ b/src/app/api/stripe/payouts/route.test.ts
@@ -14,6 +14,10 @@ vi.mock('@/lib/auth/jwt', () => ({
   verifyToken: vi.fn(),
 }));
 
+vi.mock('@/lib/auth/authz', () => ({
+  listAccessibleOwnerMerchantIds: vi.fn(async () => ['test-merchant-id']),
+}));
+
 vi.mock('@/lib/secrets', () => ({
   getJwtSecret: vi.fn(() => 'test-secret'),
 }));
@@ -39,7 +43,7 @@ import { verifyToken } from '@/lib/auth/jwt';
 
 function makeChain(resolvedValue: { data: any; error: any; count?: number }) {
   const chain: any = {};
-  for (const method of ['select', 'eq', 'not', 'gte', 'lt', 'order', 'range', 'single', 'limit', 'insert']) {
+  for (const method of ['select', 'eq', 'in', 'not', 'gte', 'lt', 'order', 'range', 'single', 'limit', 'insert']) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
   chain.then = (resolve: any) => Promise.resolve(resolvedValue).then(resolve);

--- a/src/app/api/stripe/payouts/route.ts
+++ b/src/app/api/stripe/payouts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
+import { listAccessibleOwnerMerchantIds } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 import { getStripe } from '@/lib/server/optional-deps';
 import { parsePaginationParam } from '@/lib/api/pagination';
@@ -62,6 +63,8 @@ export async function GET(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+
     // Get query parameters for filtering and pagination
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
@@ -83,7 +86,7 @@ export async function GET(request: NextRequest) {
         created_at,
         updated_at
       `)
-      .eq('merchant_id', merchantId)
+      .in('merchant_id', ownerMerchantIds)
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
 
@@ -130,7 +133,7 @@ export async function GET(request: NextRequest) {
     const { count: totalCount, error: countError } = await supabase
       .from('stripe_payouts')
       .select('*', { count: 'exact', head: true })
-      .eq('merchant_id', merchantId);
+      .in('merchant_id', ownerMerchantIds);
 
     if (countError) {
       console.error('Error getting payouts count:', countError);

--- a/src/app/api/stripe/subscriptions/route.ts
+++ b/src/app/api/stripe/subscriptions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
+import { listAccessibleOwnerMerchantIds } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 import { getStripe } from '@/lib/server/optional-deps';
 import { parsePaginationParam } from '@/lib/api/pagination';
@@ -38,10 +39,13 @@ export async function GET(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    // Team-aware: subscriptions of every business the caller can access.
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+
     let query = supabase
       .from('subscriptions')
       .select('*, subscription_plans(name, amount, currency, interval)')
-      .eq('merchant_id', merchantId)
+      .in('merchant_id', ownerMerchantIds)
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
 

--- a/src/lib/auth/authz.ts
+++ b/src/lib/auth/authz.ts
@@ -197,3 +197,23 @@ export async function listAccessibleBusinessIds(
 ): Promise<string[]> {
   return [...(await getAccessibleBusinessRoles(supabase, userId)).keys()];
 }
+
+/**
+ * Owner merchant ids for every business the user can access. Use to scope tables
+ * that key by the owner's merchant_id (stripe_disputes/payouts/subscriptions) so
+ * team members see the owner's records, not just their own.
+ */
+export async function listAccessibleOwnerMerchantIds(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<string[]> {
+  const ids = await listAccessibleBusinessIds(supabase, userId);
+  const owners = new Set<string>([userId]);
+  if (ids.length > 0) {
+    const { data } = await supabase.from('businesses').select('merchant_id').in('id', ids);
+    for (const b of (data ?? []) as { merchant_id: string | null }[]) {
+      if (b.merchant_id) owners.add(b.merchant_id);
+    }
+  }
+  return [...owners];
+}

--- a/src/lib/wallets/supported-coins.ts
+++ b/src/lib/wallets/supported-coins.ts
@@ -1,4 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { authorizeBusiness } from '@/lib/auth/authz';
+import type { Capability } from '@/lib/auth/permissions';
 
 export const CRYPTO_NAMES: Record<string, string> = {
   BTC: 'Bitcoin',
@@ -93,22 +95,22 @@ export function coinToSupportedToken(coin: SupportedCoin): SupportedToken {
   };
 }
 
+/**
+ * Verify the caller can act on a business. Team-aware: the caller may be the
+ * owner OR a team member with the required capability (default `business.read`,
+ * i.e. any member). Pass a stricter capability (e.g. `settings.manage`) for
+ * sensitive writes so a read-only member can't perform them.
+ */
 export async function verifyBusinessAccess(
   supabase: SupabaseClient,
   businessId: string,
   merchantId: string,
+  capability: Capability = 'business.read',
 ): Promise<BusinessAccessResult> {
-  const { data: business, error } = await supabase
-    .from('businesses')
-    .select('id')
-    .eq('id', businessId)
-    .eq('merchant_id', merchantId)
-    .single();
-
-  if (error || !business) {
-    return { ok: false, error: 'Business not found or access denied', status: 404 };
+  const authz = await authorizeBusiness(supabase, merchantId, businessId, capability);
+  if (!authz.ok) {
+    return { ok: false, error: authz.error, status: authz.status };
   }
-
   return { ok: true };
 }
 


### PR DESCRIPTION
Follow-up to #171. As an **admin team member** you still hit owner-only checks in many places: Stripe showed **"not connected"**, **invoice/client creation** was denied, and the **Disputes/Payouts/Subscriptions** tabs were empty.

## Root causes + fixes
### 1. `verifyBusinessAccess()` was owner-only (used by ~12 routes)
Made it team-aware with an optional capability (default `business.read`). One change fixes: Stripe **connect status** (the "not connected" bug), supported-coins, payment-method config reads, tokens, payments/create, PayPal status.
Sensitive **writes** pass a stricter capability (`settings.manage`): Stripe connect **onboard/disconnect**, PayPal **connect**, payment-method **import** + **config PUT**. So a read-only member can't perform them.

### 2. Invoices → clients
`/api/clients` was owner-only, which blocked invoice creation (invoices already used `invoice.write`). Now: **GET** lists clients across accessible businesses; **POST** gates on `customer.write` and attributes the client to the business owner.

### 3. Disputes / Payouts / Subscriptions tabs empty
These tables key by the **owner's** `merchant_id`, so a team member's id matched nothing. New `listAccessibleOwnerMerchantIds()` returns the owner merchant ids for accessible businesses; the three **GET** routes scope by it. **Payout creation stays owner-only** (`funds.move`).

## Security
Reads open to any team member (`business.read`); management writes require `admin` (`settings.manage`); moving funds out stays owner-only. Admin (your role on FlexSystems) satisfies all the read + management paths.

## Verification
- `tsc --noEmit` clean; auth/permissions/stripe route tests pass (142). No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)