### PR TITLE
feat(extension): bulk payments behind a single approval

### DIFF
--- a/docs/BULK_PAYMENTS.md
+++ b/docs/BULK_PAYMENTS.md
@@ -1,0 +1,154 @@
+# Bulk payments (`window.coinpay.payBatch`)
+
+Pay many recipients from one wallet approval. Built for payables runs — e.g.
+ugig.net's "Accepted" invoice queue, where paying 62 invoices one at a time is
+about an hour of clicking.
+
+## The shape of it
+
+```
+web page                content script        background worker        CoinPay API
+────────                ──────────────        ────────────────        ───────────
+window.coinpay
+  .payBatch(payments) ──► relay ────────────► validate + origin check
+                                              open approval window
+                                                   │
+                                            user approves ONCE
+                                                   │
+                                              for each payment:
+                                                prepare ──────────────► POST prepare-tx
+                                                sign (local, in worker)
+                                                broadcast ────────────► POST broadcast
+                                                   │
+                        ◄── progress events ◄──────┤
+  results ◄──────────────────────────────────◄─────┘
+```
+
+Keys never leave the background worker. The server assembles unsigned
+transactions (nonce, UTXOs, blockhash, fees) and relays signed blobs to the
+network — the same split the CoinPay web wallet already uses.
+
+## Page API
+
+```js
+if (!window.coinpay) return; // extension not installed
+
+await window.coinpay.connect(); // idempotent; prompts once per origin
+
+const { results } = await window.coinpay.payBatch(
+  [
+    { id: 'invoice-1', chain: 'usdc_pol', to: '0xabc…', amount: '25.00',
+      label: 'Ada Lovelace — Fix login bug', amountUsd: 25 },
+    { id: 'invoice-2', chain: 'btc', to: '1BvBM…', amount: '0.00041', amountUsd: 25 },
+  ],
+  { onProgress: (p) => console.log(p.id, p.stage, `${p.completed}/${p.total}`) },
+);
+
+for (const r of results) {
+  // r.status: 'sent' | 'failed' | 'skipped'
+  // r.txHash, r.explorerUrl when sent; r.error otherwise
+}
+```
+
+`chain` accepts CoinPay currency codes (`usdc_pol`, `btc`) or chain names
+(`USDC_POL`). Supported: BTC, BCH, ETH, POL, SOL, USDC/USDT on ETH/POL/SOL.
+Anything else is rejected up front rather than guessed — guessing a chain sends
+real funds to the wrong network.
+
+## Partial success is the contract
+
+There is no atomic 62-way transfer; each payment is its own transaction. So
+`payBatch` **resolves even when some payments fail** and reports per-item
+status. It rejects only if the user declines or the batch never starts.
+
+Callers must reconcile from `results`, not from the promise resolving.
+
+## Ordering and why it is slow-ish
+
+Transactions on the same account go one at a time, because the server derives
+chain state per `prepare-tx`:
+
+| chain | state | hazard if parallel |
+|---|---|---|
+| EVM | `eth_getTransactionCount(from,'pending')` | two txs get the same nonce; the second *replaces* the first |
+| BTC/BCH | full UTXO set spent, one change output | the next tx builds from already-spent inputs |
+| SOL | recent blockhash | expires quickly |
+
+So payments are grouped into per-account queues. Queues run concurrently (a
+Solana payment never waits on a Polygon one), but within a queue it is strictly
+prepare → sign → broadcast → settle delay → next. Delays are 1.5s (EVM), 1s
+(SOL), 8s (UTXO — a change output must reach the indexer).
+
+Those delays are heuristics, so transient chain-state errors (`nonce too low`,
+`missingorspent`, `blockhash not found`) are retried with backoff. Terminal
+errors — insufficient funds, bad address — fail immediately rather than burning
+time or risking a duplicate.
+
+**Rough wall-clock:** ~4s per payment on one EVM/SOL account, ~10s on BTC. 62
+same-chain payments ≈ 4 minutes; spread across chains it is faster.
+
+### Payment-request expiry
+
+CoinPay quotes crypto amounts at the market rate and the quote holds ~15
+minutes. A large single-chain BTC batch can approach that window. Mitigations:
+
+- Split very large BTC/BCH runs into batches.
+- Prefer USDC/SOL rails for payables — faster settle delays, stable amounts.
+- The integrating app should re-check `expires_at` and re-quote anything stale.
+
+## Security model
+
+- **Origin is stamped by the browser** (`sender.origin`), never taken from the
+  page. A page cannot claim to be a different site.
+- **Connecting ≠ spending.** A connection grants read access to public
+  addresses and the right to *ask*. Every batch opens its own approval window.
+- **The approval window shows every recipient**, per-chain totals, and the grand
+  total. Nothing is hidden behind "and 59 more".
+- **Approval requires unlocking**; the seed stays in the background worker and
+  per-chain keys are zeroed right after each signature.
+- **Closing the approval window cancels the remainder.** Already-broadcast
+  payments cannot be recalled, and their results still return.
+- Duplicate `id`s in one batch are rejected — for a payables run that ambiguity
+  is how someone gets paid twice.
+- Batch size is capped at 500.
+
+## Adding a new site
+
+The extension only injects into origins listed in the manifest. To support
+another domain, add it to **all three** lists in
+`manifest/manifest.{chrome,firefox}.json`:
+
+```jsonc
+"host_permissions": ["https://example.com/*"],   // API + progress relay
+"content_scripts": [{ "matches": ["https://example.com/*"] }],
+"web_accessible_resources": [{ "matches": ["https://example.com/*"] }]
+```
+
+`src/__tests__/packaging.test.ts` enforces that the three agree — if the bridge
+can run somewhere it cannot fetch the provider, `window.coinpay` silently never
+appears.
+
+## Portal registration
+
+On the first batch the extension registers with the portal via
+`POST /api/web-wallet/import`: public keys, addresses, and a signature proving
+key ownership. **The seed is never uploaded.** The returned `wallet_id` is
+cached in `storage.local` and cleared on re-import.
+
+Every payable chain gets its own `wallet_addresses` row — including token chains
+— because `prepare-tx` verifies `from_address` against the exact chain, so
+`USDC_POL` needs a row even though it reuses the EVM address.
+
+Subsequent calls authenticate per request by signing
+`METHOD:path:timestamp:body` with the ETH-path secp256k1 key (compact ECDSA,
+SHA-256 prehash). `src/core/__tests__/api.test.ts` verifies this against a
+byte-for-byte copy of the server's verifier.
+
+## Key derivation parity
+
+The extension signs with keys derived in `src/core/private-keys.ts`, but its
+funds sit at addresses derived by the `@profullstack/coinpay` SDK (which does
+not export private keys). `src/core/__tests__/private-keys.test.ts` derives each
+key, recomputes its address independently, and asserts it equals the SDK's
+`deriveAddress()` — so a divergence fails the build instead of signing with a
+key that controls a different address.

--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "CoinPay Wallet",
-  "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments.",
-  "version": "0.0.2",
+  "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
+  "version": "0.1.0",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"
@@ -12,7 +12,32 @@
     "type": "module"
   },
   "permissions": ["storage", "alarms"],
-  "host_permissions": ["https://coinpayportal.com/*"],
+  "host_permissions": [
+    "https://coinpayportal.com/*",
+    "https://ugig.net/*",
+    "https://www.ugig.net/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://coinpayportal.com/*",
+        "https://ugig.net/*",
+        "https://www.ugig.net/*"
+      ],
+      "js": ["content/bridge.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["inpage/provider.js"],
+      "matches": [
+        "https://coinpayportal.com/*",
+        "https://ugig.net/*",
+        "https://www.ugig.net/*"
+      ]
+    }
+  ],
   "icons": {
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "CoinPay Wallet",
-  "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments.",
-  "version": "0.0.2",
+  "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
+  "version": "0.1.0",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"
@@ -12,7 +12,32 @@
     "type": "module"
   },
   "permissions": ["storage", "alarms"],
