### PR TITLE
fix(swap): validate history pagination

### DIFF
--- a/src/app/api/swap/history/route.test.ts
+++ b/src/app/api/swap/history/route.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+const { rangeMock } = vi.hoisted(() => ({
+  rangeMock: vi.fn(),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            range: rangeMock,
+          })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+const walletId = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('GET /api/swap/history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rangeMock.mockResolvedValue({ data: [], error: null, count: 0 });
+  });
+
+  it.each(['abc', '-1', '0', '1.5', '1abc'])(
+    'falls back to the default limit for %s',
+    async (limit) => {
+      const request = new NextRequest(
+        `http://localhost/api/swap/history?walletId=${walletId}&limit=${limit}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(rangeMock).toHaveBeenCalledWith(0, 49);
+      expect(data.pagination.limit).toBe(50);
+    }
+  );
+
+  it.each(['abc', '-1', '1.5', '1abc'])(
+    'falls back to zero offset for %s',
+    async (offset) => {
+      const request = new NextRequest(
+        `http://localhost/api/swap/history?walletId=${walletId}&offset=${offset}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(rangeMock).toHaveBeenCalledWith(0, 49);
+      expect(data.pagination.offset).toBe(0);
+    }
+  );
+
+  it('clamps valid limits to 100', async () => {
+    const request = new NextRequest(
+      `http://localhost/api/swap/history?walletId=${walletId}&limit=101&offset=2`
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(rangeMock).toHaveBeenCalledWith(2, 101);
+    expect(data.pagination).toMatchObject({ limit: 100, offset: 2 });
+  });
+});

--- a/src/app/api/swap/history/route.ts
+++ b/src/app/api/swap/history/route.ts
@@ -19,14 +19,32 @@ function getSupabase() {
   );
 }
 
+function parsePaginationInteger(
+  value: string | null,
+  fallback: number,
+  minimum: number,
+  maximum?: number
+) {
+  if (value === null || !/^\d+$/.test(value)) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    return fallback;
+  }
+
+  return maximum === undefined ? parsed : Math.min(parsed, maximum);
+}
+
 export async function GET(request: NextRequest) {
   const supabase = getSupabase();
   try {
     const { searchParams } = new URL(request.url);
     const walletId = searchParams.get('walletId');
     const status = searchParams.get('status');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = parsePaginationInteger(searchParams.get('limit'), 50, 1, 100);
+    const offset = parsePaginationInteger(searchParams.get('offset'), 0, 0);
 
     if (!walletId) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

- strictly accept decimal integer pagination values for swap history
- fall back to `limit=50` and `offset=0` for malformed, partial, fractional, zero, or negative input
- preserve the documented 100-result limit cap
- add focused regression coverage for invalid values and clamping

## Validation

- 10 focused Vitest tests passed
- TypeScript typecheck passed
- `git diff --check` passed

Closes #195