### PR TITLE
fix(invoices): authorize invoice + payment-methods by business role, not owner

### DIFF
--- a/src/app/api/businesses/[id]/payment-methods/route.test.ts
+++ b/src/app/api/businesses/[id]/payment-methods/route.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-vi.mock('@/lib/auth/jwt', () => ({
-  verifyToken: vi.fn().mockReturnValue({ userId: 'merch-1' }),
+const mockResolveMerchant = vi.fn();
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: (...args: any[]) => mockResolveMerchant(...args),
 }));
 
-vi.mock('@/lib/secrets', () => ({
-  getJwtSecret: vi.fn().mockReturnValue('test-secret'),
-}));
-
-const mockListWallets = vi.fn();
-vi.mock('@/lib/wallets/service', () => ({
-  listWallets: (...args: any[]) => mockListWallets(...args),
+const mockAuthorizeBusiness = vi.fn();
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: (...args: any[]) => mockAuthorizeBusiness(...args),
 }));
 
 const mockFrom = vi.fn();
@@ -27,13 +24,23 @@ function makeRequest(): NextRequest {
   });
 }
 
-function setupStripe(account: any) {
+// Wire up the two tables the route reads: business_wallets (crypto) + stripe_accounts (card).
+function setupTables(wallets: any[], stripeAccount: any) {
   mockFrom.mockImplementation((table: string) => {
+    if (table === 'business_wallets') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: wallets, error: null }),
+          }),
+        }),
+      };
+    }
     if (table === 'stripe_accounts') {
       return {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
-            single: vi.fn().mockResolvedValue({ data: account, error: account ? null : { code: 'PGRST116' } }),
+            single: vi.fn().mockResolvedValue({ data: stripeAccount, error: stripeAccount ? null : { code: 'PGRST116' } }),
           }),
         }),
       };
@@ -47,18 +54,20 @@ describe('GET /api/businesses/[id]/payment-methods', () => {
     vi.clearAllMocks();
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    // Default: a team member with read access to the business.
+    mockResolveMerchant.mockResolvedValue({ merchantId: 'merch-1', apiKeyBusinessId: null });
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'owner' });
   });
 
   it('returns active crypto wallets and card enabled when Stripe charges are on', async () => {
-    mockListWallets.mockResolvedValue({
-      success: true,
-      wallets: [
+    setupTables(
+      [
         { cryptocurrency: 'BTC', wallet_address: 'bc1q', is_active: true },
         { cryptocurrency: 'SOL', wallet_address: 'sol1', is_active: true },
         { cryptocurrency: 'ETH', wallet_address: '0xeth', is_active: false },
       ],
-    });
-    setupStripe({ stripe_account_id: 'acct_1', charges_enabled: true });
+      { stripe_account_id: 'acct_1', charges_enabled: true },
+    );
 
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'biz-1' }) });
     const body = await res.json();
@@ -70,8 +79,7 @@ describe('GET /api/businesses/[id]/payment-methods', () => {
   });
 
   it('reports card disabled when charges are not enabled', async () => {
-    mockListWallets.mockResolvedValue({ success: true, wallets: [] });
-    setupStripe({ stripe_account_id: 'acct_1', charges_enabled: false });
+    setupTables([], { stripe_account_id: 'acct_1', charges_enabled: false });
 
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'biz-1' }) });
     const body = await res.json();
@@ -81,8 +89,7 @@ describe('GET /api/businesses/[id]/payment-methods', () => {
   });
 
   it('reports card disabled when there is no Stripe account', async () => {
-    mockListWallets.mockResolvedValue({ success: true, wallets: [] });
-    setupStripe(null);
+    setupTables([], null);
 
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'biz-1' }) });
     const body = await res.json();
@@ -90,11 +97,27 @@ describe('GET /api/businesses/[id]/payment-methods', () => {
     expect(body.card).toEqual({ enabled: false, stripe_account_id: null });
   });
 
-  it('400s when the business is not accessible', async () => {
-    mockListWallets.mockResolvedValue({ success: false, error: 'Business not found or access denied' });
-    setupStripe(null);
+  it('works for a team member (authorized by business role, not ownership)', async () => {
+    // The whole point of the fix: a non-owner with a role still sees the methods.
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'writer' });
+    setupTables([{ cryptocurrency: 'BTC', wallet_address: 'bc1q', is_active: true }], {
+      stripe_account_id: 'acct_1',
+      charges_enabled: true,
+    });
 
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'biz-1' }) });
-    expect(res.status).toBe(400);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.card.enabled).toBe(true);
+    expect(body.crypto).toHaveLength(1);
+  });
+
+  it('404s when the business is not accessible', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({ ok: false, status: 404, error: 'Business not found' });
+    setupTables([], null);
+
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'biz-1' }) });
+    expect(res.status).toBe(404);
   });
 });