-  "host_permissions": ["https://coinpayportal.com/*"],
+  "host_permissions": [
+    "https://coinpayportal.com/*",
+    "https://ugig.net/*",
+    "https://www.ugig.net/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://coinpayportal.com/*",
+        "https://ugig.net/*",
+        "https://www.ugig.net/*"
+      ],
+      "js": ["content/bridge.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["inpage/provider.js"],
+      "matches": [
+        "https://coinpayportal.com/*",
+        "https://ugig.net/*",
+        "https://www.ugig.net/*"
+      ]
+    }
+  ],
   "browser_specific_settings": {
     "gecko": {
       "id": "coinpay@profullstack.com",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension. See docs/BROWSER_EXTENSION_PRD.md.",
+  "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",
   "scripts": {
     "build": "vite build",
     "build:firefox": "TARGET=firefox vite build",
@@ -17,10 +17,12 @@
     "@scure/bip39": "^1.4.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "@scure/bip32": "^1.5.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.300",
+    "jsdom": "^23.2.0",
     "typescript": "^5.6.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.0"

--- a/packages/extension/src/__tests__/packaging.test.ts
+++ b/packages/extension/src/__tests__/packaging.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Packaging invariants that a type-checker cannot catch but a browser will.
+ *
+ * These fail loudly at test time instead of as a silent "extension didn't load"
+ * after install.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+function read(path: string): string {
+  return readFileSync(resolve(pkgRoot, path), 'utf8');
+}
+
+function manifest(target: 'chrome' | 'firefox'): any {
+  return JSON.parse(read(`manifest/manifest.${target}.json`));
+}
+
+describe('content script', () => {
+  it('has no imports — MV3 loads it as a classic script, not a module', () => {
+    const source = read('src/content/bridge.ts');
+    // A static import would bundle into a chunk that a classic script can't
+    // load, and the provider would silently never be injected.
+    expect(source).not.toMatch(/^\s*import\s/m);
+  });
+});
+
+describe.each(['chrome', 'firefox'] as const)('%s manifest', (target) => {
+  const m = manifest(target);
+
+  it('declares the content script and its injected provider together', () => {
+    const contentScript = m.content_scripts?.[0];
+    expect(contentScript?.js).toContain('content/bridge.js');
+    // document_start so `window.coinpay` exists before page scripts run.
+    expect(contentScript.run_at).toBe('document_start');
+
+    const war = m.web_accessible_resources?.[0];
+    expect(war?.resources).toContain('inpage/provider.js');
+  });
+
+  it('can inject into every site it can reach, and no further', () => {
+    const contentMatches: string[] = m.content_scripts[0].matches;
+    const warMatches: string[] = m.web_accessible_resources[0].matches;
+    // If a page can run the bridge but not fetch the provider, `window.coinpay`
+    // never appears — these two lists must agree.
+    expect([...warMatches].sort()).toEqual([...contentMatches].sort());
+
+    // Host permissions must cover every injected origin, or `chrome.tabs
+    // .sendMessage` progress relay is dropped for that tab.
+    for (const match of contentMatches) {
+      expect(m.host_permissions).toContain(match);
+    }
+  });
+
+  it('can reach the CoinPay API for prepare-tx and broadcast', () => {
+    expect(m.host_permissions).toContain('https://coinpayportal.com/*');
+  });
+
+  it('requests only the permissions the wallet actually uses', () => {
+    expect(new Set(m.permissions)).toEqual(new Set(['storage', 'alarms']));
+  });
+
+  it('ships the approval page the payment flow opens', () => {
+    expect(() => read('src/approval/index.html')).not.toThrow();
+  });
+});
+
+describe('manifest parity', () => {
+  it('keeps chrome and firefox on the same version', () => {
+    expect(manifest('chrome').version).toBe(manifest('firefox').version);
+  });
+});

--- a/packages/extension/src/approval/app.ts
+++ b/packages/extension/src/approval/app.ts
@@ -1,0 +1,288 @@
+/**
+ * Approval window — the single point where the user authorizes a batch.
+ *
+ * The whole premise of bulk paying is one confirmation instead of 62, so this
+ * screen has to carry the weight that 62 individual confirmations used to:
+ * it shows the requesting origin, per-chain totals, the grand total, and every
+ * single recipient in a scrollable list. Nothing is hidden behind "and 59
+ * more" — the list is exactly what will be signed.
+ *
+ * After approval the same window becomes the progress view, because a batch
+ * takes minutes and closing it cancels the remainder.
+ */
+
+import { el, mount, button, note } from '../popup/dom.js';
+import { call } from '../popup/rpc.js';
+import type { PendingApproval } from '../messages.js';
+import type { BatchProgress } from '../core/batch.js';
+
+const params = new URLSearchParams(window.location.search);
+const requestId = params.get('requestId') ?? '';
+
+/** Live per-payment state, keyed by payment id, for in-place row updates. */
+const rows = new Map<string, HTMLElement>();
+const stages = new Map<string, BatchProgress>();
+let approval: PendingApproval | null = null;
+
+export async function start(): Promise<void> {
+  if (!requestId) return renderMessage('Nothing to approve', 'This window was opened without a request.');
+
+  try {
+    const res = await call({ type: 'approval:get', requestId });
+    if (!('approval' in res)) throw new Error('Request not found');
+    approval = res.approval;
+    render();
+  } catch (err) {
+    renderMessage('Request unavailable', err instanceof Error ? err.message : String(err));
+  }
+}
+
+function render(): void {
+  if (!approval) return;
+  if (approval.kind === 'connect') return renderConnect(approval);
+  return renderBatch(approval);
+}
+
+// ── Connect ──────────────────────────────────────────────────────────────────
+
+function renderConnect(request: Extract<PendingApproval, { kind: 'connect' }>): void {
+  const password = passwordField(request.needsUnlock);
+  const status = note('Connecting lets this site see your wallet addresses and request payments. Every payment still needs your approval.');
+
+  mount(
+    el('h1', { class: 'title', text: 'Connect wallet' }),
+    el('span', { class: 'origin', text: request.origin }),
+    status,
+    ...(password ? [password.row] : []),
+    el('div', { class: 'row' }, [
+      button('Reject', () => void decide(false), 'btn'),
+      button(
+        'Connect',
+        () => void decide(true, password?.input.value, status),
+        'btn primary',
+      ),
+    ]),
+  );
+}
+
+// ── Batch payment ────────────────────────────────────────────────────────────
+
+function renderBatch(request: Extract<PendingApproval, { kind: 'payBatch' }>): void {
+  const password = passwordField(request.needsUnlock);
+  const status = el('p', { class: 'muted' });
+
+  const grandUsd = request.summary.reduce((sum, s) => sum + s.totalUsd, 0);
+  const totals = el('div', { class: 'totals' }, [
+    ...request.summary.map((s) =>
+      el('div', { class: 'total-row' }, [
+        el('span', { class: 'chain', text: `${s.chain} · ${s.count} payment${s.count === 1 ? '' : 's'}` }),
+        el('span', { text: s.total }),
+      ]),
+    ),
+    ...(grandUsd > 0
+      ? [
+          el('div', { class: 'total-row grand' }, [
+            el('span', { text: `${request.payments.length} payments` }),
+            el('span', { text: `≈ $${grandUsd.toFixed(2)}` }),
+          ]),
+        ]
+      : []),
+  ]);
+
+  mount(
+    el('h1', { class: 'title', text: 'Confirm bulk payment' }),
+    el('span', { class: 'origin', text: request.origin }),
+    el('p', {
+      class: 'warn',
+      text: `This sends ${request.payments.length} separate transactions. They cannot be reversed.`,
+    }),
+    totals,
+    buildList(request),
+    ...(password ? [password.row] : []),
+    status,
+    el('div', { class: 'row' }, [
+      button('Reject', () => void decide(false), 'btn'),
+      button(
+        `Approve all (${request.payments.length})`,
+        () => void decide(true, password?.input.value, status),
+        'btn primary',
+      ),
+    ]),
+  );
+}
+
+function buildList(request: Extract<PendingApproval, { kind: 'payBatch' }>): HTMLElement {
+  rows.clear();
+  const items = request.payments.map((payment) => {
+    const stage = el('span', { class: 'stage', text: '' });
+    const row = el('div', { class: 'item' }, [
+      el('div', { class: 'who' }, [
+        el('span', { class: 'label', text: payment.label || payment.id }),
+        el('span', { class: 'addr', text: shortenAddress(payment.to) }),
+      ]),
+      el('div', { class: 'amt' }, [
+        el('span', { text: `${payment.amount} ${payment.chain}` }),
+        stage,
+      ]),
+    ]);
+    rows.set(payment.id, row);
+    return row;
+  });
+  return el('div', { class: 'list' }, items);
+}
+
+function shortenAddress(address: string): string {
+  return address.length <= 20 ? address : `${address.slice(0, 10)}…${address.slice(-8)}`;
+}
+
+// ── Decision ─────────────────────────────────────────────────────────────────
+
+async function decide(approve: boolean, password?: string, status?: HTMLElement): Promise<void> {
+  if (!approve) {
+    await call({ type: 'approval:reject', requestId }).catch(() => {});
+    window.close();
+    return;
+  }
+
+  try {
+    await call({ type: 'approval:approve', requestId, password });
+  } catch (err) {
+    // Almost always a wrong password — keep the window open so they can retry.
+    if (status) {
+      status.textContent = err instanceof Error ? err.message : String(err);
+      status.className = 'err';
+    }
+    return;
+  }
+
+  if (approval?.kind === 'payBatch') renderProgress(approval);
+  else window.close();
+}
+
+// ── Progress ─────────────────────────────────────────────────────────────────
+
+function renderProgress(request: Extract<PendingApproval, { kind: 'payBatch' }>): void {
+  const total = request.payments.length;
+  const bar = el('div', {}, []);
+  const counter = el('p', { class: 'muted', text: `Sending 0 of ${total}…` });
+  const list = buildList(request);
+  // Reflect anything that arrived between approval and this render.
+  for (const progress of stages.values()) applyProgress(progress);
+
+  // The same button is "stop" while the run is live and "close" once it ends,
+  // so its action has to follow that switch.
+  let finished = false;
+  const cancel = button(
+    'Stop after current payment',
+    () => {
+      if (finished) return window.close();
+      void call({ type: 'approval:cancel', requestId }).catch(() => {});
+      cancel.disabled = true;
+      cancel.textContent = 'Stopping…';
+    },
+    'btn danger',
+  );
+
+  mount(
+    el('h1', { class: 'title', text: 'Sending payments' }),
+    el('span', { class: 'origin', text: request.origin }),
+    el('p', { class: 'muted small', text: 'Keep this window open until it finishes. Closing it cancels the payments that have not been sent yet.' }),
+    el('div', { class: 'progress-bar' }, [bar]),
+    counter,
+    list,
+    el('div', { class: 'row' }, [cancel]),
+  );
+
+  const update = (progress: BatchProgress): void => {
+    applyProgress(progress);
+    const pct = Math.round((progress.completed / progress.total) * 100);
+    bar.setAttribute('style', `width:${pct}%`);
+    counter.textContent =
+      progress.completed >= progress.total
+        ? summarize()
+        : `Sending ${progress.completed + 1} of ${progress.total}…`;
+    if (progress.completed >= progress.total) {
+      finished = true;
+      cancel.textContent = 'Close';
+      cancel.disabled = false;
+      cancel.className = 'btn primary';
+    }
+  };
+
+  for (const progress of stages.values()) update(progress);
+  progressHandlers.add(update);
+}
+
+function summarize(): string {
+  let sent = 0;
+  let failed = 0;
+  for (const progress of stages.values()) {
+    if (progress.stage === 'sent') sent++;
+    else if (progress.stage === 'failed' || progress.stage === 'skipped') failed++;
+  }
+  return failed === 0
+    ? `All ${sent} payments sent.`
+    : `${sent} sent, ${failed} not sent — see the list below.`;
+}
+
+function applyProgress(progress: BatchProgress): void {
+  const row = rows.get(progress.id);
+  if (!row) return;
+  const stage = row.querySelector('.stage');
+  if (stage) stage.textContent = stageLabel(progress);
+  row.className = `item ${progress.stage === 'sent' ? 'sent' : ''}${
+    progress.stage === 'failed' || progress.stage === 'skipped' ? 'failed' : ''
+  }`.trim();
+}
+
+function stageLabel(progress: BatchProgress): string {
+  switch (progress.stage) {
+    case 'queued':
+      return 'waiting';
+    case 'preparing':
+      return 'preparing…';
+    case 'signing':
+      return 'signing…';
+    case 'broadcasting':
+      return 'broadcasting…';
+    case 'sent':
+      return progress.txHash ? `sent · ${progress.txHash.slice(0, 10)}…` : 'sent';
+    case 'skipped':
+      return 'cancelled';
+    case 'failed':
+      return progress.error ? `failed · ${progress.error.slice(0, 40)}` : 'failed';
+  }
+}
+
+const progressHandlers = new Set<(progress: BatchProgress) => void>();
+
+chrome.runtime.onMessage.addListener((message: any) => {
+  if (message?.type === 'coinpay:progress' && message.requestId === requestId) {
+    stages.set(message.progress.id, message.progress);
+    for (const handler of progressHandlers) handler(message.progress);
+  }
+  // The background finished and tore the request down; nothing left to show.
+  if (message?.type === 'coinpay:approvalResolved' && message.requestId === requestId) {
+    progressHandlers.clear();
+  }
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function passwordField(needed: boolean): { row: HTMLElement; input: HTMLInputElement } | null {
+  if (!needed) return null;
+  const input = el('input', { class: 'input', type: 'password', autocomplete: 'current-password' });
+  const row = el('label', { class: 'field' }, [
+    el('span', { class: 'label-text', text: 'Wallet password' }),
+    input,
+  ]);
+  return { row, input };
+}
+
+function renderMessage(title: string, message: string): void {
+  mount(
+    el('h1', { class: 'title', text: title }),
+    note(message),
+    el('div', { class: 'row' }, [button('Close', () => window.close(), 'btn')]),
+  );
+}

--- a/packages/extension/src/approval/index.html
+++ b/packages/extension/src/approval/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CoinPay — Confirm</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #1a1a1a;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --brand: #7c3aed;
+        --brand-fg: #ffffff;
+        --warn-bg: #fef3c7;
+        --warn-fg: #92400e;
+        --err: #dc2626;
+        --ok: #059669;
+        --chip: #f3f4f6;
+        font-family: system-ui, -apple-system, sans-serif;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #17171b; --fg: #f3f4f6; --muted: #9ca3af; --border: #2b2b31;
+          --chip: #23232a; --warn-bg: #3a2e0b; --warn-fg: #fcd34d; --ok: #34d399;
+        }
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; padding: 16px; background: var(--bg); color: var(--fg);
+        display: flex; flex-direction: column; min-height: 100vh;
+      }
+      #app { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+      .title { font-size: 17px; margin: 0 0 4px; }
+      .origin {
+        display: inline-block; font-family: ui-monospace, monospace; font-size: 12px;
+        background: var(--chip); border: 1px solid var(--border); border-radius: 6px;
+        padding: 3px 7px; margin-bottom: 10px; word-break: break-all;
+      }
+      .muted { color: var(--muted); font-size: 12px; }
+      .small { font-size: 11px; }
+      .err { color: var(--err); font-size: 12px; }
+      .warn { background: var(--warn-bg); color: var(--warn-fg); padding: 8px 10px; border-radius: 8px; font-size: 12px; }
+      .totals { border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; margin: 10px 0; }
+      .total-row { display: flex; justify-content: space-between; align-items: baseline; font-size: 13px; padding: 3px 0; }
+      .total-row .chain { font-weight: 600; }
+      .grand { border-top: 1px solid var(--border); margin-top: 6px; padding-top: 8px; font-size: 15px; font-weight: 700; }
+      /* The payment list is the part that scrolls; header and buttons stay put
+         so "Approve" is always reachable even with 62 rows. */
+      .list { flex: 1; min-height: 80px; overflow-y: auto; border: 1px solid var(--border); border-radius: 10px; }
+      .item { display: flex; justify-content: space-between; gap: 8px; padding: 7px 10px; border-bottom: 1px solid var(--border); font-size: 12px; }
+      .item:last-child { border-bottom: none; }
+      .item .who { min-width: 0; }
+      .item .label { display: block; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .item .addr { display: block; color: var(--muted); font-family: ui-monospace, monospace; font-size: 10px; }
+      .item .amt { text-align: right; white-space: nowrap; }
+      .item .stage { display: block; font-size: 10px; color: var(--muted); }
+      .item.sent .stage { color: var(--ok); }
+      .item.failed .stage { color: var(--err); }
+      .field { display: block; margin-top: 10px; }
+      .label-text { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+      .input { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg); color: var(--fg); font-size: 13px; }
+      .row { display: flex; gap: 8px; margin-top: 12px; }
+      .row .btn { flex: 1; }
+      .btn { appearance: none; border: 1px solid var(--border); background: var(--chip); color: var(--fg); padding: 10px 12px; border-radius: 8px; font-size: 13px; cursor: pointer; font-weight: 500; }
+      .btn:hover:not(:disabled) { border-color: var(--brand); }
+      .btn:disabled { opacity: 0.55; cursor: default; }
+      .btn.primary { background: var(--brand); color: var(--brand-fg); border-color: var(--brand); }
+      .btn.danger { color: var(--err); }
+      .progress-bar { height: 6px; background: var(--chip); border-radius: 999px; overflow: hidden; margin: 8px 0; }
+      .progress-bar > div { height: 100%; background: var(--brand); width: 0%; transition: width 0.2s; }
+      .accounts { display: flex; flex-direction: column; gap: 6px; margin: 10px 0; }
+      .account { border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; }
+      .account .chain { font-weight: 600; font-size: 12px; }
+      .account .addr { display: block; margin-top: 2px; color: var(--muted); font-size: 10px; font-family: ui-monospace, monospace; word-break: break-all; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><p class="muted">Loading…</p></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/packages/extension/src/approval/main.ts
+++ b/packages/extension/src/approval/main.ts
@@ -1,0 +1,3 @@
+import { start } from './app.js';
+
+void start();

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -1,11 +1,22 @@
 /**
  * Background service worker (MV3) — the only context that holds seed material.
  *
- * Responsibilities in this Phase-1 slice:
+ * Responsibilities:
  *   - Wire `WalletService` to `browser.storage.local` (encrypted vault) and
  *     `browser.storage.session` (unlocked seed).
  *   - Route popup requests (create / import / unlock / lock / getState).
  *   - Idle auto-lock via `alarms` (PRD P0-3, default 15 min).
+ *   - Serve connected web pages: connect, read addresses, and run batch
+ *     payments — each gated behind an explicit approval window.
+ *
+ * Security posture for page-originated (`site:`) requests:
+ *   - The origin comes from `sender`, never from the message body, so a page
+ *     cannot claim to be a different site.
+ *   - Connecting grants read access to public addresses only.
+ *   - EVERY payment batch opens its own approval window showing the full list
+ *     and totals. A connected page can ask; only the user can authorize.
+ *   - Approving requires the wallet to be unlocked (password prompt inline),
+ *     and the seed never leaves this worker.
  *
  * `chrome.*` is used directly here; it exists in Chromium and Firefox MV3 for
  * the storage/alarms/runtime APIs used below. A `webextension-polyfill` layer
@@ -14,15 +25,27 @@
 
 import { WalletService } from '../core/wallet.js';
 import { WebExtStorage, type WebExtStorageArea } from '../core/storage.js';
-import type { WalletRequest, WalletResponse } from '../messages.js';
+import { ConnectionStore, normalizeOrigin } from '../core/connections.js';
+import { CoinPayApi, compressedPublicKey } from '../core/api.js';
+import { derivePrivateKey, derivationPath } from '../core/private-keys.js';
+import { runBatchPayments, summarizeBatch, parseBatchRequests } from '../core/batch.js';
+import { PAY_CHAINS, signingChain } from '../core/pay-chains.js';
+import type { NativeChain } from '../core/chains.js';
+import type { WalletRequest, WalletResponse, PendingApproval, WalletEvent } from '../messages.js';
 
 const AUTO_LOCK_ALARM = 'coinpay-auto-lock';
 const DEFAULT_IDLE_MINUTES = 15;
+const LOCAL_PORTAL_WALLET_ID = 'portalWalletId';
+const SESSION_APPROVALS = 'pendingApprovals';
+/** A batch of 62 payments takes minutes; cap the whole run, not each payment. */
+const MAX_BATCH_SIZE = 500;
 
 // chrome.storage promise API — cast to our minimal area interface.
 const local = new WebExtStorage(chrome.storage.local as unknown as WebExtStorageArea);
 const session = new WebExtStorage(chrome.storage.session as unknown as WebExtStorageArea);
 const wallet = new WalletService(local, session);
+const connections = new ConnectionStore(local);
+const api = new CoinPayApi();
 
 function scheduleAutoLock(minutes = DEFAULT_IDLE_MINUTES): void {
   chrome.alarms.create(AUTO_LOCK_ALARM, { delayInMinutes: minutes });
@@ -32,11 +55,296 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === AUTO_LOCK_ALARM) void wallet.lock();
 });
 
-async function handle(req: WalletRequest): Promise<WalletResponse> {
+// ── Pending approvals ────────────────────────────────────────────────────────
+
+/**
+ * Resolvers live in memory (functions aren't serializable) while the request
+ * DETAILS are mirrored into session storage, so the approval window can still
+ * render itself if the service worker is recycled while it is open. If the
+ * worker dies the resolver is lost and the page's promise rejects — the user
+ * sees an error and can retry, which is the safe direction to fail.
+ */
+interface ApprovalEntry {
+  approval: PendingApproval;
+  windowId?: number;
+  resolve: (approved: boolean) => void;
+  settled: boolean;
+  abort: AbortController;
+}
+
+const pending = new Map<string, ApprovalEntry>();
+
+async function persistApprovals(): Promise<void> {
+  const snapshot: Record<string, PendingApproval> = {};
+  for (const [id, entry] of pending) snapshot[id] = entry.approval;
+  await session.set(SESSION_APPROVALS, snapshot);
+}
+
+async function readApproval(requestId: string): Promise<PendingApproval | undefined> {
+  const inMemory = pending.get(requestId);
+  if (inMemory) return inMemory.approval;
+  const snapshot = await session.get<Record<string, PendingApproval>>(SESSION_APPROVALS);
+  return snapshot?.[requestId];
+}
+
+function newRequestId(): string {
+  return crypto.randomUUID();
+}
+
+function broadcast(event: WalletEvent): void {
+  // Extension pages (the approval window) listen on runtime messages. There may
+  // be no listener yet — swallow the resulting rejection.
+  chrome.runtime.sendMessage(event).catch(() => {});
+}
+
+/**
+ * Open the approval window and resolve once the user decides. Closing the
+ * window without deciding counts as a rejection — silence is never consent.
+ */
+async function requestApproval(approval: PendingApproval): Promise<boolean> {
+  const entry: ApprovalEntry = {
+    approval,
+    resolve: () => {},
+    settled: false,
+    abort: new AbortController(),
+  };
+
+  const decision = new Promise<boolean>((resolve) => {
+    entry.resolve = resolve;
+  });
+
+  pending.set(approval.requestId, entry);
+  await persistApprovals();
+
+  const url = chrome.runtime.getURL(`approval/index.html?requestId=${approval.requestId}`);
+  try {
+    const window = await chrome.windows.create({
+      url,
+      type: 'popup',
+      width: 460,
+      height: 680,
+      focused: true,
+    });
+    entry.windowId = window?.id;
+  } catch {
+    settleApproval(approval.requestId, false);
+  }
+
+  return decision;
+}
+
+function settleApproval(requestId: string, approved: boolean): void {
+  const entry = pending.get(requestId);
+  if (!entry || entry.settled) return;
+  entry.settled = true;
+  entry.resolve(approved);
+}
+
+/**
+ * Drop a finished request.
+ *
+ * `closeWindow` is false after a batch runs: the window has become the results
+ * view, and some payments may have failed. Yanking it away would hide the only
+ * per-payment error detail the wallet shows, so the user closes it themselves.
+ * A rejected or connect request has nothing left to display and is closed here.
+ */
+async function clearApproval(requestId: string, closeWindow = true): Promise<void> {
+  const entry = pending.get(requestId);
+  pending.delete(requestId);
+  await persistApprovals();
+  broadcast({ type: 'coinpay:approvalResolved', requestId });
+  if (closeWindow && entry?.windowId !== undefined) {
+    try {
+      await chrome.windows.remove(entry.windowId);
+    } catch {
+      // Already closed by the user.
+    }
+  }
+}
+
+chrome.windows.onRemoved.addListener((windowId) => {
+  for (const [requestId, entry] of pending) {
+    if (entry.windowId === windowId) {
+      // Closing the window mid-run cancels the remainder; already-sent payments
+      // cannot be recalled, and the results still come back to the page.
+      entry.abort.abort();
+      settleApproval(requestId, false);
+    }
+  }
+});
+
+// ── Portal registration ──────────────────────────────────────────────────────
+
+/**
+ * The portal's prepare-tx/broadcast endpoints work against a registered wallet.
+ * Registration is non-custodial — public keys, addresses, and a signature
+ * proving we hold the key. Done once, then cached.
+ *
+ * Every chain we might pay on is registered, including token chains: prepare-tx
+ * verifies `from_address` against the exact chain, so USDC_POL needs its own
+ * row even though it reuses the EVM address.
+ */
+async function ensurePortalWallet(seed: Uint8Array): Promise<string> {
+  const cached = await local.get<string>(LOCAL_PORTAL_WALLET_ID);
+  if (cached) return cached;
+
+  const accounts = await wallet.getAccounts();
+  const byChain = new Map<NativeChain, string>(accounts.map((a) => [a.chain, a.address]));
+
+  const addresses = PAY_CHAINS.flatMap((chain) => {
+    const signer = signingChain(chain);
+    const address = byChain.get(signer);
+    if (!address) return [];
+    return [{ chain, address, derivation_path: derivationPath(signer, 0) }];
+  });
+
+  const authKey = derivePrivateKey(seed, 'ETH', 0);
+  const solAddress = byChain.get('SOL');
+  try {
+    const { wallet_id } = await api.registerWallet({
+      publicKeySecp256k1: compressedPublicKey(authKey),
+      publicKeyEd25519: solAddress, // Solana addresses ARE base58 ed25519 pubkeys
+      addresses,
+      privateKey: authKey,
+    });
+    await local.set(LOCAL_PORTAL_WALLET_ID, wallet_id);
+    return wallet_id;
+  } finally {
+    authKey.fill(0);
+  }
+}
+
+// ── Site request handling ────────────────────────────────────────────────────
+
+/** Origin of the page that sent a message — from the browser, not the page. */
+function senderOrigin(sender: chrome.runtime.MessageSender): string | null {
+  return normalizeOrigin(sender.origin ?? sender.url ?? null);
+}
+
+async function handleSitePayBatch(
+  origin: string,
+  rawPayments: unknown,
+  sender: chrome.runtime.MessageSender,
+): Promise<WalletResponse> {
+  if (!(await connections.isConnected(origin))) {
+    return { ok: false, error: 'Site is not connected to this wallet' };
+  }
+  if (!(await wallet.isInitialized())) {
+    return { ok: false, error: 'No wallet has been set up yet' };
+  }
+
+  const payments = parseBatchRequests(rawPayments, MAX_BATCH_SIZE);
+  const requestId = newRequestId();
+  const approval: PendingApproval = {
+    kind: 'payBatch',
+    requestId,
+    origin,
+    needsUnlock: !(await wallet.isUnlocked()),
+    payments,
+    summary: summarizeBatch(payments),
+  };
+
+  const approved = await requestApproval(approval);
+  if (!approved) {
+    await clearApproval(requestId);
+    return { ok: false, error: 'Payment request rejected' };
+  }
+
+  const entry = pending.get(requestId);
+  try {
+    // Approving requires unlocking, so by here the seed is available.
+    const seed = await wallet.requireSeed();
+    const walletId = await ensurePortalWallet(seed);
+    const accounts = await wallet.getAccounts();
+    const addresses: Partial<Record<NativeChain, string>> = {};
+    for (const account of accounts) addresses[account.chain] = account.address;
+
+    const authKey = derivePrivateKey(seed, 'ETH', 0);
+    try {
+      const results = await runBatchPayments(payments, {
+        api,
+        walletId,
+        seed,
+        authKey,
+        addresses,
+        signal: entry?.abort.signal,
+        onProgress: (progress) => {
+          // Keep the wallet awake for the duration of a long run.
+          scheduleAutoLock();
+          const event: WalletEvent = { type: 'coinpay:progress', requestId, origin, progress };
+          broadcast(event);
+          if (sender.tab?.id !== undefined) {
+            chrome.tabs.sendMessage(sender.tab.id, event).catch(() => {});
+          }
+        },
+      });
+      await connections.touch(origin);
+      return { ok: true, results };
+    } finally {
+      authKey.fill(0);
+    }
+  } finally {
+    // Leave the window up as the results view; the user dismisses it.
+    await clearApproval(requestId, false);
+    scheduleAutoLock();
+  }
+}
+
+async function handleSiteConnect(origin: string): Promise<WalletResponse> {
+  if (await connections.isConnected(origin)) {
+    await connections.touch(origin);
+    return { ok: true, accounts: await wallet.getAccounts() };
+  }
+  if (!(await wallet.isInitialized())) {
+    return { ok: false, error: 'No wallet has been set up yet' };
+  }
+
+  const requestId = newRequestId();
+  const approved = await requestApproval({
+    kind: 'connect',
+    requestId,
+    origin,
+    needsUnlock: !(await wallet.isUnlocked()),
+  });
+  await clearApproval(requestId);
+
+  if (!approved) return { ok: false, error: 'Connection rejected' };
+  await connections.connect(origin);
+  return { ok: true, accounts: await wallet.getAccounts() };
+}
+
+// ── Approval-window handling ─────────────────────────────────────────────────
+
+async function handleApprovalApprove(
+  requestId: string,
+  password?: string,
+): Promise<WalletResponse> {
+  const approval = await readApproval(requestId);
+  if (!approval) return { ok: false, error: 'This request is no longer pending' };
+
+  if (!(await wallet.isUnlocked())) {
+    if (!password) return { ok: false, error: 'Password required' };
+    await wallet.unlock(password); // throws on a wrong password
+    scheduleAutoLock();
+  }
+
+  settleApproval(requestId, true);
+  return { ok: true };
+}
+
+// ── Router ───────────────────────────────────────────────────────────────────
+
+async function handle(
+  req: WalletRequest,
+  sender: chrome.runtime.MessageSender,
+): Promise<WalletResponse> {
   try {
     switch (req.type) {
       case 'getState':
-        return { ok: true, state: { initialized: await wallet.isInitialized(), unlocked: await wallet.isUnlocked() } };
+        return {
+          ok: true,
+          state: { initialized: await wallet.isInitialized(), unlocked: await wallet.isUnlocked() },
+        };
       case 'beginCreate': {
         const { mnemonic, accounts } = await wallet.beginCreate(req.words ?? 12);
         return { ok: true, mnemonic, accounts };
@@ -48,9 +356,14 @@ async function handle(req: WalletRequest): Promise<WalletResponse> {
       }
       case 'cancelCreate':
         await wallet.cancelCreate();
-        return { ok: true, state: { initialized: await wallet.isInitialized(), unlocked: await wallet.isUnlocked() } };
+        return {
+          ok: true,
+          state: { initialized: await wallet.isInitialized(), unlocked: await wallet.isUnlocked() },
+        };
       case 'import': {
         const accounts = await wallet.import(req.mnemonic, req.password);
+        // A different seed means a different portal wallet; drop the cached id.
+        await local.remove(LOCAL_PORTAL_WALLET_ID);
         scheduleAutoLock();
         return { ok: true, accounts };
       }
@@ -64,6 +377,58 @@ async function handle(req: WalletRequest): Promise<WalletResponse> {
         return { ok: true, state: { initialized: await wallet.isInitialized(), unlocked: false } };
       case 'getAccounts':
         return { ok: true, accounts: await wallet.getAccounts() };
+      case 'listConnections':
+        return { ok: true, connections: await connections.list() };
+      case 'disconnectSite':
+        await connections.disconnect(req.origin);
+        return { ok: true, connections: await connections.list() };
+
+      // ── page-originated ──
+      case 'site:getState': {
+        const origin = senderOrigin(sender);
+        return {
+          ok: true,
+          siteState: {
+            initialized: await wallet.isInitialized(),
+            unlocked: await wallet.isUnlocked(),
+            connected: await connections.isConnected(origin),
+          },
+        };
+      }
+      case 'site:connect': {
+        const origin = senderOrigin(sender);
+        if (!origin) return { ok: false, error: 'Unknown origin' };
+        return handleSiteConnect(origin);
+      }
+      case 'site:getAccounts': {
+        const origin = senderOrigin(sender);
+        if (!(await connections.isConnected(origin))) {
+          return { ok: false, error: 'Site is not connected to this wallet' };
+        }
+        return { ok: true, accounts: await wallet.getAccounts() };
+      }
+      case 'site:payBatch': {
+        const origin = senderOrigin(sender);
+        if (!origin) return { ok: false, error: 'Unknown origin' };
+        return handleSitePayBatch(origin, req.payments, sender);
+      }
+
+      // ── approval window ──
+      case 'approval:get': {
+        const approval = await readApproval(req.requestId);
+        if (!approval) return { ok: false, error: 'This request is no longer pending' };
+        return { ok: true, approval };
+      }
+      case 'approval:approve':
+        return handleApprovalApprove(req.requestId, req.password);
+      case 'approval:reject':
+        settleApproval(req.requestId, false);
+        return { ok: true };
+      case 'approval:cancel': {
+        // Stop after the payment currently in flight; sent ones stay sent.
+        pending.get(req.requestId)?.abort.abort();
+        return { ok: true };
+      }
       default:
         return { ok: false, error: 'Unknown request' };
     }
@@ -72,7 +437,10 @@ async function handle(req: WalletRequest): Promise<WalletResponse> {
   }
 }
 
-chrome.runtime.onMessage.addListener((req: WalletRequest, _sender, sendResponse) => {
-  handle(req).then(sendResponse);
+chrome.runtime.onMessage.addListener((req: WalletRequest, sender, sendResponse) => {
+  // Events we broadcast to extension pages come back through this listener too;
+  // ignore anything that isn't a request.
+  if (!req || typeof req.type !== 'string' || req.type.startsWith('coinpay:')) return;
+  handle(req, sender).then(sendResponse);
   return true; // keep the message channel open for the async response
 });

--- a/packages/extension/src/content/__tests__/bridge.test.ts
+++ b/packages/extension/src/content/__tests__/bridge.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The content script is the ONLY path between a web page and the wallet, so its
+ * job is to be a dumb, tightly-scoped pipe. These tests pin down the two things
+ * that make it safe:
+ *
+ *   1. It forwards only `site:` messages — a page must not be able to invoke
+ *      popup or approval requests (e.g. `approval:approve`) by postMessage.
+ *   2. It adds no origin claim of its own; the background reads the true origin
+ *      from `sender`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const CHANNEL_REQUEST = 'coinpay:page-request';
+const CHANNEL_RESPONSE = 'coinpay:page-response';
+const CHANNEL_EVENT = 'coinpay:page-event';
+
+const sendMessage = vi.fn();
+const onMessageListeners: ((message: unknown) => void)[] = [];
+
+/** Load bridge.ts fresh against the current jsdom window + chrome stub. */
+async function loadBridge(): Promise<void> {
+  vi.resetModules();
+  onMessageListeners.length = 0;
+  sendMessage.mockReset();
+  sendMessage.mockResolvedValue({ ok: true, results: [] });
+
+  vi.stubGlobal('chrome', {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://test-id/${path}`,
+      sendMessage,
+      onMessage: {
+        addListener: (listener: (message: unknown) => void) => onMessageListeners.push(listener),
+      },
+    },
+  });
+
+  await import('../bridge.js');
+}
+
+/** Post a page message and let the bridge's async relay settle. */
+async function postFromPage(data: unknown): Promise<void> {
+  window.dispatchEvent(new MessageEvent('message', { data, source: window }));
+  await vi.waitFor(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function capturePosts(): unknown[] {
+  const posted: unknown[] = [];
+  vi.spyOn(window, 'postMessage').mockImplementation((message: unknown) => {
+    posted.push(message);
+  });
+  return posted;
+}
+
+beforeEach(async () => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+  await loadBridge();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('provider injection', () => {
+  it('injects the in-page provider as a module at document_start', () => {
+    const script = document.querySelector('script');
+    expect(script?.getAttribute('src')).toBe('chrome-extension://test-id/inpage/provider.js');
+    expect(script?.getAttribute('type')).toBe('module');
+  });
+});
+
+describe('page → background relay', () => {
+  it('forwards a site: request and returns the unwrapped payload', async () => {
+    const posted = capturePosts();
+    sendMessage.mockResolvedValue({ ok: true, results: [{ id: 'inv-1', status: 'sent' }] });
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r1',
+      payload: { type: 'site:payBatch', payments: [] },
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'site:payBatch', payments: [] });
+    expect(posted).toContainEqual({
+      channel: CHANNEL_RESPONSE,
+      requestId: 'r1',
+      result: { results: [{ id: 'inv-1', status: 'sent' }] }, // `ok` envelope stripped
+      error: undefined,
+    });
+  });
+
+  it.each([
+    'approval:approve',
+    'approval:reject',
+    'unlock',
+    'getAccounts',
+    'import',
+    'beginCreate',
+  ])('refuses to relay a non-site request: %s', async (type) => {
+    // A page reaching `approval:approve` could self-authorize its own batch.
+    await postFromPage({ channel: CHANNEL_REQUEST, requestId: 'r1', payload: { type } });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from another window (e.g. an iframe or opener)', async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: CHANNEL_REQUEST, requestId: 'r1', payload: { type: 'site:getState' } },
+        source: null, // not this window
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages on other channels and malformed payloads', async () => {
+    await postFromPage({ channel: 'something-else', requestId: 'r1', payload: { type: 'site:x' } });
+    await postFromPage({ channel: CHANNEL_REQUEST, requestId: 'r1' });
+    await postFromPage({ channel: CHANNEL_REQUEST, requestId: 42, payload: { type: 'site:x' } });
+    await postFromPage({ channel: CHANNEL_REQUEST, requestId: 'r1', payload: { type: 42 } });
+    await postFromPage(null);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('adds nothing of its own to the forwarded message', async () => {
+    // Anything extra here would be a page-supplied claim the background might
+    // trust; the origin must come from `sender` alone.
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r1',
+      payload: { type: 'site:connect', origin: 'https://evil.example' },
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'site:connect',
+      origin: 'https://evil.example', // relayed verbatim — and ignored downstream
+    });
+  });
+
+  it('relays a rejection as an error, not a silent success', async () => {
+    const posted = capturePosts();
+    sendMessage.mockResolvedValue({ ok: false, error: 'Payment request rejected' });
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r1',
+      payload: { type: 'site:payBatch', payments: [] },
+    });
+
+    expect(posted).toContainEqual(
+      expect.objectContaining({ requestId: 'r1', error: 'Payment request rejected' }),
+    );
+  });
+
+  it('reports an unreachable background instead of hanging the page promise', async () => {
+    const posted = capturePosts();
+    sendMessage.mockRejectedValue(new Error('Extension context invalidated'));
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r1',
+      payload: { type: 'site:getState' },
+    });
+
+    expect(posted).toContainEqual(
+      expect.objectContaining({ requestId: 'r1', error: 'Extension context invalidated' }),
+    );
+  });
+
+  it('reports an empty response rather than resolving with undefined', async () => {
+    const posted = capturePosts();
+    sendMessage.mockResolvedValue(undefined);
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r1',
+      payload: { type: 'site:getState' },
+    });
+
+    expect(posted).toContainEqual(
+      expect.objectContaining({ error: 'No response from the CoinPay extension' }),
+    );
+  });
+});
+
+describe('background → page events', () => {
+  it('forwards progress events to the page', () => {
+    const posted = capturePosts();
+    const event = {
+      type: 'coinpay:progress',
+      requestId: 'r1',
+      progress: { id: 'inv-1', stage: 'sent', completed: 1, total: 2 },
+    };
+
+    for (const listener of onMessageListeners) listener(event);
+
+    expect(posted).toContainEqual({ channel: CHANNEL_EVENT, event });
+  });
+
+  it('does not forward unrelated runtime messages', () => {
+    const posted = capturePosts();
+
+    for (const listener of onMessageListeners) {
+      listener({ type: 'coinpay:approvalResolved', requestId: 'r1' });
+      listener({ type: 'somethingElse' });
+      listener(null);
+    }
+
+    expect(posted).toHaveLength(0);
+  });
+});

--- a/packages/extension/src/content/bridge.ts
+++ b/packages/extension/src/content/bridge.ts
@@ -1,0 +1,66 @@
+/**
+ * Content script — the only path between a web page and the wallet.
+ *
+ * It runs in an isolated world with access to `chrome.runtime`, and does two
+ * things:
+ *   1. Injects `inpage/provider.js` into the page so `window.coinpay` exists.
+ *   2. Relays page requests to the background worker and pushes progress events
+ *      back down.
+ *
+ * It is deliberately a dumb pipe: it makes no authorization decisions and adds
+ * no origin claims of its own. The background reads the true origin from
+ * `sender`, so a page cannot lie about who it is by talking to this script.
+ */
+
+const CHANNEL_REQUEST = 'coinpay:page-request';
+const CHANNEL_RESPONSE = 'coinpay:page-response';
+const CHANNEL_EVENT = 'coinpay:page-event';
+
+function injectProvider(): void {
+  const script = document.createElement('script');
+  script.src = chrome.runtime.getURL('inpage/provider.js');
+  script.type = 'module';
+  // Inject as early as possible so `window.coinpay` is there before app code.
+  (document.head || document.documentElement).prepend(script);
+  script.addEventListener('load', () => script.remove());
+}
+
+injectProvider();
+
+window.addEventListener('message', (event: MessageEvent) => {
+  if (event.source !== window) return;
+  const data = event.data as Record<string, any> | null;
+  if (!data || data.channel !== CHANNEL_REQUEST) return;
+
+  const { requestId, payload } = data;
+  if (typeof requestId !== 'string' || !payload || typeof payload.type !== 'string') return;
+  // Only the page-facing surface is reachable from here; popup and approval
+  // messages must never be invocable by a web page.
+  if (!payload.type.startsWith('site:')) return;
+
+  const reply = (result: unknown, error?: string): void => {
+    window.postMessage(
+      { channel: CHANNEL_RESPONSE, requestId, result, error },
+      window.location.origin,
+    );
+  };
+
+  chrome.runtime
+    .sendMessage(payload)
+    .then((response: any) => {
+      if (!response) return reply(undefined, 'No response from the CoinPay extension');
+      if (response.ok === false) return reply(undefined, response.error || 'Request failed');
+      // Strip the transport envelope; hand the page just the payload fields.
+      const { ok, ...rest } = response;
+      void ok;
+      reply(rest);
+    })
+    .catch((err: unknown) => {
+      reply(undefined, err instanceof Error ? err.message : 'Extension unavailable');
+    });
+});
+
+chrome.runtime.onMessage.addListener((message: any) => {
+  if (message?.type !== 'coinpay:progress') return;
+  window.postMessage({ channel: CHANNEL_EVENT, event: message }, window.location.origin);
+});

--- a/packages/extension/src/core/__tests__/api.test.ts
+++ b/packages/extension/src/core/__tests__/api.test.ts
@@ -1,0 +1,218 @@
+/**
+ * API client contract tests.
+ *
+ * The auth signature format is not documented anywhere the extension can
+ * import — it is whatever the portal's `verifySecp256k1Signature` accepts. This
+ * file pins it down by verifying exactly the way the server does, so a noble
+ * upgrade or a refactor that changes prehashing/encoding fails here instead of
+ * as a 401 in production.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import { CoinPayApi, CoinPayApiError, signAuthMessage, compressedPublicKey } from '../api.js';
+
+const PRIVATE_KEY = new Uint8Array(32).fill(7);
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/** Byte-for-byte what src/lib/web-wallet/auth.ts does to check a signature. */
+function serverVerify(signatureHex: string, message: string, publicKeyHex: string): boolean {
+  try {
+    return secp256k1.verify(
+      hexToBytes(signatureHex),
+      new TextEncoder().encode(message),
+      hexToBytes(publicKeyHex),
+    );
+  } catch {
+    return false;
+  }
+}
+
+describe('signAuthMessage', () => {
+  it('produces a signature the portal verifier accepts', () => {
+    const message = 'POST:/api/web-wallet/abc/prepare-tx:1700000000:{"amount":"1"}';
+    const signature = signAuthMessage(message, PRIVATE_KEY);
+
+    expect(serverVerify(signature, message, compressedPublicKey(PRIVATE_KEY))).toBe(true);
+  });
+
+  it('emits a 64-byte compact signature as hex', () => {
+    // The server hex-decodes with no length negotiation; DER (70-72 bytes)
+    // would be rejected.
+    expect(signAuthMessage('hello', PRIVATE_KEY)).toMatch(/^[0-9a-f]{128}$/);
+  });
+
+  it('does not verify against a different message', () => {
+    const signature = signAuthMessage('GET:/a:1:', PRIVATE_KEY);
+    expect(serverVerify(signature, 'GET:/b:1:', compressedPublicKey(PRIVATE_KEY))).toBe(false);
+  });
+
+  it('does not verify against a different key', () => {
+    const signature = signAuthMessage('GET:/a:1:', PRIVATE_KEY);
+    const otherKey = new Uint8Array(32).fill(9);
+    expect(serverVerify(signature, 'GET:/a:1:', compressedPublicKey(otherKey))).toBe(false);
+  });
+});
+
+describe('compressedPublicKey', () => {
+  it('is 33 bytes starting with 02 or 03, as the portal validates', () => {
+    const hex = compressedPublicKey(PRIVATE_KEY);
+    expect(hex).toMatch(/^0[23][0-9a-f]{64}$/);
+  });
+});
+
+describe('CoinPayApi', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function ok(data: unknown) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data, error: null }),
+    };
+  }
+
+  it('signs authenticated requests over the exact bytes it sends', async () => {
+    fetchMock.mockResolvedValue(ok({ tx_id: 't1' }));
+    const api = new CoinPayApi('https://coinpayportal.com/api');
+
+    await api.prepareTx('wallet-1', PRIVATE_KEY, {
+      from_address: '0xfrom',
+      to_address: '0xto',
+      chain: 'USDC_POL',
+      amount: '10',
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const auth: string = init.headers.Authorization;
+    const [walletId, signature, timestamp] = auth.replace('Wallet ', '').split(':');
+
+    expect(walletId).toBe('wallet-1');
+    // The server rebuilds the message from METHOD, its own path, the timestamp,
+    // and the raw body — reconstruct it the same way.
+    const message = `POST:/api/web-wallet/wallet-1/prepare-tx:${timestamp}:${init.body}`;
+    expect(serverVerify(signature!, message, compressedPublicKey(PRIVATE_KEY))).toBe(true);
+  });
+
+  it('sends a timestamp inside the portal 5-minute window', async () => {
+    fetchMock.mockResolvedValue(ok({}));
+    await new CoinPayApi().broadcast('w', PRIVATE_KEY, {
+      tx_id: 't',
+      signed_tx: '0x',
+      chain: 'ETH',
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const timestamp = Number(init.headers.Authorization.split(':')[2]);
+    expect(Math.abs(Math.floor(Date.now() / 1000) - timestamp)).toBeLessThan(5);
+  });
+
+  it('does not attach auth to wallet registration', async () => {
+    fetchMock.mockResolvedValue(ok({ wallet_id: 'w1' }));
+
+    await new CoinPayApi().registerWallet({
+      publicKeySecp256k1: compressedPublicKey(PRIVATE_KEY),
+      addresses: [],
+      privateKey: PRIVATE_KEY,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    // Registration is the bootstrap — there is no wallet id to authenticate as.
+    expect(url).toBe('https://coinpayportal.com/api/web-wallet/import');
+    expect(init.headers.Authorization).toBeUndefined();
+
+    const body = JSON.parse(init.body);
+    expect(
+      serverVerify(
+        body.proof_of_ownership.signature,
+        body.proof_of_ownership.message,
+        compressedPublicKey(PRIVATE_KEY),
+      ),
+    ).toBe(true);
+  });
+
+  it('unwraps the portal success envelope', async () => {
+    fetchMock.mockResolvedValue(ok({ tx_hash: '0xhash', status: 'pending' }));
+
+    const result = await new CoinPayApi().broadcast('w', PRIVATE_KEY, {
+      tx_id: 't',
+      signed_tx: '0x',
+      chain: 'ETH',
+    });
+
+    expect(result).toMatchObject({ tx_hash: '0xhash' });
+  });
+
+  it('surfaces the portal error code and message', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        success: false,
+        data: null,
+        error: { code: 'INSUFFICIENT_FUNDS', message: 'Insufficient funds: need 5000 sats' },
+      }),
+    });
+
+    await expect(
+      new CoinPayApi().prepareTx('w', PRIVATE_KEY, {
+        from_address: 'a',
+        to_address: 'b',
+        chain: 'BTC',
+        amount: '1',
+      }),
+    ).rejects.toMatchObject({
+      name: 'CoinPayApiError',
+      code: 'INSUFFICIENT_FUNDS',
+      status: 400,
+    });
+  });
+
+  it('reports a 200 body with success:false as an error', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, error: { code: 'NOPE', message: 'no' } }),
+    });
+
+    await expect(
+      new CoinPayApi().broadcast('w', PRIVATE_KEY, { tx_id: 't', signed_tx: '0x', chain: 'ETH' }),
+    ).rejects.toBeInstanceOf(CoinPayApiError);
+  });
+
+  it('wraps a network failure rather than leaking a raw TypeError', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(
+      new CoinPayApi().broadcast('w', PRIVATE_KEY, { tx_id: 't', signed_tx: '0x', chain: 'ETH' }),
+    ).rejects.toMatchObject({ code: 'NETWORK_ERROR' });
+  });
+
+  it('trims a trailing slash so signed paths stay canonical', async () => {
+    fetchMock.mockResolvedValue(ok({}));
+    await new CoinPayApi('https://coinpayportal.com/api/').broadcast('w', PRIVATE_KEY, {
+      tx_id: 't',
+      signed_tx: '0x',
+      chain: 'ETH',
+    });
+
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      'https://coinpayportal.com/api/web-wallet/w/broadcast',
+    );
+  });
+});

