### PR TITLE
fix(lightning): validate payment invoice input

### DIFF
--- a/src/app/api/lightning/lightning-routes.test.ts
+++ b/src/app/api/lightning/lightning-routes.test.ts
@@ -351,6 +351,27 @@ describe('Lightning Route Handlers', () => {
   });
 
   describe('POST /api/lightning/payments', () => {
+    it.each([123, {}, [], true, '   '])(
+      'should reject invalid bolt12 value %j before loading wallet keys',
+      async (bolt12) => {
+        const { POST } = await import('./payments/route');
+        const req = makeRequest('http://localhost:3000/api/lightning/payments', {
+          method: 'POST',
+          body: JSON.stringify({ wallet_id: 'w-1', bolt12 }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error.code).toBe('VALIDATION_ERROR');
+        expect(mockAuthenticateWalletRequest).not.toHaveBeenCalled();
+        expect(mockChain.select).not.toHaveBeenCalled();
+        expect(mockPayInvoice).not.toHaveBeenCalled();
+      }
+    );
+
     it('should reject unauthenticated payment requests before loading wallet keys', async () => {
       const { POST } = await import('./payments/route');
       mockAuthenticateWalletRequest.mockResolvedValue({

--- a/src/app/api/lightning/payments/route.ts
+++ b/src/app/api/lightning/payments/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
     if (!wallet_id) {
       return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');
     }
-    if (!bolt12) {
+    if (typeof bolt12 !== 'string' || !bolt12.trim()) {
       return WalletErrors.badRequest('VALIDATION_ERROR', 'bolt12 (invoice or lightning address) is required');
     }
 


### PR DESCRIPTION
## Summary

- requires `bolt12` to be a non-empty string before authentication and wallet access
- returns the existing 400 `VALIDATION_ERROR` response instead of throwing a TypeError
- prevents invalid client requests from reaching key lookup or LNbits payment processing
- adds regression coverage for numbers, objects, arrays, booleans, and whitespace-only strings

## Validation

- `vitest run src/app/api/lightning/lightning-routes.test.ts` (24 tests)
- `tsc --noEmit`
- `eslint src/app/api/lightning/payments/route.ts src/app/api/lightning/lightning-routes.test.ts`
- `git diff --check`

Closes #202