### PR TITLE
fix(webhooks): validate limit/offset pagination params before passing to query

### DIFF
--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -86,11 +86,28 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Parse and validate pagination params
+    const parsedLimit = limit ? parseInt(limit, 10) : undefined;
+    const parsedOffset = offset ? parseInt(offset, 10) : undefined;
+
+    if (parsedLimit !== undefined && (isNaN(parsedLimit) || parsedLimit < 1)) {
+      return NextResponse.json(
+        { success: false, error: 'limit must be a positive integer' },
+        { status: 400 }
+      );
+    }
+    if (parsedOffset !== undefined && (isNaN(parsedOffset) || parsedOffset < 0)) {
+      return NextResponse.json(
+        { success: false, error: 'offset must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+
     // Get webhook logs
     const result = await getWebhookLogs(supabase, businessId, {
       payment_id: paymentId || undefined,
-      limit: limit ? parseInt(limit) : undefined,
-      offset: offset ? parseInt(offset) : undefined,
+      limit: parsedLimit,
+      offset: parsedOffset,
     });
 
     if (!result.success) {


### PR DESCRIPTION
## Bug

`GET /api/webhooks` accepts `limit` and `offset` as query string parameters and passes them through `parseInt()` before forwarding to `getWebhookLogs`:

```ts
limit: limit ? parseInt(limit) : undefined,
offset: offset ? parseInt(offset) : undefined,
```

When a caller passes a non-numeric value (e.g. `?limit=abc`), `parseInt("abc")` returns `NaN`. The truthy guard (`limit ?`) does not catch this because a non-empty string is truthy regardless of whether it parses to a valid number. `NaN` is then forwarded to `getWebhookLogs`, which passes it to the Supabase query builder — Supabase silently ignores or misinterprets `NaN` limits, returning unpredictable result sets and potentially triggering a 500 error.

The same pattern exists for `offset`.

## Fix

- Add explicit radix `10` to both `parseInt` calls (best practice)
- After parsing, check `isNaN()` and validate bounds
- Return `400` with a descriptive message for invalid values

```ts
const parsedLimit = limit ? parseInt(limit, 10) : undefined;
const parsedOffset = offset ? parseInt(offset, 10) : undefined;

if (parsedLimit !== undefined && (isNaN(parsedLimit) || parsedLimit < 1)) {
  return NextResponse.json({ success: false, error: 'limit must be a positive integer' }, { status: 400 });
}
if (parsedOffset !== undefined && (isNaN(parsedOffset) || parsedOffset < 0)) {
  return NextResponse.json({ success: false, error: 'offset must be a non-negative integer' }, { status: 400 });
}
```

## Reproduction

```sh
curl -H 'Authorization: Bearer <token>' \
  '/api/webhooks?business_id=<id>&limit=abc'
```

Before this fix: unpredictable result or 500.  
After this fix: `400 { success: false, error: "limit must be a positive integer" }`