### PR TITLE
Allow AI bots access to /api/ and add JSON API endpoint

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,16 @@ Disallow: /admin/
 Disallow: /dashboard/
 
 Sitemap: https://coinpayportal.com/sitemap.xml
+
+# Allow AI bots to access /api/ endpoints
+User-agent: GPTBot
+Allow: /api/
+
+User-agent: ClaudeBot
+Allow: /api/
+
+User-agent: PerplexityBot
+Allow: /api/
+
+User-agent: CCBot
+Allow: /api/

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  return NextResponse.json({
+    name: 'CoinPayPortal API',
+    version: '1.0',
+    documentation: 'https://coinpayportal.com/docs',
+    endpoints: {
+      health: '/api/health',
+      payments: '/api/payments',
+      invoices: '/api/invoices',
+      webhooks: '/api/webhooks',
+      x402: '/api/x402',
+    },
+    timestamp: new Date().toISOString(),
+  }, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+export async function HEAD(request: NextRequest) {
+  return new NextResponse(null, { status: 200 });
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Allow': 'GET, HEAD, OPTIONS',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+    },
+  });
+}


### PR DESCRIPTION
This PR addresses bugs reported by QA:

1. **robots.txt blocks AI crawlers** – Added explicit allowances for GPTBot, ClaudeBot, PerplexityBot, and CCBot to access /api/ endpoints.
2. **No /api JSON endpoint** – Added route.ts that returns a JSON representation of the API root, including available endpoints and documentation link.

These changes improve AI crawler compliance and provide a machine-readable entry point for API clients.

Related to ugig.net gig #14eb1fad (QA report).