### PR TITLE
fix(api): normalize pagination params

### DIFF
--- a/src/app/api/business-collection/route.ts
+++ b/src/app/api/business-collection/route.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/entitlements/middleware';
 import { incrementTransactionCount } from '@/lib/entitlements/service';
 import { getJwtSecret } from '@/lib/secrets';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 /**
  * POST /api/business-collection
@@ -177,8 +178,8 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const businessId = searchParams.get('business_id') || undefined;
     const status = searchParams.get('status') || undefined;
-    const limit = parseInt(searchParams.get('limit') || '50', 10);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const limit = parsePaginationParam(searchParams.get('limit'), 50, { min: 1 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     // Create Supabase client
     const supabase = await createServerClient();

--- a/src/app/api/lightning/offers/route.ts
+++ b/src/app/api/lightning/offers/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { getLightningService } from '@/lib/lightning/lightning-service';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 
 /**
@@ -24,8 +25,8 @@ export async function GET(request: NextRequest) {
     const node_id = searchParams.get('node_id') || undefined;
     const wallet_id = searchParams.get('wallet_id') || undefined;
     const status = searchParams.get('status') || undefined;
-    const limit = parseInt(searchParams.get('limit') || '20', 10);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const limit = parsePaginationParam(searchParams.get('limit'), 20, { min: 1 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     const service = getLightningService();
 

--- a/src/app/api/lightning/payments/route.ts
+++ b/src/app/api/lightning/payments/route.ts
@@ -5,6 +5,7 @@ import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { getLightningService } from '@/lib/lightning/lightning-service';
 import { listPayments as listLnbitsPayments, payInvoice } from '@/lib/lightning/lnbits';
 import { authorizeWalletRequest } from '../wallet-auth';
+import { parsePaginationParam } from '@/lib/api/pagination';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -117,8 +118,8 @@ export async function GET(request: NextRequest) {
       ? directionParam
       : undefined;
     const status = searchParams.get('status') || undefined;
-    const limit = parseInt(searchParams.get('limit') || '50', 10);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const limit = parsePaginationParam(searchParams.get('limit'), 50, { min: 1 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     if (!wallet_id) {
       return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { listAccessibleBusinessIds } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
+import { parsePaginationParam } from '@/lib/api/pagination';
 // Re-export POST from create sub-route so POST /api/payments works
 export { POST } from './create/route';
 
@@ -67,8 +68,8 @@ export async function GET(request: NextRequest) {
     // return a total; without it the endpoint keeps its old "return all" behavior.
     const limitParam = searchParams.get('limit');
     const paginate = limitParam !== null;
-    const limit = Math.min(Math.max(parseInt(limitParam || '50', 10) || 50, 1), 100);
-    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10) || 0, 0);
+    const limit = parsePaginationParam(limitParam, 50, { min: 1, max: 100 });
+    const offset = parsePaginationParam(searchParams.get('offset'), 0);
 
     // All businesses this user can access — owned plus those granted via org or
     // per-business team membership. Owner-only scoping here hid data from invited


### PR DESCRIPTION
## Summary

- normalize pagination query params with the existing parsePaginationParam helper
- apply stricter parsing to business collection, payments, and Lightning list endpoints
- preserve existing defaults and the current payments max limit behavior

Closes #183

## Tests

- `node node_modules/vitest/vitest.mjs run src/lib/api/pagination.test.ts src/app/api/lightning/lightning-routes.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/eslint/bin/eslint.js src/app/api/business-collection/route.ts src/app/api/lightning/offers/route.ts src/app/api/lightning/payments/route.ts src/app/api/payments/route.ts` (0 errors; 3 pre-existing warnings)
- `git diff --check origin/master...HEAD`