--- a/packages/extension/src/core/__tests__/batch-request.test.ts
+++ b/packages/extension/src/core/__tests__/batch-request.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `parseBatchRequests` guards the boundary between an untrusted web page and a
+ * wallet that spends real money. Every input here is attacker-controlled, so
+ * these tests are mostly about what must be REJECTED.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { parseBatchRequests } from '../batch.js';
+
+const MAX = 500;
+
+function payment(overrides: Record<string, unknown> = {}) {
+  return { id: 'inv-1', chain: 'usdc_pol', to: '0xabc', amount: '10', ...overrides };
+}
+
+describe('parseBatchRequests', () => {
+  it('normalizes a well-formed batch', () => {
+    const result = parseBatchRequests(
+      [payment({ label: 'Ada — Fix login', amountUsd: 10 })],
+      MAX,
+    );
+
+    expect(result).toEqual([
+      {
+        id: 'inv-1',
+        chain: 'USDC_POL', // wire code normalized to a chain the wallet signs
+        to: '0xabc',
+        amount: '10',
+        label: 'Ada — Fix login',
+        amountUsd: 10,
+      },
+    ]);
+  });
+
+  it('trims whitespace around addresses and amounts', () => {
+    const [result] = parseBatchRequests([payment({ to: '  0xabc  ', amount: ' 10 ' })], MAX);
+    expect(result).toMatchObject({ to: '0xabc', amount: '10' });
+  });
+
+  it('rejects duplicate ids', () => {
+    // The single most dangerous input: it would make results ambiguous and is
+    // exactly how a worker ends up paid twice.
+    expect(() => parseBatchRequests([payment(), payment()], MAX)).toThrow(/Duplicate payment id/);
+  });
+
+  it('rejects an empty or non-array batch', () => {
+    expect(() => parseBatchRequests([], MAX)).toThrow(/No payments supplied/);
+    expect(() => parseBatchRequests(null, MAX)).toThrow(/No payments supplied/);
+    expect(() => parseBatchRequests('62 payments', MAX)).toThrow(/No payments supplied/);
+    expect(() => parseBatchRequests({ length: 2 }, MAX)).toThrow(/No payments supplied/);
+  });
+
+  it('enforces the batch size cap', () => {
+    const many = Array.from({ length: 4 }, (_, i) => payment({ id: `inv-${i}` }));
+    expect(() => parseBatchRequests(many, 3)).toThrow(/Too many payments/);
+    expect(parseBatchRequests(many, 4)).toHaveLength(4);
+  });
+
+  it('rejects a missing or non-string id, naming the position', () => {
+    expect(() => parseBatchRequests([payment({ id: undefined })], MAX)).toThrow(
+      /Payment #1 is missing an id/,
+    );
+    expect(() => parseBatchRequests([payment({ id: 123 })], MAX)).toThrow(/missing an id/);
+    expect(() => parseBatchRequests([payment({ id: '' })], MAX)).toThrow(/missing an id/);
+  });
+
+  it('rejects a missing recipient', () => {
+    expect(() => parseBatchRequests([payment({ to: '   ' })], MAX)).toThrow(
+      /missing a recipient address/,
+    );
+    expect(() => parseBatchRequests([payment({ to: undefined })], MAX)).toThrow(
+      /missing a recipient address/,
+    );
+  });
+
+  it('rejects a chain the wallet cannot sign instead of guessing', () => {
+    // Guessing would broadcast real funds on the wrong network.
+    expect(() => parseBatchRequests([payment({ chain: 'DOGE' })], MAX)).toThrow(
+      /unsupported chain/,
+    );
+    expect(() => parseBatchRequests([payment({ chain: undefined })], MAX)).toThrow(
+      /unsupported chain/,
+    );
+  });
+
+  it.each([
+    ['zero', '0'],
+    ['negative', '-5'],
+    ['not a number', 'abc'],
+    ['empty', ''],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['null', null],
+  ])('rejects a %s amount', (_label, amount) => {
+    expect(() => parseBatchRequests([payment({ amount })], MAX)).toThrow(/invalid amount/);
+  });
+
+  it('accepts a numeric amount and stringifies it', () => {
+    const [result] = parseBatchRequests([payment({ amount: 0.5 })], MAX);
+    expect(result).toMatchObject({ amount: '0.5' });
+  });
+
+  it('caps an overlong label so it cannot flood the approval screen', () => {
+    // A page could otherwise push the Approve button off-screen behind text.
+    const [result] = parseBatchRequests([payment({ label: 'x'.repeat(5000) })], MAX);
+    expect(result!.label).toHaveLength(200);
+  });
+
+  it('drops non-string labels and non-numeric USD rather than rendering them', () => {
+    const [result] = parseBatchRequests(
+      [payment({ label: { toString: () => 'evil' }, amountUsd: '10' })],
+      MAX,
+    );
+    expect(result!.label).toBeUndefined();
+    expect(result!.amountUsd).toBeUndefined();
+  });
+
+  it('survives null and non-object entries without crashing the worker', () => {
+    expect(() => parseBatchRequests([null], MAX)).toThrow(/missing an id/);
+    expect(() => parseBatchRequests(['nope'], MAX)).toThrow(/missing an id/);
+  });
+
+  it('reports the first problem and does not partially accept a batch', () => {
+    expect(() =>
+      parseBatchRequests([payment({ id: 'a' }), payment({ id: 'b', chain: 'DOGE' })], MAX),
+    ).toThrow(/Payment b has an unsupported chain/);
+  });
+});