--- a/src/app/api/businesses/[id]/payment-methods/route.ts
+++ b/src/app/api/businesses/[id]/payment-methods/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { verifyToken } from '@/lib/auth/jwt';
-import { getJwtSecret } from '@/lib/secrets';
-import { listWallets } from '@/lib/wallets/service';
+import { resolveMerchant } from '@/lib/auth/merchant';
+import { authorizeBusiness } from '@/lib/auth/authz';
 
 /**
  * GET /api/businesses/[id]/payment-methods
@@ -12,6 +11,11 @@ import { listWallets } from '@/lib/wallets/service';
  * the invoice flow so the creator (and ultimately the payer) see every accepted
  * method for the business.
  *
+ * Authorized by business ROLE (owner, team member, or a matching API key) — not
+ * by `businesses.merchant_id`. The old owner-only gate made this route 400 for
+ * team members, which the invoice-create UI surfaced as "Card payments are off
+ * for this business" and an empty wallet list even when both were configured.
+ *
  * Response:
  * {
  *   success: true,
@@ -19,34 +23,12 @@ import { listWallets } from '@/lib/wallets/service';
  *   card: { enabled: boolean, stripe_account_id: string | null }
  * }
  */
-async function verifyAuth(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return { error: 'Missing authorization header', status: 401 } as const;
-  }
-  const token = authHeader.substring(7);
-  const jwtSecret = getJwtSecret();
-  if (!jwtSecret) {
-    return { error: 'Server configuration error', status: 500 } as const;
-  }
-  try {
-    const decoded = verifyToken(token, jwtSecret);
-    return { merchantId: decoded.userId } as const;
-  } catch {
-    return { error: 'Invalid or expired token', status: 401 } as const;
-  }
-}
-
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id } = await params;
-    const auth = await verifyAuth(request);
-    if ('error' in auth) {
-      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
-    }
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -55,12 +37,35 @@ export async function GET(
     }
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    // Active crypto wallets (listWallets verifies the business belongs to the merchant).
-    const walletResult = await listWallets(supabase, id, auth.merchantId);
-    if (!walletResult.success) {
-      return NextResponse.json({ success: false, error: walletResult.error }, { status: 400 });
+    const auth = await resolveMerchant(supabase, request);
+    if ('error' in auth) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
     }
-    const crypto = (walletResult.wallets || [])
+    const { merchantId, apiKeyBusinessId } = auth;
+
+    // Authorize read access to this business. API keys are locked to their own
+    // business; JWT/team callers must hold a role that grants business.read.
+    if (apiKeyBusinessId) {
+      if (apiKeyBusinessId !== id) {
+        return NextResponse.json({ success: false, error: 'Business not found' }, { status: 404 });
+      }
+    } else {
+      const authz = await authorizeBusiness(supabase, merchantId, id, 'business.read');
+      if (!authz.ok) {
+        return NextResponse.json({ success: false, error: authz.error }, { status: authz.status });
+      }
+    }
+
+    // Active crypto wallets for the business.
+    const { data: wallets, error: walletError } = await supabase
+      .from('business_wallets')
+      .select('*')
+      .eq('business_id', id)
+      .order('cryptocurrency', { ascending: true });
+    if (walletError) {
+      return NextResponse.json({ success: false, error: walletError.message }, { status: 400 });
+    }
+    const crypto = (wallets || [])
       .filter((w) => w.is_active !== false)
       .map((w) => ({ cryptocurrency: w.cryptocurrency, wallet_address: w.wallet_address }));
 

--- a/src/app/api/invoices/[id]/enable-card/route.test.ts
+++ b/src/app/api/invoices/[id]/enable-card/route.test.ts
@@ -30,6 +30,15 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({ from: mockFrom })),
 }));
 
