### PR TITLE
fix(db): resolve Supabase security linter findings (RLS + SECURITY DEFINER)

### DIFF
--- a/supabase/migrations/20260722000000_rls_business_api_keys.sql
+++ b/supabase/migrations/20260722000000_rls_business_api_keys.sql
@@ -1,0 +1,26 @@
+-- Fix Supabase linter finding: rls_disabled_in_public
+--   Table `public.business_api_keys` is public (exposed to PostgREST) but RLS
+--   was never enabled, so any anon/authenticated caller could read every
+--   business's scoped API-key rows (hashes, prefixes, scopes).
+--   https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public
+--
+-- The table is written/read server-side with the service role. We enable RLS
+-- and add:
+--   * service_role  -> full access (unchanged effective server behaviour)
+--   * merchants     -> SELECT only their own business's keys (dashboard listing).
+--     Raw keys are never stored (only HMAC hashes), so SELECT stays safe.
+-- No anon access.
+
+ALTER TABLE business_api_keys ENABLE ROW LEVEL SECURITY;
+
+-- Merchants can list the keys belonging to businesses they own.
+DROP POLICY IF EXISTS "merchants_select_own_business_api_keys" ON business_api_keys;
+CREATE POLICY "merchants_select_own_business_api_keys" ON business_api_keys
+  FOR SELECT TO authenticated
+  USING (business_id IN (SELECT id FROM businesses WHERE merchant_id = auth.uid()));
+
+-- Service role performs all mint/revoke/last_used bookkeeping.
+DROP POLICY IF EXISTS "service_role_all_business_api_keys" ON business_api_keys;
+CREATE POLICY "service_role_all_business_api_keys" ON business_api_keys
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);

--- a/supabase/migrations/20260722010000_revoke_exec_create_default_org_trigger_fn.sql
+++ b/supabase/migrations/20260722010000_revoke_exec_create_default_org_trigger_fn.sql
@@ -1,0 +1,21 @@
+-- Fix Supabase linter findings:
+--   anon_security_definer_function_executable          (lint 0028)
+--   authenticated_security_definer_function_executable (lint 0029)
+--
+-- public.create_default_org_for_merchant() is a TRIGGER function fired by
+-- `merchant_create_default_org` AFTER INSERT ON merchants. It is SECURITY
+-- DEFINER because it must write across organizations / organization_members /
+-- merchants regardless of the inserting caller's RLS.
+--
+-- PostgREST still exposes it as an RPC (/rest/v1/rpc/create_default_org_for_merchant),
+-- so anon/authenticated could invoke this privileged function directly. It is
+-- never meant to be called by clients — only by the trigger.
+--
+-- Revoking EXECUTE does NOT disable the trigger: triggers execute the function
+-- as the table owner, independent of the RPC EXECUTE grant. SECURITY DEFINER is
+-- kept intentionally.
+--   https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable
+
+REVOKE EXECUTE ON FUNCTION public.create_default_org_for_merchant() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.create_default_org_for_merchant() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.create_default_org_for_merchant() FROM authenticated;


### PR DESCRIPTION
## What

Two migrations fixing Supabase database-linter security findings:

1. **`20260722000000_rls_business_api_keys.sql`** — `rls_disabled_in_public` (ERROR)
   - Enables RLS on `public.business_api_keys` (stores hashed scoped API keys).
   - `service_role` → full access (server-side mint/revoke/last_used, unchanged).
   - `authenticated` merchants → SELECT only their own business's keys. Raw keys are never stored (HMAC hashes only), so SELECT is safe. No anon access.

2. **`20260722010000_revoke_exec_create_default_org_trigger_fn.sql`** — `anon`/`authenticated_security_definer_function_executable` (WARN, lints 0028/0029)
   - Revokes EXECUTE on the `create_default_org_for_merchant()` **trigger** function from `PUBLIC`/`anon`/`authenticated` so it can't be invoked directly via `/rest/v1/rpc/...`.
   - Trigger (`AFTER INSERT ON merchants`) still fires — triggers run as the table owner, independent of the RPC EXECUTE grant. `SECURITY DEFINER` kept intentionally (needs to write across `organizations`/`organization_members`/`merchants`).

## Apply

Not yet applied to prod — run `supabase db push` (or Supabase MCP `apply_migration`) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)