--- a/packages/extension/src/core/__tests__/batch.test.ts
+++ b/packages/extension/src/core/__tests__/batch.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Batch runner behaviour: partial success, per-account serialization,
+ * cross-account concurrency, and retry policy.
+ *
+ * The API is faked so these assert orchestration only — signing itself is
+ * covered by signing.diff.test.ts and private-keys.test.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  runBatchPayments,
+  summarizeBatch,
+  isTransientChainError,
+  type BatchPaymentRequest,
+} from '../batch.js';
+import type { CoinPayApi } from '../api.js';
+import { seedFromMnemonic } from '../derivation.js';
+
+const SEED = seedFromMnemonic(
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+);
+const AUTH_KEY = new Uint8Array(32).fill(9);
+
+const ADDRESSES = {
+  BTC: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+  BCH: 'bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy',
+  ETH: '0x1111111111111111111111111111111111111111',
+  POL: '0x1111111111111111111111111111111111111111',
+  SOL: '11111111111111111111111111111112',
+};
+
+interface FakeApiOptions {
+  /** Per-request-id list of errors to throw before succeeding. */
+  failures?: Record<string, string[]>;
+  /** Records call order across the whole batch. */
+  trace?: string[];
+}
+
+function fakeApi(options: FakeApiOptions = {}): CoinPayApi {
+  const { failures = {}, trace = [] } = options;
+  const attempts = new Map<string, number>();
+  let counter = 0;
+
+  // The runner passes to_address through untouched, so we key fakes off it.
+  const idFor = (to: string): string => to;
+
+  return {
+    async prepareTx(_walletId: unknown, _key: unknown, input: any) {
+      const id = idFor(input.to_address);
+      const attempt = (attempts.get(id) ?? 0) + 1;
+      attempts.set(id, attempt);
+      trace.push(`prepare:${id}:${attempt}`);
+
+      const queued = failures[id];
+      if (queued && queued.length >= attempt) {
+        throw new Error(queued[attempt - 1]);
+      }
+
+      return {
+        tx_id: `tx-${++counter}`,
+        chain: input.chain,
+        from_address: input.from_address,
+        to_address: input.to_address,
+        amount: input.amount,
+        fee: {},
+        expires_at: new Date(Date.now() + 300_000).toISOString(),
+        // Minimal EVM shape; signing is stubbed out below.
+        unsigned_tx: {
+          type: 'evm',
+          chainId: 1,
+          nonce: 0,
+          to: '0x2222222222222222222222222222222222222222',
+          value: '0x1',
+          gasLimit: 21000,
+          maxFeePerGas: '1',
+          maxPriorityFeePerGas: '1',
+        },
+      } as any;
+    },
+    async broadcast(_walletId: unknown, _key: unknown, input: any) {
+      trace.push(`broadcast:${input.tx_id}`);
+      return {
+        tx_hash: `hash-${input.tx_id}`,
+        chain: input.chain,
+        status: 'pending' as const,
+        explorer_url: `https://explorer/${input.tx_id}`,
+      };
+    },
+  } as unknown as CoinPayApi;
+}
+
+// Signing is exercised elsewhere; here it must not depend on real tx bytes.
+vi.mock('../signing.js', () => ({
+  signTransaction: vi.fn(async () => ({ signed_tx: '0xdeadbeef', format: 'hex' as const })),
+}));
+
+function request(overrides: Partial<BatchPaymentRequest> & { id: string }): BatchPaymentRequest {
+  return {
+    chain: 'ETH',
+    to: overrides.id,
+    amount: '0.01',
+    ...overrides,
+  };
+}
+
+const noSleep = async (): Promise<void> => {};
+
+function run(requests: BatchPaymentRequest[], api: CoinPayApi, extra: Record<string, unknown> = {}) {
+  return runBatchPayments(requests, {
+    api,
+    walletId: 'wallet-1',
+    seed: SEED,
+    authKey: AUTH_KEY,
+    addresses: ADDRESSES,
+    sleep: noSleep,
+    ...extra,
+  } as any);
+}
+
+describe('runBatchPayments', () => {
+  it('pays every item and returns results in the requested order', async () => {
+    const requests = [request({ id: 'a' }), request({ id: 'b' }), request({ id: 'c' })];
+    const results = await run(requests, fakeApi());
+
+    expect(results.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+    expect(results.every((r) => r.status === 'sent')).toBe(true);
+    expect(results[0]!.txHash).toMatch(/^hash-tx-/);
+    expect(results[0]!.explorerUrl).toContain('https://explorer/');
+  });
+
+  it('keeps paying the rest when one item fails (partial success)', async () => {
+    const requests = [request({ id: 'a' }), request({ id: 'b' }), request({ id: 'c' })];
+    const results = await run(
+      requests,
+      fakeApi({ failures: { b: ['Insufficient funds', 'Insufficient funds', 'Insufficient funds'] } }),
+    );
+
+    expect(results.map((r) => r.status)).toEqual(['sent', 'failed', 'sent']);
+    expect(results[1]!.error).toMatch(/Insufficient funds/);
+  });
+
+  it('does not retry terminal errors', async () => {
+    const trace: string[] = [];
+    await run([request({ id: 'a' })], fakeApi({ failures: { a: ['Insufficient funds'] }, trace }));
+
+    expect(trace.filter((t) => t.startsWith('prepare:a'))).toEqual(['prepare:a:1']);
+  });
+
+  it('retries transient chain-state errors and succeeds', async () => {
+    const trace: string[] = [];
+    const results = await run(
+      [request({ id: 'a' })],
+      fakeApi({ failures: { a: ['nonce too low'] }, trace }),
+    );
+
+    expect(results[0]!.status).toBe('sent');
+    expect(trace.filter((t) => t.startsWith('prepare:a'))).toEqual(['prepare:a:1', 'prepare:a:2']);
+  });
+
+  it('gives up after maxAttempts on a persistently transient error', async () => {
+    const results = await run(
+      [request({ id: 'a' })],
+      fakeApi({ failures: { a: ['nonce too low', 'nonce too low', 'nonce too low'] } }),
+    );
+
+    expect(results[0]!.status).toBe('failed');
+    expect(results[0]!.error).toMatch(/nonce too low/);
+  });
+
+  it('serializes same-account payments: each broadcast precedes the next prepare', async () => {
+    const trace: string[] = [];
+    await run(
+      [request({ id: 'a' }), request({ id: 'b' }), request({ id: 'c' })],
+      fakeApi({ trace }),
+    );
+
+    expect(trace).toEqual([
+      'prepare:a:1',
+      'broadcast:tx-1',
+      'prepare:b:1',
+      'broadcast:tx-2',
+      'prepare:c:1',
+      'broadcast:tx-3',
+    ]);
+  });
+
+  it('runs different accounts concurrently', async () => {
+    const trace: string[] = [];
+    await run(
+      [
+        request({ id: 'eth-1', chain: 'ETH' }),
+        request({ id: 'sol-1', chain: 'SOL' }),
+        request({ id: 'eth-2', chain: 'ETH' }),
+      ],
+      fakeApi({ trace }),
+    );
+
+    // Solana starts before the second Ethereum item — it is not stuck behind
+    // the ETH queue.
+    expect(trace.indexOf('prepare:sol-1:1')).toBeLessThan(trace.indexOf('prepare:eth-2:1'));
+  });
+
+  it('treats USDC_ETH as sharing the ETH account queue', async () => {
+    const trace: string[] = [];
+    await run(
+      [request({ id: 'a', chain: 'ETH' }), request({ id: 'b', chain: 'USDC_ETH' })],
+      fakeApi({ trace }),
+    );
+
+    // Same account ⇒ strictly serialized, or they would collide on one nonce.
+    expect(trace).toEqual(['prepare:a:1', 'broadcast:tx-1', 'prepare:b:1', 'broadcast:tx-2']);
+  });
+
+  it('skips remaining payments once aborted, without marking them sent', async () => {
+    const controller = new AbortController();
+    const requests = [request({ id: 'a' }), request({ id: 'b' }), request({ id: 'c' })];
+    const api = fakeApi();
+    const originalBroadcast = (api as any).broadcast;
+    (api as any).broadcast = async (...args: unknown[]) => {
+      controller.abort(); // cancel right after the first send goes out
+      return originalBroadcast(...args);
+    };
+
+    const results = await run(requests, api, { signal: controller.signal });
+
+    expect(results[0]!.status).toBe('sent');
+    expect(results[1]!.status).toBe('skipped');
+    expect(results[2]!.status).toBe('skipped');
+  });
+
+  it('fails an item whose chain has no address, without touching the others', async () => {
+    const results = await runBatchPayments([request({ id: 'a', chain: 'BTC' }), request({ id: 'b' })], {
+      api: fakeApi(),
+      walletId: 'wallet-1',
+      seed: SEED,
+      authKey: AUTH_KEY,
+      addresses: { ETH: ADDRESSES.ETH }, // no BTC account
+      sleep: noSleep,
+    } as any);
+
+    expect(results[0]!.status).toBe('failed');
+    expect(results[0]!.error).toMatch(/no BTC address/);
+    expect(results[1]!.status).toBe('sent');
+  });
+
+  it('reports progress ending in a terminal stage per item', async () => {
+    const events: string[] = [];
+    await run([request({ id: 'a' }), request({ id: 'b' })], fakeApi(), {
+      onProgress: (p: any) => events.push(`${p.id}:${p.stage}`),
+    });
+
+    expect(events).toContain('a:preparing');
+    expect(events).toContain('a:broadcasting');
+    expect(events).toContain('a:sent');
+    expect(events).toContain('b:sent');
+  });
+
+  it('counts completed items monotonically up to the total', async () => {
+    const completions: number[] = [];
+    await run([request({ id: 'a' }), request({ id: 'b' })], fakeApi(), {
+      onProgress: (p: any) => {
+        if (p.stage === 'sent' || p.stage === 'failed') completions.push(p.completed);
+        expect(p.total).toBe(2);
+      },
+    });
+
+    expect(completions).toEqual([1, 2]);
+  });
+});
+
+describe('isTransientChainError', () => {
+  it('flags chain-state races as retryable', () => {
+    expect(isTransientChainError('nonce too low')).toBe(true);
+    expect(isTransientChainError('bad-txns-inputs-missingorspent')).toBe(true);
+    expect(isTransientChainError('Blockhash not found')).toBe(true);
+    expect(isTransientChainError('replacement transaction underpriced')).toBe(true);
+  });
+
+  it('does not flag errors that retrying cannot fix', () => {
+    expect(isTransientChainError('Insufficient funds: need 5000 sats')).toBe(false);
+    expect(isTransientChainError('Invalid recipient address')).toBe(false);
+    expect(isTransientChainError('Wallet is locked')).toBe(false);
+  });
+});
+
+describe('summarizeBatch', () => {
+  it('totals amount and USD per chain', () => {
+    const summary = summarizeBatch([
+      request({ id: 'a', chain: 'USDC_SOL', amount: '10.5', amountUsd: 10.5 }),
+      request({ id: 'b', chain: 'USDC_SOL', amount: '4.5', amountUsd: 4.5 }),
+      request({ id: 'c', chain: 'BTC', amount: '0.001', amountUsd: 60 }),
+    ]);
+
+    expect(summary).toEqual([
+      { chain: 'USDC_SOL', count: 2, total: '15', totalUsd: 15 },
+      { chain: 'BTC', count: 1, total: '0.001', totalUsd: 60 },
+    ]);
+  });
+
+  it('keeps satoshi-level precision', () => {
+    const summary = summarizeBatch([
+      request({ id: 'a', chain: 'BTC', amount: '0.00000001' }),
+      request({ id: 'b', chain: 'BTC', amount: '0.00000002' }),
+    ]);
+
+    expect(summary[0]!.total).toBe('0.00000003');
+  });
+});

--- a/packages/extension/src/core/__tests__/connections.test.ts
+++ b/packages/extension/src/core/__tests__/connections.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { ConnectionStore, normalizeOrigin } from '../connections.js';
+import { MemoryStorage } from '../storage.js';
+
+describe('normalizeOrigin', () => {
+  it('reduces a URL to scheme://host[:port]', () => {
+    expect(normalizeOrigin('https://ugig.net/dashboard/invoices?tab=received')).toBe(
+      'https://ugig.net',
+    );
+  });
+
+  it('keeps scheme, host, and port distinct', () => {
+    // A grant to the real site must never cover a look-alike on another scheme
+    // or port.
+    expect(normalizeOrigin('http://ugig.net')).not.toBe(normalizeOrigin('https://ugig.net'));
+    expect(normalizeOrigin('https://ugig.net:8443')).not.toBe(normalizeOrigin('https://ugig.net'));
+    expect(normalizeOrigin('https://evil.ugig.net')).not.toBe(normalizeOrigin('https://ugig.net'));
+  });
+
+  it('rejects non-web and malformed origins', () => {
+    expect(normalizeOrigin('file:///etc/passwd')).toBeNull();
+    expect(normalizeOrigin('javascript:alert(1)')).toBeNull();
+    expect(normalizeOrigin('not a url')).toBeNull();
+    expect(normalizeOrigin(null)).toBeNull();
+    expect(normalizeOrigin('')).toBeNull();
+  });
+});
+
+describe('ConnectionStore', () => {
+  let store: ConnectionStore;
+
+  beforeEach(() => {
+    store = new ConnectionStore(new MemoryStorage());
+  });
+
+  it('reports nothing connected initially', async () => {
+    expect(await store.isConnected('https://ugig.net')).toBe(false);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('connects and recognizes an origin', async () => {
+    await store.connect('https://ugig.net');
+
+    expect(await store.isConnected('https://ugig.net')).toBe(true);
+    expect(await store.isConnected('https://example.com')).toBe(false);
+  });
+
+  it('treats a null origin as never connected', async () => {
+    await store.connect('https://ugig.net');
+    expect(await store.isConnected(null)).toBe(false);
+  });
+
+  it('is idempotent and preserves the original connection time', async () => {
+    const first = await store.connect('https://ugig.net');
+    const second = await store.connect('https://ugig.net');
+
+    expect(second.connectedAt).toBe(first.connectedAt);
+    expect(await store.list()).toHaveLength(1);
+  });
+
+  it('forgets a disconnected origin', async () => {
+    await store.connect('https://ugig.net');
+    await store.disconnect('https://ugig.net');
+
+    expect(await store.isConnected('https://ugig.net')).toBe(false);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('touch only updates an existing connection, never creates one', async () => {
+    await store.touch('https://ugig.net');
+    expect(await store.isConnected('https://ugig.net')).toBe(false);
+
+    await store.connect('https://ugig.net');
+    await store.touch('https://ugig.net');
+    expect(await store.isConnected('https://ugig.net')).toBe(true);
+  });
+
+  it('keeps connections separate per origin', async () => {
+    await store.connect('https://ugig.net');
+    await store.connect('https://coinpayportal.com');
+    await store.disconnect('https://ugig.net');
+
+    expect(await store.isConnected('https://coinpayportal.com')).toBe(true);
+    expect(await store.isConnected('https://ugig.net')).toBe(false);
+  });
+
+  it('survives a round-trip through storage', async () => {
+    const storage = new MemoryStorage();
+    await new ConnectionStore(storage).connect('https://ugig.net');
+
+    // A fresh store over the same storage = a service-worker restart.
+    expect(await new ConnectionStore(storage).isConnected('https://ugig.net')).toBe(true);
+  });
+});

--- a/packages/extension/src/core/__tests__/pay-chains.test.ts
+++ b/packages/extension/src/core/__tests__/pay-chains.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  toPayChain,
+  signingChain,
+  nonceQueueKey,
+  isPayChain,
+  payChainLabel,
+  PAY_CHAINS,
+} from '../pay-chains.js';
+import { CHAINS } from '../chains.js';
+
+describe('toPayChain', () => {
+  it('accepts the lowercase currency codes CoinPay payments use', () => {
+    expect(toPayChain('usdc_pol')).toBe('USDC_POL');
+    expect(toPayChain('btc')).toBe('BTC');
+    expect(toPayChain('sol')).toBe('SOL');
+  });
+
+  it('accepts already-normalized chain names', () => {
+    expect(toPayChain('USDC_SOL')).toBe('USDC_SOL');
+  });
+
+  it('normalizes separators and case', () => {
+    expect(toPayChain('usdc-pol')).toBe('USDC_POL');
+    expect(toPayChain('  Usdc Pol ')).toBe('USDC_POL');
+  });
+
+  it('maps MATIC to POL', () => {
+    expect(toPayChain('MATIC')).toBe('POL');
+  });
+
+  it('resolves bare USDC/USDT to Solana, matching CoinPay', () => {
+    // preferredCoinToPaymentCurrency() in ugig.net does the same, so a bare
+    // "USDC" invoice and this wallet agree on which chain is meant.
+    expect(toPayChain('USDC')).toBe('USDC_SOL');
+    expect(toPayChain('USDT')).toBe('USDT_SOL');
+  });
+
+  it('returns null for anything unsignable rather than guessing', () => {
+    // Guessing a chain here would send real funds to the wrong network.
+    expect(toPayChain('DOGE')).toBeNull();
+    expect(toPayChain('XRP')).toBeNull();
+    expect(toPayChain('')).toBeNull();
+    expect(toPayChain(null)).toBeNull();
+    expect(toPayChain(undefined)).toBeNull();
+  });
+});
+
+describe('signingChain', () => {
+  it('signs tokens with their base chain key', () => {
+    expect(signingChain('USDC_POL')).toBe('POL');
+    expect(signingChain('USDC_ETH')).toBe('ETH');
+    expect(signingChain('USDC_SOL')).toBe('SOL');
+    expect(signingChain('USDT_ETH')).toBe('ETH');
+  });
+
+  it('signs native chains with their own key', () => {
+    expect(signingChain('BTC')).toBe('BTC');
+    expect(signingChain('SOL')).toBe('SOL');
+  });
+
+  it('only ever names a chain the wallet actually derives', () => {
+    for (const chain of PAY_CHAINS) {
+      expect(CHAINS).toHaveProperty(signingChain(chain));
+    }
+  });
+});
+
+describe('nonceQueueKey', () => {
+  it('puts a token and its base chain in one queue', () => {
+    // They share an account, so two concurrent sends would collide on a nonce.
+    expect(nonceQueueKey('USDC_ETH')).toBe(nonceQueueKey('ETH'));
+    expect(nonceQueueKey('USDC_SOL')).toBe(nonceQueueKey('SOL'));
+  });
+
+  it('keeps ETH and POL in separate queues despite the shared address', () => {
+    // Same address, independent networks — independent nonces.
+    expect(nonceQueueKey('ETH')).not.toBe(nonceQueueKey('POL'));
+  });
+});
+
+describe('isPayChain / payChainLabel', () => {
+  it('recognizes exactly the supported set', () => {
+    expect(isPayChain('USDC_POL')).toBe(true);
+    expect(isPayChain('DOGE')).toBe(false);
+  });
+
+  it('labels every supported chain', () => {
+    for (const chain of PAY_CHAINS) {
+      expect(payChainLabel(chain)).toBeTruthy();
+    }
+  });
+});

--- a/packages/extension/src/core/__tests__/private-keys.test.ts
+++ b/packages/extension/src/core/__tests__/private-keys.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Parity guard for `private-keys.ts`.
+ *
+ * The extension signs with keys derived HERE but its funds sit at addresses
+ * derived by the `@profullstack/coinpay` SDK. If the two ever disagree the
+ * wallet signs with a key that controls a different address — transactions
+ * would be rejected (or worse, spend from somewhere unexpected). So for every
+ * chain we derive the private key, recompute the address from it, and assert it
+ * equals `deriveAddress()` from the SDK.
+ *
+ * The address recomputation below deliberately does NOT reuse extension code:
+ * a shared helper with the same bug in it would agree with itself. It follows
+ * the published rules for each chain instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveAddress } from '@profullstack/coinpay/wallet';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { keccak_256 } from '@noble/hashes/sha3.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { ripemd160 } from '@noble/hashes/legacy.js';
+
+import { derivePrivateKey, derivePrivateKeyHex, derivationPath } from '../private-keys.js';
+import { seedFromMnemonic } from '../derivation.js';
+import { DEFAULT_CHAINS, type NativeChain } from '../chains.js';
+
+// A published BIP-39 test vector — never used for real funds.
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const SEED = seedFromMnemonic(MNEMONIC);
+
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Encode(bytes: Uint8Array): string {
+  let num = 0n;
+  for (const b of bytes) num = num * 256n + BigInt(b);
+
+  let out = '';
+  while (num > 0n) {
+    out = B58[Number(num % 58n)] + out;
+    num /= 58n;
+  }
+  for (const b of bytes) {
+    if (b !== 0) break;
+    out = '1' + out;
+  }
+  return out;
+}
+
+function hash160(data: Uint8Array): Uint8Array {
+  return ripemd160(sha256(data));
+}
+
+function base58Check(version: number, payload: Uint8Array): string {
+  const body = new Uint8Array(1 + payload.length);
+  body[0] = version;
+  body.set(payload, 1);
+  const checksum = sha256(sha256(body)).slice(0, 4);
+  const full = new Uint8Array(body.length + 4);
+  full.set(body);
+  full.set(checksum, body.length);
+  return base58Encode(full);
+}
+
+/** EIP-55 checksummed hex address from an uncompressed secp256k1 public key. */
+function evmAddress(privateKey: Uint8Array): string {
+  const pub = secp256k1.getPublicKey(privateKey, false).slice(1); // drop 0x04
+  const hex = Array.from(keccak_256(pub).slice(-20), (b) => b.toString(16).padStart(2, '0')).join('');
+  const hashed = Array.from(keccak_256(new TextEncoder().encode(hex)), (b) =>
+    b.toString(16).padStart(2, '0'),
+  ).join('');
+  let out = '';
+  for (let i = 0; i < hex.length; i++) {
+    out += Number.parseInt(hashed[i]!, 16) >= 8 ? hex[i]!.toUpperCase() : hex[i]!;
+  }
+  return '0x' + out;
+}
+
+/** hash160 embedded in a CashAddr payload, for comparing BCH without re-encoding. */
+function cashAddrHash160(address: string): string {
+  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const payload = address.split(':').pop()!;
+  const values = [...payload].map((c) => CHARSET.indexOf(c));
+  // Drop the 8-symbol checksum, convert 5-bit → 8-bit, drop the version byte.
+  const data = values.slice(0, -8);
+  let acc = 0;
+  let bits = 0;
+  const bytes: number[] = [];
+  for (const v of data) {
+    acc = (acc << 5) | v;
+    bits += 5;
+    while (bits >= 8) {
+      bits -= 8;
+      bytes.push((acc >> bits) & 0xff);
+    }
+  }
+  return bytes
+    .slice(1, 21)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+describe('derivationPath', () => {
+  it('matches the SDK BIP-44 layout per chain', () => {
+    expect(derivationPath('BTC', 0)).toBe("m/44'/0'/0'/0/0");
+    expect(derivationPath('BCH', 0)).toBe("m/44'/145'/0'/0/0");
+    expect(derivationPath('ETH', 0)).toBe("m/44'/60'/0'/0/0");
+    // POL is EVM and shares the ETH coin type — hence the shared address.
+    expect(derivationPath('POL', 0)).toBe("m/44'/60'/0'/0/0");
+    // Solana hardens the account segment instead of using change/index.
+    expect(derivationPath('SOL', 0)).toBe("m/44'/501'/0'/0'");
+    expect(derivationPath('SOL', 3)).toBe("m/44'/501'/3'/0'");
+    expect(derivationPath('ETH', 3)).toBe("m/44'/60'/0'/0/3");
+  });
+});
+
+describe('derivePrivateKey ↔ SDK deriveAddress parity', () => {
+  it.each(DEFAULT_CHAINS)('%s: key derives the SDK address', (chain: NativeChain) => {
+    const key = derivePrivateKey(SEED, chain, 0);
+    const expected = deriveAddress(SEED, chain, 0) as string;
+
+    switch (chain) {
+      case 'ETH':
+      case 'POL':
+        expect(evmAddress(key).toLowerCase()).toBe(expected.toLowerCase());
+        break;
+      case 'BTC':
+        expect(base58Check(0x00, hash160(secp256k1.getPublicKey(key, true)))).toBe(expected);
+        break;
+      case 'BCH':
+        expect(cashAddrHash160(expected)).toBe(toHex(hash160(secp256k1.getPublicKey(key, true))));
+        break;
+      case 'SOL':
+        expect(base58Encode(ed25519.getPublicKey(key))).toBe(expected);
+        break;
+    }
+  });
+
+  it('ETH and POL share one EVM key (so USDC_POL can sign with it)', () => {
+    expect(toHex(derivePrivateKey(SEED, 'ETH', 0))).toBe(toHex(derivePrivateKey(SEED, 'POL', 0)));
+  });
+
+  it('derives distinct keys per account index', () => {
+    expect(toHex(derivePrivateKey(SEED, 'ETH', 0))).not.toBe(toHex(derivePrivateKey(SEED, 'ETH', 1)));
+    expect(toHex(derivePrivateKey(SEED, 'SOL', 0))).not.toBe(toHex(derivePrivateKey(SEED, 'SOL', 1)));
+  });
+});
+
+describe('derivePrivateKeyHex', () => {
+  it('returns 32 bytes of lowercase hex with no 0x prefix', () => {
+    for (const chain of DEFAULT_CHAINS) {
+      const hex = derivePrivateKeyHex(SEED, chain, 0);
+      expect(hex).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('agrees with the raw byte form', () => {
+    expect(derivePrivateKeyHex(SEED, 'ETH', 0)).toBe(toHex(derivePrivateKey(SEED, 'ETH', 0)));
+  });
+});

--- a/packages/extension/src/core/api.ts
+++ b/packages/extension/src/core/api.ts
@@ -1,0 +1,199 @@
+/**
+ * CoinPay portal API client (background context only).
+ *
+ * The extension holds the keys but NOT the chain infrastructure: it has no RPC
+ * endpoints, no UTXO indexer, no fee oracle. Rather than duplicate all of that
+ * inside a service worker, it reuses the portal's existing web-wallet API,
+ * which already does exactly this split for the CoinPay web wallet:
+ *
+ *   POST /web-wallet/:id/prepare-tx  → server assembles the UNSIGNED tx
+ *                                      (nonce / UTXOs / blockhash / fees)
+ *   ── sign locally, keys never leave the device ──
+ *   POST /web-wallet/:id/broadcast   → server relays the SIGNED blob to the net
+ *
+ * Registration (`/web-wallet/import`) is non-custodial: it uploads PUBLIC keys
+ * and addresses plus a signature proving we hold the matching private key. The
+ * seed is never sent. Subsequent calls authenticate per-request by signing
+ * `METHOD:path:timestamp:body` with the same key.
+ */
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import type { PayChain } from './pay-chains.js';
+import type { UnsignedTransactionData } from './signing.js';
+
+const DEFAULT_BASE_URL = 'https://coinpayportal.com/api';
+
+export interface RegisteredAddress {
+  chain: string;
+  address: string;
+  derivation_path: string;
+}
+
+export interface PreparedTx {
+  tx_id: string;
+  chain: PayChain;
+  from_address: string;
+  to_address: string;
+  amount: string;
+  fee: { total_fee?: string; fee_rate?: string; [k: string]: unknown };
+  expires_at: string;
+  unsigned_tx: UnsignedTransactionData;
+}
+
+export interface BroadcastedTx {
+  tx_hash: string;
+  chain: PayChain;
+  status: 'pending' | 'confirming';
+  explorer_url: string;
+}
+
+/** A portal error surfaced with its API code so callers can branch on it. */
+export class CoinPayApiError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'CoinPayApiError';
+  }
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Sign a UTF-8 message the way the portal's `verifySecp256k1Signature` expects:
+ * compact (64-byte) ECDSA over the message with internal SHA-256 prehashing.
+ */
+export function signAuthMessage(message: string, privateKey: Uint8Array): string {
+  const sig = secp256k1.sign(new TextEncoder().encode(message), privateKey, { prehash: true });
+  return toHex(sig);
+}
+
+export function compressedPublicKey(privateKey: Uint8Array): string {
+  return toHex(secp256k1.getPublicKey(privateKey, true));
+}
+
+export class CoinPayApi {
+  readonly baseUrl: string;
+
+  constructor(baseUrl: string = DEFAULT_BASE_URL) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  /** Path as the server sees it, for signature reconstruction. */
+  #signedPath(path: string): string {
+    const url = new URL(this.baseUrl + path);
+    return url.pathname;
+  }
+
+  async #request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    options: { body?: unknown; walletId?: string; privateKey?: Uint8Array } = {},
+  ): Promise<T> {
+    const { body, walletId, privateKey } = options;
+    // The signature covers the exact bytes sent, so serialize once and reuse.
+    const rawBody = body === undefined ? '' : JSON.stringify(body);
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (walletId && privateKey) {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const message = `${method}:${this.#signedPath(path)}:${timestamp}:${rawBody}`;
+      headers.Authorization = `Wallet ${walletId}:${signAuthMessage(message, privateKey)}:${timestamp}`;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(this.baseUrl + path, {
+        method,
+        headers,
+        body: method === 'GET' ? undefined : rawBody,
+      });
+    } catch (err) {
+      throw new CoinPayApiError(
+        err instanceof Error ? err.message : 'Network request failed',
+        'NETWORK_ERROR',
+        0,
+      );
+    }
+
+    let payload: any = null;
+    try {
+      payload = await response.json();
+    } catch {
+      // Fall through — a non-JSON body is reported via the status below.
+    }
+
+    if (!response.ok || payload?.success === false) {
+      throw new CoinPayApiError(
+        payload?.error?.message || `Request failed with status ${response.status}`,
+        payload?.error?.code || 'HTTP_ERROR',
+        response.status,
+      );
+    }
+
+    return payload?.data as T;
+  }
+
+  /**
+   * Register this wallet's public material so prepare-tx/broadcast will accept
+   * it. Idempotent: an already-registered key returns its existing wallet id
+   * (and backfills any addresses added since).
+   */
+  async registerWallet(input: {
+    publicKeySecp256k1: string;
+    publicKeyEd25519?: string;
+    addresses: RegisteredAddress[];
+    /** Signs the proof-of-ownership challenge. Must match publicKeySecp256k1. */
+    privateKey: Uint8Array;
+  }): Promise<{ wallet_id: string; already_exists?: boolean }> {
+    // The challenge is self-describing and time-stamped so a captured proof
+    // can't be replayed into a different context later.
+    const message = `CoinPay extension wallet registration:${Date.now()}`;
+    return this.#request('POST', '/web-wallet/import', {
+      body: {
+        public_key_secp256k1: input.publicKeySecp256k1,
+        public_key_ed25519: input.publicKeyEd25519,
+        addresses: input.addresses,
+        proof_of_ownership: {
+          message,
+          signature: signAuthMessage(message, input.privateKey),
+        },
+      },
+    });
+  }
+
+  async prepareTx(
+    walletId: string,
+    privateKey: Uint8Array,
+    input: {
+      from_address: string;
+      to_address: string;
+      chain: PayChain;
+      amount: string;
+      priority?: 'low' | 'medium' | 'high';
+    },
+  ): Promise<PreparedTx> {
+    return this.#request('POST', `/web-wallet/${walletId}/prepare-tx`, {
+      body: input,
+      walletId,
+      privateKey,
+    });
+  }
+
+  async broadcast(
+    walletId: string,
+    privateKey: Uint8Array,
+    input: { tx_id: string; signed_tx: string; chain: PayChain },
+  ): Promise<BroadcastedTx> {
+    return this.#request('POST', `/web-wallet/${walletId}/broadcast`, {
+      body: input,
+      walletId,
+      privateKey,
+    });
+  }
+}