+// authorizeInvoice gates on the invoice's business role; stub the resolve/authorize
+// primitives so the route's real invoice fetch (supabase mock) still runs.
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: vi.fn().mockResolvedValue({ merchantId: 'merch-1', apiKeyBusinessId: null }),
+}));
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: vi.fn().mockResolvedValue({ ok: true, role: 'owner' }),
+}));
+
 import { POST } from './route';
 
 const baseInvoice = {
@@ -61,9 +70,7 @@ function setupMocks(overrides: { invoice?: any; stripeAccount?: any } = {}) {
       return {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
-            }),
+            single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
           }),
         }),
         update: vi.fn().mockReturnValue({

--- a/src/app/api/invoices/[id]/enable-card/route.ts
+++ b/src/app/api/invoices/[id]/enable-card/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { resolveMerchant } from '@/lib/auth/merchant';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { createInvoiceStripeCheckout } from '@/lib/payments/invoice-stripe';
 
@@ -19,22 +19,17 @@ export async function POST(
   try {
     const { id } = await params;
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-    const authResult = await resolveMerchant(supabase, request);
-    if ('error' in authResult) {
-      return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'invoice.write',
+      `*, businesses (id, name, merchant_id)`,
+    );
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
-    const { merchantId } = authResult;
-
-    const { data: invoice, error: fetchError } = await supabase
-      .from('invoices')
-      .select(`*, businesses (id, name, merchant_id)`)
-      .eq('id', id)
-      .eq('user_id', merchantId)
-      .single();
-
-    if (fetchError || !invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
-    }
+    const { invoice } = access;
 
     // Only meaningful once the invoice is live for payment.
     if (!['sent', 'overdue'].includes(invoice.status)) {

--- a/src/app/api/invoices/[id]/enable-paypal/route.ts
+++ b/src/app/api/invoices/[id]/enable-paypal/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { resolveMerchant } from '@/lib/auth/merchant';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
 import { businessHasPaypal } from '@/lib/paypal/accounts';
 
 /**
@@ -16,22 +16,17 @@ export async function POST(
   try {
     const { id } = await params;
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-    const authResult = await resolveMerchant(supabase, request);
-    if ('error' in authResult) {
-      return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'invoice.write',
+      '*, businesses (id, name, merchant_id)',
+    );
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
-    const { merchantId } = authResult;
-
-    const { data: invoice, error: fetchError } = await supabase
-      .from('invoices')
-      .select('*, businesses (id, name, merchant_id)')
-      .eq('id', id)
-      .eq('user_id', merchantId)
-      .single();
-
-    if (fetchError || !invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
-    }
+    const { invoice } = access;
 
     if (!['sent', 'overdue'].includes(invoice.status)) {
       return NextResponse.json(

--- a/src/app/api/invoices/[id]/mark-paid/route.ts
+++ b/src/app/api/invoices/[id]/mark-paid/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { resolveMerchant } from '@/lib/auth/merchant';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
 import { sendPaymentWebhook } from '@/lib/webhooks/service';
 
 /**
@@ -20,25 +20,20 @@ export async function POST(
   try {
     const { id } = await params;
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-    const authResult = await resolveMerchant(supabase, request);
-    if ('error' in authResult) {
-      return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
-    }
-    const { merchantId } = authResult;
-
     const body = await request.json().catch(() => ({}));
     const method = typeof body.method === 'string' ? body.method : 'manual';
 
-    const { data: invoice, error: fetchError } = await supabase
-      .from('invoices')
-      .select('*, businesses (id, name, merchant_id)')
-      .eq('id', id)
-      .eq('user_id', merchantId)
-      .single();
-
-    if (fetchError || !invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'invoice.write',
+      '*, businesses (id, name, merchant_id)',
+    );
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
+    const { merchantId, invoice } = access;
     if (invoice.status === 'paid') {
       return NextResponse.json({ success: true, alreadyPaid: true, invoice });
     }

--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -1,20 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { verifyToken } from '@/lib/auth/jwt';
-import { getJwtSecret } from '@/lib/secrets';
-
-function getAuth(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  const token = authHeader.substring(7);
-  const jwtSecret = getJwtSecret();
-  if (!jwtSecret) return null;
-  try {
-    return verifyToken(token, jwtSecret);
-  } catch {
-    return null;
-  }
-}
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
 
 /**
  * GET /api/invoices/[id]
@@ -25,27 +11,25 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const decoded = getAuth(request);
-    if (!decoded) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-    const { data: invoice, error } = await supabase
-      .from('invoices')
-      .select(`
+
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'business.read',
+      `
         *,
         clients (id, name, email, company_name, phone, address),
         businesses (id, name, description),
         invoice_schedules (*)
-      `)
-      .eq('id', id)
-      .eq('user_id', decoded.userId)
-      .single();
-
-    if (error || !invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+      `,
+    );
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
 
-    return NextResponse.json({ success: true, invoice });
+    return NextResponse.json({ success: true, invoice: access.invoice });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
@@ -60,23 +44,14 @@ export async function PUT(
 ) {
   try {
     const { id } = await params;
-    const decoded = getAuth(request);
-    if (!decoded) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
     const body = await request.json();
 
-    // Only allow updating certain fields based on status
-    const { data: existing } = await supabase
-      .from('invoices')
-      .select('status')
-      .eq('id', id)
-      .eq('user_id', decoded.userId)
-      .single();
-
-    if (!existing) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+    const access = await authorizeInvoice(supabase, request, id, 'invoice.write', 'id, status, business_id');
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
+    const existing = access.invoice as { status: string };
 
     const allowedFields: Record<string, unknown> = {};
     const editableFields = ['client_id', 'currency', 'amount', 'crypto_currency', 'due_date', 'notes', 'merchant_wallet_address', 'wallet_id'];
@@ -117,7 +92,6 @@ export async function PUT(
       .from('invoices')
       .update(allowedFields)
       .eq('id', id)
-      .eq('user_id', decoded.userId)
       .select(`*, clients (id, name, email, company_name), businesses (id, name)`)
       .single();
 
@@ -140,22 +114,13 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const decoded = getAuth(request);
-    if (!decoded) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
 
-    // Only allow deleting draft invoices
-    const { data: invoice } = await supabase
-      .from('invoices')
-      .select('status')
-      .eq('id', id)
-      .eq('user_id', decoded.userId)
-      .single();
-
-    if (!invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+    const access = await authorizeInvoice(supabase, request, id, 'invoice.write', 'id, status, business_id');
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
+    const invoice = access.invoice as { status: string };
 
     if (invoice.status !== 'draft') {
       return NextResponse.json({ success: false, error: 'Only draft invoices can be deleted' }, { status: 400 });
@@ -164,8 +129,7 @@ export async function DELETE(
     const { error } = await supabase
       .from('invoices')
       .delete()
-      .eq('id', id)
-      .eq('user_id', decoded.userId);
+      .eq('id', id);
 
     if (error) {
       return NextResponse.json({ success: false, error: 'Failed to delete invoice' }, { status: 500 });

--- a/src/app/api/invoices/[id]/send/route.test.ts
+++ b/src/app/api/invoices/[id]/send/route.test.ts
@@ -72,6 +72,17 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
+// Invoice access is authorized by business role via authorizeInvoice, which
+// resolves the caller and gates on the invoice's business. Stub the underlying
+// resolve/authorize so the route's real invoice fetch (via the supabase mock)
+// still runs.
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: vi.fn().mockResolvedValue({ merchantId: 'merch-1', apiKeyBusinessId: null }),
+}));
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: vi.fn().mockResolvedValue({ ok: true, role: 'owner' }),
+}));
+
 import { POST } from './route';
 import { createPayment } from '@/lib/payments/service';
 
@@ -123,9 +134,7 @@ describe('POST /api/invoices/[id]/send', () => {
         return {
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
-              }),
+              single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
             }),
           }),
           update: vi.fn().mockReturnValue({

--- a/src/app/api/invoices/[id]/send/route.ts
+++ b/src/app/api/invoices/[id]/send/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { resolveMerchant } from '@/lib/auth/merchant';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
 import { createPayment, type Blockchain } from '@/lib/payments/service';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { sendEmail } from '@/lib/email';
@@ -23,27 +23,23 @@ export async function POST(
   try {
     const { id } = await params;
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-    const authResult = await resolveMerchant(supabase, request);
-    if ('error' in authResult) {
-      return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status });
-    }
-    const { merchantId } = authResult;
-
-    // Get the invoice with client and business info
-    const { data: invoice, error: fetchError } = await supabase
-      .from('invoices')
-      .select(`
+    // Authorize by the invoice's business (team members included), then load it
+    // with client + business info.
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'invoice.write',
+      `
         *,
         clients (id, name, email, company_name),
         businesses (id, name, merchant_id)
-      `)
-      .eq('id', id)
-      .eq('user_id', merchantId)
-      .single();
-
-    if (fetchError || !invoice) {
-      return NextResponse.json({ success: false, error: 'Invoice not found' }, { status: 404 });
+      `,
+    );
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
     }
+    const { invoice } = access;
 
     if (invoice.status !== 'draft' && invoice.status !== 'overdue') {
       return NextResponse.json({ success: false, error: `Cannot send invoice with status: ${invoice.status}` }, { status: 400 });

--- a/src/lib/auth/invoice-access.ts
+++ b/src/lib/auth/invoice-access.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+import { resolveMerchant } from './merchant';
+import { authorizeBusiness } from './authz';
+import type { Capability } from './permissions';
+
+/**
+ * Resolve the caller and authorize them for a single invoice by the invoice's
+ * OWNING BUSINESS — not by `invoices.user_id`.
+ *
+ * Invoices are created with `user_id = business.merchant_id` (the business
+ * owner), so the legacy `.eq('user_id', callerId)` gate 404s every invoice a
+ * team member owns/created/manages, even though they hold a role on the
+ * business. This mirrors the business-scoped authz used by `GET/POST
+ * /api/invoices` (see listAccessibleBusinessIds / authorizeBusiness) so the
+ * whole `/api/invoices/[id]/*` family agrees on who may act.
+ *
+ * On success returns the fetched invoice plus the resolved caller. On failure
+ * returns a ready-to-send status/error (404 is used both when the invoice does
+ * not exist and when the caller cannot see its business, so existence is not
+ * leaked).
+ */
+export type InvoiceAccessOk = {
+  ok: true;
+  merchantId: string;
+  apiKeyBusinessId: string | null;
+  invoice: any;
+};
+export type InvoiceAccessErr = { ok: false; status: number; error: string };
+
+export async function authorizeInvoice(
+  supabase: SupabaseClient,
+  request: NextRequest,
+  invoiceId: string,
+  capability: Capability,
+  select = '*',
+): Promise<InvoiceAccessOk | InvoiceAccessErr> {
+  const auth = await resolveMerchant(supabase, request);
+  if ('error' in auth) return { ok: false, status: auth.status, error: auth.error };
+  const { merchantId, apiKeyBusinessId } = auth;
+
+  const { data: invoice, error } = await supabase
+    .from('invoices')
+    .select(select)
+    .eq('id', invoiceId)
+    .single();
+
+  if (error || !invoice || !(invoice as any).business_id) {
+    return { ok: false, status: 404, error: 'Invoice not found' };
+  }
+  const businessId = (invoice as any).business_id as string;
+
+  if (apiKeyBusinessId) {
+    // API keys are locked to their own business.
+    if (businessId !== apiKeyBusinessId) {
+      return { ok: false, status: 404, error: 'Invoice not found' };
+    }
+  } else {
+    const authz = await authorizeBusiness(supabase, merchantId, businessId, capability);
+    if (!authz.ok) {
+      // 404 when the caller has no access at all (don't reveal the invoice exists);
+      // 403 when they can see the business but lack the capability.
+      return { ok: false, status: authz.status, error: authz.status === 404 ? 'Invoice not found' : authz.error };
+    }
+  }
+
+  return { ok: true, merchantId, apiKeyBusinessId, invoice };
+}


### PR DESCRIPTION
## Problem
A **team member** (not the business owner) could not work with invoices:

- **Create → immediate "Invoice not found".** `POST /api/invoices` sets `user_id` to the business **owner** (so owner-scoped views still see team-created invoices). But every `GET/PUT/DELETE /api/invoices/[id]` and the sub-routes (`mark-paid`, `send`, `enable-card`, `enable-paypal`) gated on `.eq('user_id', caller)`. Owner ≠ team member → the invoice 404s the instant you open it after creating it. Drafts were likewise unviewable.
- **"Card payments are off for this business."** The invoice-create modal reads `GET /api/businesses/[id]/payment-methods`, which called owner-only `listWallets(…, merchantId)`. For a team member that returned `success:false` → the route 400'd → the UI set **both** `cardsEnabled=false` **and** an empty wallet list, even though a wallet **and** Stripe Connect were configured.

## Fix
- New `authorizeInvoice()` helper (`src/lib/auth/invoice-access.ts`): resolves the caller (JWT or API key) and authorizes against the invoice's **owning business** via `authorizeBusiness` (owner ∪ business-member ∪ org-member) — the same model as `GET/POST /api/invoices`. API-key callers stay locked to their own business. Reads use `business.read`, mutations use `invoice.write`.
- Applied to `GET/PUT/DELETE /api/invoices/[id]`, `mark-paid`, `send`, `enable-card`, `enable-paypal`.
- Rewrote `GET /api/businesses/[id]/payment-methods` to authorize by business role and read `business_wallets` directly instead of owner-scoped `listWallets`. The Stripe/`stripe_accounts` check was already business-scoped and is unchanged.

## Tests
- Updated the 3 affected route tests to the new authz path; added a team-member (`writer` role) case to payment-methods. Full changed-area suite green; `tsc --noEmit` clean.
- Note: 11 failures elsewhere (`payments/[id]/forward`, `swap`, `wallets/*`) are **pre-existing** on `master`, unrelated to this change (verified by stashing).

Continuation of the team-authz read-path work (see PR #163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)