### PR TITLE
chore(extension): version the store listing copy alongside the code

### DIFF
--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",

--- a/packages/extension/store-listing.json
+++ b/packages/extension/store-listing.json
@@ -1,0 +1,6 @@
+{
+  "name": "CoinPay Wallet",
+  "summary": "Non-custodial multi-chain wallet with one-click x402 payments and bulk payouts.",
+  "description": "CoinPay Wallet is a non-custodial, cross-browser (MV3) wallet for the CoinPay multi-chain platform.\n\n- Create or import a BIP-39 wallet. The seed is encrypted at rest (WebCrypto AES-256-GCM + PBKDF2) and never leaves your device; signing happens inside the extension's background worker, so private keys are never exposed to a web page.\n- Derives addresses for BTC, BCH, ETH, POL and SOL (with USDC on ETH/POL/SOL), matching the CoinPay web wallet.\n- Backup-confirmation gate before the wallet is usable, plus a configurable idle auto-lock.\n- One-click x402 (HTTP 402) payment approval for sites that request payment.\n- Bulk payouts: a site can request many payments at once via window.coinpay.payBatch and you approve the whole run once, with per-payment progress — built for payables queues like ugig.net's accepted-invoice list.\n- Sites connect per-origin and only after you approve the prompt.\n\nSource: https://github.com/profullstack/coinpayportal/tree/master/packages/extension",
+  "homepageUrl": "https://coinpayportal.com"
+}


### PR DESCRIPTION
The [tronbrowser.dev listing](https://tronbrowser.dev/store/extension.html?slug=coinpay-wallet) for CoinPay Wallet still advertises

> Phase 1 ships wallet + receive; send and one-click x402 payment approval land in subsequent updates.

Both shipped in #189. The bundle it serves is current — today's `extension-v0.1.0` release — but the store's publish flow only refreshes the bundle, so the copy stayed frozen at whatever it said the day the listing was created (`updated_at` is still 2026-07-07).

This adds `packages/extension/store-listing.json` so the text lives in the repo that actually knows what shipped, and can be synced on publish:

```bash
LISTING=packages/extension/store-listing.json ./scripts/publish-extension.sh
```

The `LISTING` step and the `PATCH` endpoint it calls are in profullstack/tronbrowser.dev#43 — that needs to land first. Owners can also now edit the copy directly from the extension's page on the store.

The description here is rewritten against what the extension actually does today: BIP-39 create/import with the seed encrypted at rest, signing confined to the background worker, BTC/BCH/ETH/POL/SOL (+USDC), backup gate and idle auto-lock, one-click x402 approval, and `payBatch` bulk payouts behind a single approval.

Follow-up not included here: `packages/extension/README.md` is stale the same way — it still says "Status — Phase 1 (wallet core) in progress".

🤖 Generated with [Claude Code](https://claude.com/claude-code)