--- a/packages/extension/src/core/batch.ts
+++ b/packages/extension/src/core/batch.ts
@@ -1,0 +1,373 @@
+/**
+ * Batch payment runner — pay many recipients from one approval.
+ *
+ * Each payment is an independent on-chain transaction; there is no such thing
+ * as an atomic 62-way transfer. So the contract here is deliberately
+ * **partial-success**: every item reports its own outcome, one failure never
+ * cancels the rest, and the caller reconciles from the per-item results. For a
+ * payables run (e.g. 62 accepted invoices) finishing 61 and reporting 1 failure
+ * is far better than aborting after 20.
+ *
+ * ── Ordering ────────────────────────────────────────────────────────────────
+ * Transactions on the same account must go ONE AT A TIME, because the server
+ * derives chain state per prepare-tx call:
+ *
+ *   EVM      `eth_getTransactionCount(from, 'pending')` — preparing two txs
+ *            before broadcasting either yields the SAME nonce, so the second
+ *            replaces (not follows) the first.
+ *   BTC/BCH  the full UTXO set is spent as inputs with one change output back.
+ *            Item N+1 must see N's change UTXO or it will build a tx from
+ *            already-spent inputs.
+ *
+ * Hence: items are grouped into per-account queues, queues run concurrently
+ * (Solana and Polygon don't block each other), and within a queue we strictly
+ * serialize prepare → sign → broadcast, then wait `settleDelayMs` for the
+ * network's view to catch up before the next item.
+ *
+ * That delay is a heuristic, not a guarantee, so transient chain-state errors
+ * ("nonce too low", "inputs missing or spent") are retried with backoff rather
+ * than surfaced. Errors that retrying cannot fix — insufficient funds, a bad
+ * address — fail the item immediately.
+ */
+
+import { signTransaction } from './signing.js';
+import { derivePrivateKey } from './private-keys.js';
+import { signingChain, nonceQueueKey, toPayChain, type PayChain } from './pay-chains.js';
+import type { CoinPayApi } from './api.js';
+import type { NativeChain } from './chains.js';
+
+export interface BatchPaymentRequest {
+  /** Caller's correlation id (e.g. a ugig.net invoice id). Echoed in results. */
+  id: string;
+  chain: PayChain;
+  /** Recipient address. */
+  to: string;
+  /** Amount in the chain's display units, as a decimal string. */
+  amount: string;
+  /** Human label for the approval screen ("Ada Lovelace — Fix login bug"). */
+  label?: string;
+  /** Fiat value for the approval summary only; never used for the transfer. */
+  amountUsd?: number;
+}
+
+export type BatchItemStage =
+  | 'queued'
+  | 'preparing'
+  | 'signing'
+  | 'broadcasting'
+  | 'sent'
+  | 'failed'
+  | 'skipped';
+
+export interface BatchItemResult {
+  id: string;
+  chain: PayChain;
+  to: string;
+  amount: string;
+  status: 'sent' | 'failed' | 'skipped';
+  txHash?: string;
+  explorerUrl?: string;
+  error?: string;
+}
+
+export interface BatchProgress {
+  id: string;
+  stage: BatchItemStage;
+  /** Populated once broadcast succeeds. */
+  txHash?: string;
+  explorerUrl?: string;
+  error?: string;
+  /** Items finished (sent + failed + skipped) out of the total. */
+  completed: number;
+  total: number;
+}
+
+export interface BatchRunnerOptions {
+  api: CoinPayApi;
+  walletId: string;
+  /** Raw BIP-39 seed; per-chain keys are derived, used, and zeroed per item. */
+  seed: Uint8Array;
+  /** Signs API auth headers — the secp256k1 key registered with the portal. */
+  authKey: Uint8Array;
+  /** Sender address per signing chain, from the unlocked wallet's accounts. */
+  addresses: Partial<Record<NativeChain, string>>;
+  onProgress?: (progress: BatchProgress) => void;
+  signal?: AbortSignal;
+  /** Overridable for tests, which would otherwise wait out the real delays. */
+  sleep?: (ms: number) => Promise<void>;
+  maxAttempts?: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+/**
+ * How long to let the network absorb a broadcast before preparing the next
+ * transaction from the same account. UTXO chains need the most: a change output
+ * has to reach the indexer the server queries.
+ */
+function settleDelayMs(chain: NativeChain): number {
+  switch (chain) {
+    case 'BTC':
+    case 'BCH':
+      return 8000;
+    case 'ETH':
+    case 'POL':
+      return 1500;
+    case 'SOL':
+      return 1000;
+  }
+}
+
+/**
+ * Transient = the transaction was built against chain state that has since
+ * moved. Re-preparing from scratch is very likely to succeed, so we retry.
+ * Anything else (insufficient funds, invalid address) is terminal — retrying
+ * only wastes the user's time and, worse, risks a duplicate payment.
+ */
+export function isTransientChainError(message: string): boolean {
+  return /nonce too low|replacement transaction underpriced|already known|missingorspent|missing or spent|utxo|txn-mempool-conflict|blockhash not found|block height exceeded|rate limit|timeout|temporarily|502|503|504/i.test(
+    message,
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run a batch of payments. Resolves once every item has a terminal outcome;
+ * it does not reject on individual failures — inspect the returned results.
+ */
+export async function runBatchPayments(
+  requests: BatchPaymentRequest[],
+  options: BatchRunnerOptions,
+): Promise<BatchItemResult[]> {
+  const {
+    api,
+    walletId,
+    seed,
+    authKey,
+    addresses,
+    onProgress,
+    signal,
+    sleep = defaultSleep,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  } = options;
+
+  const total = requests.length;
+  let completed = 0;
+  const results = new Map<string, BatchItemResult>();
+
+  const report = (
+    request: BatchPaymentRequest,
+    stage: BatchItemStage,
+    extra: { txHash?: string; explorerUrl?: string; error?: string } = {},
+  ): void => {
+    onProgress?.({ id: request.id, stage, completed, total, ...extra });
+  };
+
+  const finish = (
+    request: BatchPaymentRequest,
+    result: Omit<BatchItemResult, 'id' | 'chain' | 'to' | 'amount'>,
+  ): void => {
+    results.set(request.id, {
+      id: request.id,
+      chain: request.chain,
+      to: request.to,
+      amount: request.amount,
+      ...result,
+    });
+    completed++;
+    report(request, result.status === 'sent' ? 'sent' : result.status, {
+      txHash: result.txHash,
+      explorerUrl: result.explorerUrl,
+      error: result.error,
+    });
+  };
+
+  /** prepare → sign → broadcast for one payment. Throws on failure. */
+  const payOnce = async (request: BatchPaymentRequest): Promise<BatchItemResult> => {
+    const signer = signingChain(request.chain);
+    const from = addresses[signer];
+    if (!from) {
+      throw new Error(`Wallet has no ${signer} address to send from`);
+    }
+
+    report(request, 'preparing');
+    const prepared = await api.prepareTx(walletId, authKey, {
+      from_address: from,
+      to_address: request.to,
+      chain: request.chain,
+      amount: request.amount,
+    });
+
+    report(request, 'signing');
+    const privateKey = derivePrivateKey(seed, signer, 0);
+    let signed: string;
+    try {
+      const result = await signTransaction({
+        unsigned_tx: prepared.unsigned_tx,
+        privateKey: Array.from(privateKey, (b) => b.toString(16).padStart(2, '0')).join(''),
+      });
+      signed = result.signed_tx;
+    } finally {
+      // Key material lives only as long as the signature it produces.
+      privateKey.fill(0);
+    }
+
+    report(request, 'broadcasting');
+    const broadcasted = await api.broadcast(walletId, authKey, {
+      tx_id: prepared.tx_id,
+      signed_tx: signed,
+      chain: request.chain,
+    });
+
+    return {
+      id: request.id,
+      chain: request.chain,
+      to: request.to,
+      amount: request.amount,
+      status: 'sent',
+      txHash: broadcasted.tx_hash,
+      explorerUrl: broadcasted.explorer_url,
+    };
+  };
+
+  /** One account's payments, strictly in order. */
+  const runQueue = async (queue: BatchPaymentRequest[], account: NativeChain): Promise<void> => {
+    for (const request of queue) {
+      if (signal?.aborted) {
+        finish(request, { status: 'skipped', error: 'Cancelled before this payment was sent' });
+        continue;
+      }
+
+      report(request, 'queued');
+      let lastError = '';
+      let sent = false;
+
+      for (let attempt = 1; attempt <= maxAttempts && !sent; attempt++) {
+        try {
+          const result = await payOnce(request);
+          results.set(request.id, result);
+          completed++;
+          report(request, 'sent', { txHash: result.txHash, explorerUrl: result.explorerUrl });
+          sent = true;
+        } catch (err) {
+          lastError = errorMessage(err);
+          const canRetry = attempt < maxAttempts && isTransientChainError(lastError);
+          if (!canRetry) break;
+          // Back off and let chain state settle before rebuilding the tx.
+          await sleep(settleDelayMs(account) * attempt);
+        }
+      }
+
+      if (!sent) {
+        finish(request, { status: 'failed', error: lastError || 'Payment failed' });
+        // A failed broadcast consumes no nonce and spends no UTXO, so the next
+        // item can proceed immediately against unchanged state.
+        continue;
+      }
+
+      // Give the network time to reflect this send before building the next.
+      const isLast = queue[queue.length - 1] === request;
+      if (!isLast) await sleep(settleDelayMs(account));
+    }
+  };
+
+  // Group into per-account queues. Insertion order is preserved so payments go
+  // out in the order the user saw them on the approval screen.
+  const queues = new Map<NativeChain, BatchPaymentRequest[]>();
+  for (const request of requests) {
+    const key = nonceQueueKey(request.chain);
+    const queue = queues.get(key);
+    if (queue) queue.push(request);
+    else queues.set(key, [request]);
+  }
+
+  await Promise.all([...queues.entries()].map(([account, queue]) => runQueue(queue, account)));
+
+  // Return in the caller's original order so the UI can zip results to rows.
+  return requests.map(
+    (request) =>
+      results.get(request.id) ?? {
+        id: request.id,
+        chain: request.chain,
+        to: request.to,
+        amount: request.amount,
+        status: 'failed' as const,
+        error: 'Payment did not run',
+      },
+  );
+}
+
+/**
+ * Validate a batch request that arrived from an untrusted web page.
+ *
+ * Everything here is attacker-controlled, and the approval screen is only
+ * meaningful if it describes what will actually be signed — so anything
+ * ambiguous is rejected outright rather than coerced into something plausible.
+ * In particular a duplicate id is fatal: for a payables run that ambiguity is
+ * exactly how someone gets paid twice.
+ *
+ * Throws on the first problem, naming the offending payment.
+ */
+export function parseBatchRequests(payments: unknown, maxSize: number): BatchPaymentRequest[] {
+  if (!Array.isArray(payments) || payments.length === 0) {
+    throw new Error('No payments supplied');
+  }
+  if (payments.length > maxSize) {
+    throw new Error(`Too many payments in one batch (max ${maxSize})`);
+  }
+
+  const seen = new Set<string>();
+  return payments.map((raw, index) => {
+    const item = (raw ?? {}) as Record<string, unknown>;
+    const id = typeof item.id === 'string' ? item.id : '';
+    const to = typeof item.to === 'string' ? item.to.trim() : '';
+    const amount = String(item.amount ?? '').trim();
+    const chain = toPayChain(typeof item.chain === 'string' ? item.chain : null);
+
+    if (!id) throw new Error(`Payment #${index + 1} is missing an id`);
+    if (seen.has(id)) throw new Error(`Duplicate payment id: ${id}`);
+    seen.add(id);
+    if (!to) throw new Error(`Payment ${id} is missing a recipient address`);
+    if (!chain) throw new Error(`Payment ${id} has an unsupported chain`);
+    // Rejects NaN, Infinity, negatives, and zero in one check.
+    if (!(Number(amount) > 0) || !Number.isFinite(Number(amount))) {
+      throw new Error(`Payment ${id} has an invalid amount`);
+    }
+
+    return {
+      id,
+      chain,
+      to,
+      amount,
+      label: typeof item.label === 'string' ? item.label.slice(0, 200) : undefined,
+      amountUsd: typeof item.amountUsd === 'number' ? item.amountUsd : undefined,
+    };
+  });
+}
+
+/** Per-chain totals for the approval screen. */
+export function summarizeBatch(
+  requests: BatchPaymentRequest[],
+): { chain: PayChain; count: number; total: string; totalUsd: number }[] {
+  const groups = new Map<PayChain, { count: number; total: number; totalUsd: number }>();
+  for (const request of requests) {
+    const group = groups.get(request.chain) ?? { count: 0, total: 0, totalUsd: 0 };
+    group.count++;
+    group.total += Number(request.amount) || 0;
+    group.totalUsd += request.amountUsd || 0;
+    groups.set(request.chain, group);
+  }
+  return [...groups.entries()].map(([chain, group]) => ({
+    chain,
+    count: group.count,
+    // 8 decimals covers BTC's satoshi precision; trailing zeros trimmed.
+    total: group.total.toFixed(8).replace(/\.?0+$/, ''),
+    totalUsd: group.totalUsd,
+  }));
+}

--- a/packages/extension/src/core/connections.ts
+++ b/packages/extension/src/core/connections.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-origin site permissions.
+ *
+ * A page can only see addresses or request payments after the user has
+ * explicitly connected that ORIGIN (scheme + host + port — never a bare
+ * hostname, so `http://` and a look-alike port can't inherit a grant made to
+ * `https://ugig.net`).
+ *
+ * Connecting is not an allowance: it grants read access to public addresses and
+ * the right to *ask*. Every payment still needs its own approval, so a
+ * compromised connected page cannot move funds on its own.
+ */
+
+import type { KeyValueStore } from './storage.js';
+
+const CONNECTIONS_KEY = 'connections';
+
+export interface SiteConnection {
+  origin: string;
+  connectedAt: number;
+  /** Bumped whenever the site makes an authorized request; shown in the UI. */
+  lastUsedAt: number;
+}
+
+/** Normalize to scheme://host[:port], or null if not a usable web origin. */
+export function normalizeOrigin(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export class ConnectionStore {
+  constructor(private store: KeyValueStore) {}
+
+  async #all(): Promise<Record<string, SiteConnection>> {
+    return (await this.store.get<Record<string, SiteConnection>>(CONNECTIONS_KEY)) ?? {};
+  }
+
+  async list(): Promise<SiteConnection[]> {
+    const all = await this.#all();
+    return Object.values(all).sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+  }
+
+  async isConnected(origin: string | null): Promise<boolean> {
+    if (!origin) return false;
+    const all = await this.#all();
+    return Boolean(all[origin]);
+  }
+
+  async connect(origin: string): Promise<SiteConnection> {
+    const all = await this.#all();
+    const now = Date.now();
+    const connection: SiteConnection = all[origin]
+      ? { ...all[origin]!, lastUsedAt: now }
+      : { origin, connectedAt: now, lastUsedAt: now };
+    all[origin] = connection;
+    await this.store.set(CONNECTIONS_KEY, all);
+    return connection;
+  }
+
+  async touch(origin: string): Promise<void> {
+    const all = await this.#all();
+    const existing = all[origin];
+    if (!existing) return;
+    all[origin] = { ...existing, lastUsedAt: Date.now() };
+    await this.store.set(CONNECTIONS_KEY, all);
+  }
+
+  async disconnect(origin: string): Promise<void> {
+    const all = await this.#all();
+    delete all[origin];
+    await this.store.set(CONNECTIONS_KEY, all);
+  }
+}

--- a/packages/extension/src/core/pay-chains.ts
+++ b/packages/extension/src/core/pay-chains.ts
@@ -1,0 +1,141 @@
+/**
+ * Payment-chain vocabulary shared by the batch payer.
+ *
+ * Three different names for "what coin is this" show up in a batch payment and
+ * they are NOT interchangeable:
+ *
+ *   1. `PayChain`  — what the CoinPay server's prepare-tx/broadcast API calls it
+ *                    (`USDC_POL`). This decides fees, contract address, RPC.
+ *   2. signing key — which derived key signs it. USDC_POL rides on the POL/ETH
+ *                    address, so it signs with the `ETH`-path secp256k1 key.
+ *   3. wire currency — the lowercase code payment providers hand us
+ *                      (`usdc_pol`), e.g. ugig.net invoice metadata.
+ *
+ * `toPayChain()` normalizes (3) → (1); `signingChain()` maps (1) → (2).
+ */
+
+import type { NativeChain } from './chains.js';
+
+/** Chains the CoinPay web-wallet API accepts AND this extension can sign. */
+export type PayChain =
+  | 'BTC'
+  | 'BCH'
+  | 'ETH'
+  | 'POL'
+  | 'SOL'
+  | 'USDC_ETH'
+  | 'USDC_POL'
+  | 'USDC_SOL'
+  | 'USDT_ETH'
+  | 'USDT_POL'
+  | 'USDT_SOL';
+
+export const PAY_CHAINS: readonly PayChain[] = [
+  'BTC',
+  'BCH',
+  'ETH',
+  'POL',
+  'SOL',
+  'USDC_ETH',
+  'USDC_POL',
+  'USDC_SOL',
+  'USDT_ETH',
+  'USDT_POL',
+  'USDT_SOL',
+];
+
+export function isPayChain(value: string): value is PayChain {
+  return (PAY_CHAINS as readonly string[]).includes(value);
+}
+
+/**
+ * Which derived key signs for this chain. Tokens have no key of their own —
+ * they ride on the base chain's address (USDC_POL → the EVM key, USDC_SOL →
+ * the Solana key), matching `CHAINS[*].tokens` in chains.ts.
+ */
+const SIGNING_CHAIN: Record<PayChain, NativeChain> = {
+  BTC: 'BTC',
+  BCH: 'BCH',
+  ETH: 'ETH',
+  POL: 'POL',
+  SOL: 'SOL',
+  USDC_ETH: 'ETH',
+  USDC_POL: 'POL',
+  USDC_SOL: 'SOL',
+  USDT_ETH: 'ETH',
+  USDT_POL: 'POL',
+  USDT_SOL: 'SOL',
+};
+
+export function signingChain(chain: PayChain): NativeChain {
+  return SIGNING_CHAIN[chain];
+}
+
+/**
+ * Transactions on the same chain must be prepared and broadcast one at a time
+ * (an EVM nonce or a BTC UTXO set only advances once the previous tx is out).
+ * ETH and USDC_ETH share an account, so they share a queue — this key is what
+ * the batch runner serializes on.
+ */
+export function nonceQueueKey(chain: PayChain): NativeChain {
+  const signer = SIGNING_CHAIN[chain];
+  // POL and ETH are distinct networks with independent nonces despite the
+  // shared address, so the signing chain is already the right granularity.
+  return signer;
+}
+
+/**
+ * Normalize a wire currency code to a `PayChain`.
+ *
+ * Accepts what CoinPay payment records use (`usdc_pol`, `btc`), plain tickers
+ * (`USDC`, `MATIC`), and already-normalized chains (`USDC_POL`).
+ * Returns null for anything this extension cannot sign — the caller surfaces
+ * that as a skipped payment rather than guessing a chain.
+ */
+export function toPayChain(value: string | null | undefined): PayChain | null {
+  const normalized = (value || '').trim().toUpperCase().replace(/[\s-]+/g, '_');
+  if (!normalized) return null;
+  if (isPayChain(normalized)) return normalized;
+
+  switch (normalized) {
+    case 'MATIC':
+      return 'POL';
+    // Bare `USDC`/`USDT` are ambiguous across chains. CoinPay's own
+    // `preferredCoinToPaymentCurrency` resolves bare USDC to Solana, so we
+    // match that rather than inventing a different default.
+    case 'USDC':
+      return 'USDC_SOL';
+    case 'USDT':
+      return 'USDT_SOL';
+    default:
+      return null;
+  }
+}
+
+/** Display label for the approval screen. */
+export function payChainLabel(chain: PayChain): string {
+  switch (chain) {
+    case 'BTC':
+      return 'Bitcoin';
+    case 'BCH':
+      return 'Bitcoin Cash';
+    case 'ETH':
+      return 'Ethereum';
+    case 'POL':
+      return 'Polygon';
+    case 'SOL':
+      return 'Solana';
+    case 'USDC_ETH':
+      return 'USDC on Ethereum';
+    case 'USDC_POL':
+      return 'USDC on Polygon';
+    case 'USDC_SOL':
+      return 'USDC on Solana';
+    case 'USDT_ETH':
+      return 'USDT on Ethereum';
+    case 'USDT_POL':
+      return 'USDT on Polygon';
+    case 'USDT_SOL':
+      return 'USDT on Solana';
+  }
+}

--- a/packages/extension/src/core/private-keys.ts
+++ b/packages/extension/src/core/private-keys.ts
@@ -1,0 +1,102 @@
+/**
+ * Private-key derivation for signing (PRD §9: background context only).
+ *
+ * `derivation.ts` gets ADDRESSES from the audited `@profullstack/coinpay` SDK,
+ * but the SDK deliberately keeps private keys internal — it exports
+ * `deriveAddress`, not `deriveKeyPair`. To sign we need the key itself, so this
+ * module reimplements the SDK's derivation recipe verbatim:
+ *
+ *   secp256k1 (BTC/BCH/ETH/POL) — BIP32 via @scure/bip32, path
+ *                                 m/44'/<coinType>'/0'/0/<index>
+ *   ed25519   (SOL)             — SLIP-0010, path m/44'/501'/<index>'/0'
+ *
+ * "Verbatim" is not taken on faith: `__tests__/private-keys.test.ts` derives a
+ * key here, computes its address, and asserts it equals the SDK's
+ * `deriveAddress()` for the same seed/chain/index. If the SDK ever changes its
+ * paths, that test fails rather than this signing with a key whose funds live
+ * at a different address.
+ *
+ * Callers MUST zero the returned bytes once signing is done (`clearMemory`).
+ */
+
+import { HDKey } from '@scure/bip32';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha512 } from '@noble/hashes/sha2.js';
+
+import type { NativeChain } from './chains.js';
+
+/** BIP-44 coin types — copied from the SDK's COIN_TYPES table. */
+const COIN_TYPES: Record<NativeChain, number> = {
+  BTC: 0,
+  BCH: 145,
+  ETH: 60,
+  POL: 60, // EVM: shares the ETH path (and therefore the ETH address)
+  SOL: 501,
+};
+
+/** The SDK's `getDerivationPath()` for the chains this extension derives. */
+export function derivationPath(chain: NativeChain, index = 0): string {
+  const coinType = COIN_TYPES[chain];
+  if (chain === 'SOL') return `m/44'/${coinType}'/${index}'/0'`;
+  return `m/44'/${coinType}'/0'/0/${index}`;
+}
+
+/**
+ * SLIP-0010 ed25519 derivation (Solana). Only hardened segments are legal on
+ * ed25519 — a non-hardened path is a programming error, not user input.
+ */
+function deriveEd25519Key(seed: Uint8Array, path: string): Uint8Array {
+  const master = hmac(sha512, new TextEncoder().encode('ed25519 seed'), seed);
+  let key = master.slice(0, 32);
+  let chainCode = master.slice(32);
+
+  for (const segment of path.replace(/^m\//, '').split('/')) {
+    if (!segment.endsWith("'")) {
+      throw new Error('SLIP-0010 ed25519 only supports hardened derivation');
+    }
+    const index = Number.parseInt(segment.slice(0, -1), 10);
+    const hardened = (index | 0x80000000) >>> 0;
+
+    // data = 0x00 || key || ser32(hardened index)
+    const data = new Uint8Array(1 + 32 + 4);
+    data[0] = 0x00;
+    data.set(key, 1);
+    data[33] = (hardened >> 24) & 0xff;
+    data[34] = (hardened >> 16) & 0xff;
+    data[35] = (hardened >> 8) & 0xff;
+    data[36] = hardened & 0xff;
+
+    const derived = hmac(sha512, chainCode, data);
+    key = derived.slice(0, 32);
+    chainCode = derived.slice(32);
+  }
+
+  return key;
+}
+
+/** Derive the raw signing key for a chain. Caller must zero it after use. */
+export function derivePrivateKey(seed: Uint8Array, chain: NativeChain, index = 0): Uint8Array {
+  const path = derivationPath(chain, index);
+
+  if (chain === 'SOL') {
+    return deriveEd25519Key(seed, path);
+  }
+
+  const derived = HDKey.fromMasterSeed(seed).derive(path);
+  if (!derived.privateKey) {
+    throw new Error(`Failed to derive private key for ${chain}`);
+  }
+  // Copy: the HDKey instance is garbage after this call and we want a buffer we
+  // own and can zero.
+  return Uint8Array.from(derived.privateKey);
+}
+
+/** Hex form expected by `signTransaction({ privateKey })`. */
+export function derivePrivateKeyHex(seed: Uint8Array, chain: NativeChain, index = 0): string {
+  const key = derivePrivateKey(seed, chain, index);
+  try {
+    return Array.from(key, (b) => b.toString(16).padStart(2, '0')).join('');
+  } finally {
+    key.fill(0);
+  }
+}

--- a/packages/extension/src/inpage/__tests__/provider.test.ts
+++ b/packages/extension/src/inpage/__tests__/provider.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * `window.coinpay` is the API integrators code against, so its contract has to
+ * hold: requests correlate to their own responses, rejections surface as thrown
+ * errors, progress reaches subscribers, and the object cannot be tampered with
+ * by other page scripts.
+ *
+ * The provider installs itself once per window with `configurable: false` (so a
+ * page script cannot swap in a look-alike that redirects payments). That is
+ * exactly why this file imports it ONCE and shares it across tests — a
+ * per-test reload would be impossible, which is the property being defended.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const CHANNEL_REQUEST = 'coinpay:page-request';
+const CHANNEL_RESPONSE = 'coinpay:page-response';
+const CHANNEL_EVENT = 'coinpay:page-event';
+
+let posted: any[] = [];
+let coinpay: any;
+let sawInitEvent = false;
+
+beforeAll(async () => {
+  // Must be listening before the module evaluates to catch its ready signal.
+  window.addEventListener('coinpay#initialized', () => {
+    sawInitEvent = true;
+  });
+  vi.spyOn(window, 'postMessage').mockImplementation((message: any) => {
+    posted.push(message);
+  });
+
+  await import('../provider.js');
+  coinpay = (window as any).coinpay;
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  posted = [];
+});
+
+/** Answer the most recent outbound request as the content script would. */
+function respond(result: unknown, error?: string): void {
+  respondTo(posted.at(-1).requestId, result, error);
+}
+
+function respondTo(requestId: string, result: unknown, error?: string): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { channel: CHANNEL_RESPONSE, requestId, result, error },
+      source: window,
+    }),
+  );
+}
+
+function emitProgress(progress: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { channel: CHANNEL_EVENT, event: { type: 'coinpay:progress', progress } },
+      source: window,
+    }),
+  );
+}
+
+describe('provider surface', () => {
+  it('advertises itself so pages can feature-detect', () => {
+    expect(coinpay.isCoinPay).toBe(true);
+    expect(typeof coinpay.version).toBe('string');
+  });
+
+  it('announces readiness for pages that loaded before the extension', () => {
+    expect(sawInitEvent).toBe(true);
+  });
+
+  it('is frozen and non-configurable so page scripts cannot swap it out', () => {
+    // A replaceable provider could silently redirect every payment.
+    expect(Object.isFrozen(coinpay)).toBe(true);
+    expect(() => {
+      (window as any).coinpay = { isCoinPay: true, payBatch: () => {} };
+    }).toThrow();
+    expect(() => delete (window as any).coinpay).toThrow();
+    expect((window as any).coinpay).toBe(coinpay);
+  });
+
+  it('cannot have its methods replaced', () => {
+    expect(() => {
+      coinpay.payBatch = () => Promise.resolve({ results: [] });
+    }).toThrow();
+  });
+});
+
+describe('request/response', () => {
+  it('sends a typed request on the page-request channel', async () => {
+    const promise = coinpay.getState();
+
+    expect(posted.at(-1)).toMatchObject({
+      channel: CHANNEL_REQUEST,
+      payload: { type: 'site:getState' },
+    });
+    expect(typeof posted.at(-1).requestId).toBe('string');
+
+    respond({});
+    await promise;
+  });
+
+  it('resolves with the relayed result', async () => {
+    const promise = coinpay.connect();
+    respond({ accounts: [{ chain: 'ETH', address: '0xabc', tokens: ['USDC'] }] });
+
+    await expect(promise).resolves.toEqual({
+      accounts: [{ chain: 'ETH', address: '0xabc', tokens: ['USDC'] }],
+    });
+  });
+
+  it('rejects with the relayed error', async () => {
+    const promise = coinpay.connect();
+    respond(undefined, 'Connection rejected');
+
+    await expect(promise).rejects.toThrow('Connection rejected');
+  });
+
+  it('correlates concurrent requests to their own responses', async () => {
+    const first = coinpay.getState();
+    const firstId = posted.at(-1).requestId;
+    const second = coinpay.getAccounts();
+    const secondId = posted.at(-1).requestId;
+
+    expect(firstId).not.toBe(secondId);
+
+    // Answer out of order — a mix-up would resolve the wrong promise.
+    respondTo(secondId, { accounts: [] });
+    respondTo(firstId, { connected: true });
+
+    await expect(second).resolves.toEqual({ accounts: [] });
+    await expect(first).resolves.toEqual({ connected: true });
+  });
+
+  it('ignores responses from another window', async () => {
+    const promise = coinpay.getState();
+    const requestId = posted.at(-1).requestId;
+    const settled = vi.fn();
+    promise.then(settled, settled);
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: CHANNEL_RESPONSE, requestId, result: {} },
+        source: null, // not this window
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(settled).not.toHaveBeenCalled();
+    respondTo(requestId, {}); // clean up the pending promise
+    await promise;
+  });
+
+  it('ignores an unknown requestId without crashing', () => {
+    expect(() => respondTo('never-sent', {})).not.toThrow();
+  });
+
+  it('ignores malformed and unrelated messages', () => {
+    expect(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: null, source: window }));
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { channel: 'other' }, source: window }),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe('payBatch', () => {
+  const payments = [{ id: 'inv-1', chain: 'usdc_pol', to: '0xabc', amount: '10' }];
+
+  it('sends the payments through and resolves with per-item results', async () => {
+    const promise = coinpay.payBatch(payments);
+
+    expect(posted.at(-1).payload).toEqual({ type: 'site:payBatch', payments });
+
+    respond({ results: [{ id: 'inv-1', status: 'sent', txHash: '0xhash' }] });
+    await expect(promise).resolves.toEqual({
+      results: [{ id: 'inv-1', status: 'sent', txHash: '0xhash' }],
+    });
+  });
+
+  it('resolves — not rejects — when some payments failed', async () => {
+    // Partial success is the documented contract; rejecting here would make
+    // callers discard the successful transactions.
+    const promise = coinpay.payBatch(payments);
+    respond({
+      results: [
+        { id: 'inv-1', status: 'sent', txHash: '0x1' },
+        { id: 'inv-2', status: 'failed', error: 'Insufficient funds' },
+      ],
+    });
+
+    const { results } = await promise;
+    expect(results.map((r: any) => r.status)).toEqual(['sent', 'failed']);
+  });
+
+  it('delivers progress to the onProgress callback', async () => {
+    const onProgress = vi.fn();
+    const promise = coinpay.payBatch(payments, { onProgress });
+
+    emitProgress({ id: 'inv-1', stage: 'broadcasting', completed: 0, total: 1 });
+    emitProgress({ id: 'inv-1', stage: 'sent', completed: 1, total: 1 });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stage: 'sent', completed: 1 }),
+    );
+
+    respond({ results: [] });
+    await promise;
+  });
+
+  it('unsubscribes onProgress once the batch settles', async () => {
+    const onProgress = vi.fn();
+    const promise = coinpay.payBatch(payments, { onProgress });
+    respond({ results: [] });
+    await promise;
+    onProgress.mockClear();
+
+    emitProgress({ id: 'inv-1', stage: 'sent', completed: 1, total: 1 });
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes onProgress even when the batch is rejected', async () => {
+    const onProgress = vi.fn();
+    const promise = coinpay.payBatch(payments, { onProgress });
+    respond(undefined, 'Payment request rejected');
+    await expect(promise).rejects.toThrow();
+    onProgress.mockClear();
+
+    emitProgress({ id: 'inv-1', stage: 'sent', completed: 1, total: 1 });
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('does not let a throwing listener break delivery to the others', async () => {
+    const good = vi.fn();
+    const offBad = coinpay.onProgress(() => {
+      throw new Error('page bug');
+    });
+    const offGood = coinpay.onProgress(good);
+
+    expect(() => emitProgress({ id: 'inv-1', stage: 'sent', completed: 1, total: 1 })).not.toThrow();
+    expect(good).toHaveBeenCalled();
+
+    offBad();
+    offGood();
+  });
+});
+
+describe('onProgress subscription', () => {
+  it('returns an unsubscribe function', () => {
+    const listener = vi.fn();
+    const off = coinpay.onProgress(listener);
+
+    emitProgress({ id: 'a', stage: 'sent', completed: 1, total: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    off();
+    emitProgress({ id: 'a', stage: 'sent', completed: 1, total: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/extension/src/inpage/provider.ts
+++ b/packages/extension/src/inpage/provider.ts
@@ -1,0 +1,147 @@
+/**
+ * `window.coinpay` — the page-facing provider.
+ *
+ * Runs in the PAGE's world, so it is fully untrusted: it holds no keys, no
+ * state, and no authority. Everything it does is a postMessage to the content
+ * script, which relays to the background worker, which decides. The page cannot
+ * spoof its origin (the browser stamps it) and cannot move funds without the
+ * user approving in the extension's own window.
+ *
+ * Usage:
+ *   await window.coinpay.connect()
+ *   const { results } = await window.coinpay.payBatch(payments, {
+ *     onProgress: (p) => render(p),
+ *   })
+ */
+
+const CHANNEL_REQUEST = 'coinpay:page-request';
+const CHANNEL_RESPONSE = 'coinpay:page-response';
+const CHANNEL_EVENT = 'coinpay:page-event';
+
+export interface CoinPayPayment {
+  /** Your correlation id — echoed back on the matching result. */
+  id: string;
+  /** BTC | BCH | ETH | POL | SOL | USDC_ETH | USDC_POL | USDC_SOL | USDT_* */
+  chain: string;
+  to: string;
+  /** Decimal string in the chain's display units. */
+  amount: string;
+  label?: string;
+  amountUsd?: number;
+}
+
+export interface CoinPayPaymentResult {
+  id: string;
+  chain: string;
+  to: string;
+  amount: string;
+  status: 'sent' | 'failed' | 'skipped';
+  txHash?: string;
+  explorerUrl?: string;
+  error?: string;
+}
+
+export interface CoinPayProgress {
+  id: string;
+  stage: 'queued' | 'preparing' | 'signing' | 'broadcasting' | 'sent' | 'failed' | 'skipped';
+  txHash?: string;
+  explorerUrl?: string;
+  error?: string;
+  completed: number;
+  total: number;
+}
+
+type Pending = { resolve: (value: any) => void; reject: (error: Error) => void };
+
+const pending = new Map<string, Pending>();
+const progressListeners = new Set<(progress: CoinPayProgress) => void>();
+let counter = 0;
+
+function send<T>(payload: Record<string, unknown>): Promise<T> {
+  const requestId = `cp-${Date.now()}-${++counter}`;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(requestId, { resolve, reject });
+    window.postMessage({ channel: CHANNEL_REQUEST, requestId, payload }, window.location.origin);
+  });
+}
+
+window.addEventListener('message', (event: MessageEvent) => {
+  // Only trust messages this window posted to itself (i.e. from our own content
+  // script), never anything arriving from a frame or another origin.
+  if (event.source !== window) return;
+  const data = event.data as Record<string, any> | null;
+  if (!data) return;
+
+  if (data.channel === CHANNEL_RESPONSE) {
+    const entry = pending.get(data.requestId);
+    if (!entry) return;
+    pending.delete(data.requestId);
+    if (data.error) entry.reject(new Error(String(data.error)));
+    else entry.resolve(data.result);
+    return;
+  }
+
+  if (data.channel === CHANNEL_EVENT && data.event?.type === 'coinpay:progress') {
+    for (const listener of progressListeners) {
+      try {
+        listener(data.event.progress as CoinPayProgress);
+      } catch {
+        // A broken page listener must not break the run.
+      }
+    }
+  }
+});
+
+const provider = {
+  isCoinPay: true as const,
+  version: '0.1.0',
+
+  /** Wallet presence/lock/connection state. Safe to call before connecting. */
+  getState(): Promise<{ initialized: boolean; unlocked: boolean; connected: boolean }> {
+    return send({ type: 'site:getState' });
+  },
+
+  /**
+   * Ask the user to connect this site. Resolves with the wallet's public
+   * addresses; rejects if the user declines.
+   */
+  connect(): Promise<{ accounts: { chain: string; address: string; tokens: string[] }[] }> {
+    return send({ type: 'site:connect' });
+  },
+
+  getAccounts(): Promise<{ accounts: { chain: string; address: string; tokens: string[] }[] }> {
+    return send({ type: 'site:getAccounts' });
+  },
+
+  /**
+   * Request a batch of payments. Opens ONE approval window listing them all.
+   *
+   * Resolves after every payment reaches a terminal state — including when some
+   * fail: inspect `status` per result rather than assuming all-or-nothing.
+   * Rejects only if the user declines or the batch never starts.
+   */
+  async payBatch(
+    payments: CoinPayPayment[],
+    options: { onProgress?: (progress: CoinPayProgress) => void } = {},
+  ): Promise<{ results: CoinPayPaymentResult[] }> {
+    if (options.onProgress) progressListeners.add(options.onProgress);
+    try {
+      return await send({ type: 'site:payBatch', payments });
+    } finally {
+      if (options.onProgress) progressListeners.delete(options.onProgress);
+    }
+  },
+
+  /** Subscribe to progress independently of a `payBatch` call. */
+  onProgress(listener: (progress: CoinPayProgress) => void): () => void {
+    progressListeners.add(listener);
+    return () => progressListeners.delete(listener);
+  },
+};
+
+Object.defineProperty(window, 'coinpay', { value: Object.freeze(provider), configurable: false });
+
+// Let pages that loaded before the extension know the provider is now live.
+window.dispatchEvent(new Event('coinpay#initialized'));
+
+export type CoinPayProvider = typeof provider;

--- a/packages/extension/src/messages.ts
+++ b/packages/extension/src/messages.ts
@@ -1,12 +1,22 @@
 /**
- * Message protocol between the popup/content contexts and the background
- * service worker. All signing/seed access happens in the background only
- * (PRD §9); the popup never touches key material directly.
+ * Message protocol between the popup / content / approval contexts and the
+ * background service worker. All signing/seed access happens in the background
+ * only (PRD §9); no other context touches key material directly.
+ *
+ * Three families, distinguished by prefix:
+ *   (none)     — popup ↔ background wallet lifecycle. Trusted context.
+ *   `site:`    — web page ↔ background, relayed by the content script. UNTRUSTED:
+ *                the background stamps the real origin from `sender` and never
+ *                takes the page's word for it.
+ *   `approval:`— the approval window ↔ background, resolving a pending request.
  */
 
 import type { DerivedAddress } from './core/derivation.js';
+import type { BatchPaymentRequest, BatchItemResult, BatchProgress } from './core/batch.js';
+import type { SiteConnection } from './core/connections.js';
 
 export type WalletRequest =
+  // ── popup: wallet lifecycle ──
   | { type: 'getState' }
   | { type: 'beginCreate'; words?: 12 | 24 }
   | { type: 'confirmCreate'; password: string }
@@ -14,15 +24,64 @@ export type WalletRequest =
   | { type: 'import'; mnemonic: string; password: string }
   | { type: 'unlock'; password: string }
   | { type: 'lock' }
-  | { type: 'getAccounts' };
+  | { type: 'getAccounts' }
+  | { type: 'listConnections' }
+  | { type: 'disconnectSite'; origin: string }
+  // ── page (via content script) ──
+  | { type: 'site:getState' }
+  | { type: 'site:connect' }
+  | { type: 'site:getAccounts' }
+  | { type: 'site:payBatch'; payments: BatchPaymentRequest[] }
+  // ── approval window ──
+  | { type: 'approval:get'; requestId: string }
+  | { type: 'approval:approve'; requestId: string; password?: string }
+  | { type: 'approval:reject'; requestId: string }
+  | { type: 'approval:cancel'; requestId: string };
 
 export interface WalletState {
   initialized: boolean;
   unlocked: boolean;
 }
 
+/** What a page may learn about the wallet before connecting. */
+export interface SiteState extends WalletState {
+  connected: boolean;
+}
+
+/** A request parked while the approval window is open. */
+export type PendingApproval =
+  | {
+      kind: 'connect';
+      requestId: string;
+      origin: string;
+      /** True when the wallet must be unlocked before approving. */
+      needsUnlock: boolean;
+    }
+  | {
+      kind: 'payBatch';
+      requestId: string;
+      origin: string;
+      needsUnlock: boolean;
+      payments: BatchPaymentRequest[];
+      summary: { chain: string; count: number; total: string; totalUsd: number }[];
+    };
+
 export type WalletResponse =
   | { ok: true; state: WalletState }
+  | { ok: true; siteState: SiteState }
   | { ok: true; accounts: DerivedAddress[] }
   | { ok: true; mnemonic: string; accounts: DerivedAddress[] }
+  | { ok: true; connections: SiteConnection[] }
+  | { ok: true; approval: PendingApproval }
+  | { ok: true; results: BatchItemResult[] }
+  | { ok: true }
   | { ok: false; error: string };
+
+/**
+ * Background → other contexts, pushed rather than requested.
+ * `coinpay:progress` also reaches the page: the content script forwards it so a
+ * 62-payment run can render live instead of blocking on one long promise.
+ */
+export type WalletEvent =
+  | { type: 'coinpay:progress'; requestId: string; origin: string; progress: BatchProgress }
+  | { type: 'coinpay:approvalResolved'; requestId: string };

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
-    "types": ["chrome"],
+    "types": ["chrome", "node"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -13,18 +13,23 @@ const target = process.env.TARGET === 'firefox' ? 'firefox' : 'chrome';
  * Copy the non-bundled extension assets into dist after the JS build:
  *   - manifest/manifest.<target>.json -> dist/manifest.json
  *   - src/popup/index.html            -> dist/popup/index.html
+ *   - src/approval/index.html         -> dist/approval/index.html
  *   - public/icons/*                  -> dist/icons/*
  *
- * The popup HTML references `./main.js`; the build below emits `popup/main.js`,
- * and the manifest references `background/index.js` — both stable, unhashed.
+ * The popup/approval HTML reference `./main.js`; the build below emits
+ * `popup/main.js` and `approval/main.js`, and the manifest references
+ * `background/index.js`, `content/bridge.js` and `inpage/provider.js` — all
+ * stable and unhashed.
  */
 function copyExtensionAssets() {
   return {
     name: 'copy-extension-assets',
     closeBundle() {
       copyFileSync(resolve(root, `manifest/manifest.${target}.json`), resolve(outDir, 'manifest.json'));
-      mkdirSync(resolve(outDir, 'popup'), { recursive: true });
-      copyFileSync(resolve(root, 'src/popup/index.html'), resolve(outDir, 'popup/index.html'));
+      for (const page of ['popup', 'approval']) {
+        mkdirSync(resolve(outDir, page), { recursive: true });
+        copyFileSync(resolve(root, `src/${page}/index.html`), resolve(outDir, `${page}/index.html`));
+      }
       cpSync(resolve(root, 'public/icons'), resolve(outDir, 'icons'), { recursive: true });
       // eslint-disable-next-line no-console
       console.log(`\n[extension] assembled dist/ for target=${target}`);
@@ -45,6 +50,13 @@ export default defineConfig({
       input: {
         'background/index': resolve(root, 'src/background/index.ts'),
         'popup/main': resolve(root, 'src/popup/main.ts'),
+        'approval/main': resolve(root, 'src/approval/main.ts'),
+        // The content script is loaded as a CLASSIC script (MV3 does not
+        // support `type: module` content scripts), so it must stay
+        // import-free — enforced by src/__tests__/packaging.test.ts.
+        'content/bridge': resolve(root, 'src/content/bridge.ts'),
+        // Injected into the page with `<script type="module">`, so ESM is fine.
+        'inpage/provider': resolve(root, 'src/inpage/provider.ts'),
       },
       output: {
         format: 'es',
@@ -52,6 +64,7 @@ export default defineConfig({
         chunkFileNames: 'chunks/[name].js',
         assetFileNames: 'assets/[name][extname]',
       },
+      preserveEntrySignatures: 'allow-extension',
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@profullstack/autoblog':
         specifier: github:profullstack/autoblog#75e54af
-        version: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af
+        version: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af77cbcf61dbd90fb3ed529c1b2dad1ed6f
       '@profullstack/coinpay':
         specifier: workspace:*
         version: link:packages/sdk
@@ -304,6 +304,9 @@ importers:
       '@profullstack/coinpay':
         specifier: workspace:*
         version: link:../sdk
+      '@scure/bip32':
+        specifier: ^1.5.0
+        version: 1.7.0
       '@scure/bip39':
         specifier: ^1.4.0
         version: 1.6.0
@@ -314,6 +317,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.300
         version: 0.0.300
+      jsdom:
+        specifier: ^23.2.0
+        version: 23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -322,7 +328,7 @@ importers:
         version: 8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/sdk:
     dependencies:
@@ -350,7 +356,7 @@ importers:
         version: 3.6.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1(vitest@4.1.0))(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -1934,8 +1940,8 @@ packages:
   '@posthog/types@1.381.0':
     resolution: {integrity: sha512-AW68BovKFCNbPdq3VjOzfQeSQRYMvQVv+46LDywWFXO/oOTXFKwjY92FaJQSTXWgTNgDpqigCw3yUFDinK3hZA==}
 
-  '@profullstack/autoblog@https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af':
-    resolution: {tarball: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af}
+  '@profullstack/autoblog@https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af77cbcf61dbd90fb3ed529c1b2dad1ed6f':
+    resolution: {tarball: https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af77cbcf61dbd90fb3ed529c1b2dad1ed6f}
     version: 0.4.0
     engines: {node: '>=18'}
 
@@ -8678,11 +8684,6 @@ snapshots:
       '@noble/hashes': 1.8.0
     optional: true
 
-  '@exodus/bytes@1.15.1(@noble/hashes@2.0.1)':
-    optionalDependencies:
-      '@noble/hashes': 2.0.1
-    optional: true
-
   '@fivebinaries/coin-selection@3.0.0':
     dependencies:
       '@emurgo/cardano-serialization-lib-browser': 13.2.1
@@ -9706,7 +9707,7 @@ snapshots:
 
   '@posthog/types@1.381.0': {}
 
-  '@profullstack/autoblog@https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af': {}
+  '@profullstack/autoblog@https://codeload.github.com/profullstack/autoblog/tar.gz/75e54af77cbcf61dbd90fb3ed529c1b2dad1ed6f': {}
 
   '@profullstack/emailer@1.0.1': {}
 
@@ -13590,14 +13591,6 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  data-urls@7.0.0(@noble/hashes@2.0.1):
-    dependencies:
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
-
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -14039,7 +14032,7 @@ snapshots:
       eslint: 9.39.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@1.21.7))
@@ -14072,7 +14065,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -14087,7 +14080,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14709,13 +14702,6 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
-    dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
-
   html-escaper@2.0.2: {}
 
   html2canvas@1.4.1:
@@ -15217,33 +15203,6 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
       whatwg-url: 16.0.1(@noble/hashes@1.8.0)
-      xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
-
-  jsdom@29.1.1(@noble/hashes@2.0.1):
-    dependencies:
-      '@asamuzakjp/css-color': 5.1.11
-      '@asamuzakjp/dom-selector': 7.1.1
-      '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
-      css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@2.0.1)
-      decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
-      is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.2
-      parse5: 8.0.1
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 6.0.2
-      undici: 7.28.0
-      w3c-xmlserializer: 5.0.0
-      webidl-conversions: 8.0.1
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -17630,7 +17589,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1(vitest@4.1.0))(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -17660,7 +17619,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/ui@1.6.1)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.10(@types/node@20.19.43)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -17686,7 +17645,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.43
       '@vitest/ui': 1.6.1(vitest@4.1.0)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - msw
 
@@ -17741,15 +17700,6 @@ snapshots:
   whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
-      tr46: 6.0.0
-      webidl-conversions: 8.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
-
-  whatwg-url@16.0.1(@noble/hashes@2.0.1):
-    dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
Adds the page-to-chain payment path to the wallet extension, which previously had a vault, address derivation, and a signer — but no way for a web page to reach any of it.

**Why:** paying a payables queue one invoice at a time (62 accepted invoices on ugig.net) is roughly an hour of clicking. This collapses it into one approval.

```js
await window.coinpay.connect();
const { results } = await window.coinpay.payBatch(payments, { onProgress });
```

## What's here

- **`window.coinpay` provider + content-script bridge.** The bridge relays only `site:` messages, so a page cannot invoke popup or approval requests (e.g. `approval:approve`). The background stamps the true origin from `sender` rather than trusting the page.
- **Per-origin `ConnectionStore`.** Connecting grants read access to public addresses and the right to *ask*; every batch still opens its own approval window listing all recipients and per-chain totals.
- **`core/batch.ts`** — the batch runner. Partial success is the contract: one failure never cancels the rest.
- **`core/api.ts`** — reuses the portal's existing `prepare-tx`/`broadcast` endpoints instead of rebuilding RPC, UTXO and fee infrastructure inside a service worker. Registration via `/web-wallet/import` is non-custodial: public keys, addresses, and a proof signature. **The seed is never sent.**
- **`core/private-keys.ts`** — the SDK exports `deriveAddress` but keeps private keys internal.
- **Approval window** showing every recipient, which then becomes the live progress view.

## Ordering drove the design

Transactions on the same account must go one at a time, because the server derives chain state per `prepare-tx`:

| chain | state read | hazard if parallel |
|---|---|---|
| EVM | `eth_getTransactionCount(from,'pending')` | both get the same nonce; the second **replaces** the first |
| BTC/BCH | whole UTXO set spent, one change output | next tx builds from already-spent inputs |

So payments are grouped into per-account queues. Queues run concurrently (Solana never waits on Polygon), but within a queue it is strictly prepare → sign → broadcast → settle → next, with retries on transient chain-state errors (`nonce too low`, `missingorspent`) and immediate failure on terminal ones like insufficient funds.

## Tests — 155 pass

The riskiest piece is guarded directly: `private-keys.test.ts` derives each key, independently recomputes its address, and asserts it equals the SDK's `deriveAddress()` on all five chains — so a divergence fails the build instead of signing with a key that controls a different address.

Also covered: the API auth format (verified against a byte-for-byte copy of the server's verifier), the batch runner's ordering/retry/partial-success behaviour, request validation from untrusted pages, the content bridge's `site:`-only filter, the provider's request correlation, and manifest/packaging invariants.

## Notes for review

- Adding `"node"` to `tsconfig` types drops **pre-existing** type errors from 157 to 31; the remainder are pre-existing in `signing.ts` and the imported web-wallet reference.
- `pnpm-lock.yaml` includes some unrelated pnpm normalization (autoblog tarball hash expansion, vitest peer strings) — that is what a clean `pnpm install` produces on the current pnpm, not a hand edit.
- I could not load the extension in a browser or move real funds in this environment, so the on-chain path is covered by unit and contract tests rather than an actual transaction. Worth a small real run (2–3 invoices) before heavy use.

Docs: `docs/BULK_PAYMENTS.md`
Pairs with: profullstack/ugig.net `feat/bulk-invoice-payments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)