### PR TITLE
fix(auth): restrict post-login redirects

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -4,11 +4,14 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { startAuthentication } from '@simplewebauthn/browser';
+import { getSafeLoginRedirect } from '@/lib/auth/login-redirect';
 
 export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirect') || searchParams.get('redirectTo');
+  const redirectTo = getSafeLoginRedirect(
+    searchParams.get('redirect') || searchParams.get('redirectTo')
+  );
   const [formData, setFormData] = useState({
     email: '',
     password: '',

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -189,6 +189,34 @@ describe('LoginPage', () => {
       });
     });
 
+    it('should ignore external redirect parameters after login', async () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('redirect=https://example.com/phishing')
+      );
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          token: 'mock-jwt-token',
+          merchant: { id: 'merchant-123', is_admin: false },
+        }),
+      } as Response);
+
+      render(<LoginPage />);
+      fireEvent.change(screen.getByLabelText(/email address/i), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText(/password/i), {
+        target: { value: 'SecurePassword123!' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+      await waitFor(() => {
+        expect(locationHrefSpy).toHaveBeenCalledWith('/dashboard');
+      });
+      expect(locationHrefSpy).not.toHaveBeenCalledWith('https://example.com/phishing');
+    });
+
     it('should show loading state during login', async () => {
       vi.mocked(fetch).mockImplementationOnce(
         () =>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,11 +3,14 @@
 import { useState, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { getSafeLoginRedirect } from '@/lib/auth/login-redirect';
 
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirect') || searchParams.get('redirectTo');
+  const redirectTo = getSafeLoginRedirect(
+    searchParams.get('redirect') || searchParams.get('redirectTo')
+  );
   const [formData, setFormData] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);

--- a/src/lib/auth/login-redirect.test.ts
+++ b/src/lib/auth/login-redirect.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getSafeLoginRedirect } from './login-redirect';
+
+describe('getSafeLoginRedirect', () => {
+  it('keeps internal application paths', () => {
+    expect(getSafeLoginRedirect('/invoices?tab=sent#latest')).toBe(
+      '/invoices?tab=sent#latest'
+    );
+  });
+
+  it.each([
+    'https://example.com/phishing',
+    '//example.com/phishing',
+    '/\\example.com/phishing',
+    'javascript:alert(1)',
+    'dashboard',
+  ])('rejects external or ambiguous redirect %s', (value) => {
+    expect(getSafeLoginRedirect(value)).toBeNull();
+  });
+});

--- a/src/lib/auth/login-redirect.ts
+++ b/src/lib/auth/login-redirect.ts
@@ -1,0 +1,23 @@
+const LOGIN_ORIGIN = 'https://coinpayportal.invalid';
+
+export function getSafeLoginRedirect(value: string | null): string | null {
+  const candidate = value?.trim();
+  if (
+    !candidate ||
+    !candidate.startsWith('/') ||
+    candidate.startsWith('//') ||
+    candidate.includes('\\')
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(candidate, LOGIN_ORIGIN);
+    if (parsed.origin !== LOGIN_ORIGIN) {
+      return null;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- allow post-login redirects only to normalized internal application paths
- reject absolute URLs, protocol-relative URLs, backslash variants, and non-path values
- apply the same validation to password and passkey login flows
- add helper and login-page regression coverage

## Bug
The `redirect` and `redirectTo` query parameters were assigned directly to `window.location.href` or passed to the router after authentication. A crafted login URL could therefore send a user to an external site immediately after a successful login.

## Tests
- pre-commit related tests: 25/25 passed
- focused helper + login tests: 25/25 passed
- full suite: 3,402 passed, 12 skipped; one unrelated suite could not resolve dependencies absent from the reused local install
- changed-file ESLint: 0 errors
- `git diff --check`: passed

## Notes
The local dependency policy blocks installing today's `@profullstack/stack@0.1.3`; the full-suite/typecheck limitation is due to that stale local installation, not errors in these files. No invoice will be sent until the PR is merged and accepted.