### PR TITLE
fix(x402): key Stripe settlement by PaymentIntent ID

### DIFF
--- a/src/app/api/x402/settle/route.test.ts
+++ b/src/app/api/x402/settle/route.test.ts
@@ -337,5 +337,6 @@ describe('POST /api/x402/settle', () => {
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.details).toContain('Stripe not configured');
+    expect(mockEq).toHaveBeenCalledWith('unique_key', 'pi_test123');
   });
 });

--- a/src/app/api/x402/settle/route.ts
+++ b/src/app/api/x402/settle/route.ts
@@ -202,7 +202,12 @@ export async function POST(request: NextRequest) {
     }
 
     const { network, scheme } = payment.payload;
-    const uniqueKey = payment.payload.nonce || payment.payload.txId || payment.payload.txSignature || payment.payload.preimage;
+    const uniqueKey =
+      payment.payload.nonce ||
+      payment.payload.txId ||
+      payment.payload.txSignature ||
+      payment.payload.preimage ||
+      payment.payload.paymentIntentId;
 
     // Find the verified payment record
     const query = supabase


### PR DESCRIPTION
## Summary

- include Stripe `paymentIntentId` in the x402 settlement lookup key
- keep the settlement record tied to the payment verified earlier
- add regression coverage for the Stripe query

Fixes #192

## Testing

- `pnpm exec vitest run src/app/api/x402/settle/route.test.ts` — 13 tests passed
- `pnpm type-check`
- `git diff --check`