### PR TITLE
feat(extension): replace alert/confirm/prompt with <dialog>

### DIFF
--- a/packages/extension/src/popup/__tests__/dialog.test.ts
+++ b/packages/extension/src/popup/__tests__/dialog.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { dialogConfirm, dialogPrompt, dialogAlert } from '../dialog.js';
+
+const modal = () => document.querySelector('dialog.modal') as HTMLDialogElement | null;
+const buttonLabelled = (text: string) =>
+  [...document.querySelectorAll('dialog.modal button')].find((b) => b.textContent === text) as HTMLButtonElement;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('dialogConfirm', () => {
+  it('renders a <dialog> rather than calling window.confirm', async () => {
+    const pending = dialogConfirm({ title: 'Confirm payment', confirmLabel: 'Send' });
+    expect(modal()).not.toBeNull();
+    expect(modal()!.textContent).toContain('Confirm payment');
+
+    buttonLabelled('Send').click();
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('resolves false on cancel and cleans the dialog out of the DOM', async () => {
+    const pending = dialogConfirm({ title: 'Confirm payment' });
+    buttonLabelled('Cancel').click();
+    await expect(pending).resolves.toBe(false);
+    expect(modal()).toBeNull();
+  });
+
+  it('resolves false when dismissed with Esc (the dialog just fires close)', async () => {
+    const pending = dialogConfirm({ title: 'Confirm payment' });
+    modal()!.dispatchEvent(new Event('close'));
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('shows details as a list instead of cramming them into one string', async () => {
+    const pending = dialogConfirm({
+      title: 'Confirm payment',
+      details: [{ label: 'Amount', value: '1.5 ETH' }, { label: 'To', value: '0xabc' }],
+      confirmLabel: 'Send',
+    });
+    const text = modal()!.textContent ?? '';
+    expect(text).toContain('Amount');
+    expect(text).toContain('1.5 ETH');
+    expect(text).toContain('0xabc');
+    buttonLabelled('Send').click();
+    await pending;
+  });
+});
+
+describe('dialogPrompt', () => {
+  it('returns the trimmed input value', async () => {
+    const pending = dialogPrompt({ title: 'Rename account', confirmLabel: 'Rename' });
+    const input = document.querySelector('dialog.modal input') as HTMLInputElement;
+    input.value = '  Treasury  ';
+    buttonLabelled('Rename').click();
+    await expect(pending).resolves.toBe('Treasury');
+  });
+
+  it('prefills an existing value', async () => {
+    const pending = dialogPrompt({ title: 'Rename account', value: 'Account 2', confirmLabel: 'Rename' });
+    const input = document.querySelector('dialog.modal input') as HTMLInputElement;
+    expect(input.value).toBe('Account 2');
+    buttonLabelled('Cancel').click();
+    await pending;
+  });
+
+  it('returns null on cancel, and for an empty value', async () => {
+    const cancelled = dialogPrompt({ title: 'Add account' });
+    buttonLabelled('Cancel').click();
+    await expect(cancelled).resolves.toBeNull();
+
+    const blank = dialogPrompt({ title: 'Add account', confirmLabel: 'Add' });
+    buttonLabelled('Add').click();
+    await expect(blank).resolves.toBeNull();
+  });
+
+  it('submits on Enter', async () => {
+    const pending = dialogPrompt({ title: 'Add account' });
+    const input = document.querySelector('dialog.modal input') as HTMLInputElement;
+    input.value = 'Payouts';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    await expect(pending).resolves.toBe('Payouts');
+  });
+});
+
+describe('dialogAlert', () => {
+  it('resolves on OK and marks the error tone', async () => {
+    const pending = dialogAlert({ title: "Couldn't rename", message: 'boom', tone: 'error' });
+    expect(document.querySelector('dialog.modal .modal-title')!.classList).toContain('error');
+    buttonLabelled('OK').click();
+    await expect(pending).resolves.toBeUndefined();
+    expect(modal()).toBeNull();
+  });
+
+  it('only ever opens one dialog per call', async () => {
+    const pending = dialogAlert({ title: 'Sent' });
+    expect(document.querySelectorAll('dialog.modal')).toHaveLength(1);
+    buttonLabelled('OK').click();
+    await pending;
+    expect(document.querySelectorAll('dialog.modal')).toHaveLength(0);
+  });
+});

--- a/packages/extension/src/popup/app.ts
+++ b/packages/extension/src/popup/app.ts
@@ -15,6 +15,7 @@ import { pickIndices, makeChoices } from '../core/backup.js';
 import { call } from './rpc.js';
 import { el, mount, button, field, note } from './dom.js';
 import { PAY_CHAINS, signingChain, payChainLabel } from '../core/pay-chains.js';
+import { dialogConfirm, dialogPrompt, dialogAlert } from './dialog.js';
 
 interface CreateFlow {
   mnemonic: string;
@@ -252,17 +253,27 @@ function accountSwitcher(accounts: { index: number; label: string }[], active: n
   return el('div', { class: 'acct-bar' }, [
     select,
     button('+ Add', async () => {
-      const label = prompt('Name for the new account?')?.trim();
+      const label = await dialogPrompt({
+        title: 'Add account',
+        label: 'Name',
+        placeholder: `Account ${accounts.length + 1}`,
+        confirmLabel: 'Add',
+      });
       const res = await call({ type: 'addAccount', ...(label ? { label } : {}) });
-      if (!res.ok) { alert(res.error); return; }
+      if (!res.ok) { await dialogAlert({ title: "Couldn't add account", message: res.error, tone: 'error' }); return; }
       void renderWallet();
     }, 'btn small'),
     button('Rename', async () => {
       const current = accounts.find((a) => a.index === active);
-      const label = prompt('Rename account', current?.label ?? '')?.trim();
+      const label = await dialogPrompt({
+        title: 'Rename account',
+        label: 'Name',
+        value: current?.label ?? '',
+        confirmLabel: 'Rename',
+      });
       if (!label) return;
       const res = await call({ type: 'renameAccount', index: active, label });
-      if (!res.ok) { alert(res.error); return; }
+      if (!res.ok) { await dialogAlert({ title: "Couldn't rename", message: res.error, tone: 'error' }); return; }
       void renderWallet();
     }, 'btn small'),
   ]);
@@ -312,7 +323,17 @@ function sendForm(addresses: DerivedAddress[]): HTMLElement {
       fail(status, 'Chain, recipient and amount are all required.');
       return;
     }
-    if (!confirm(`Send ${amountValue} ${chainValue.toUpperCase()} to\n${toValue}?\n\nThis cannot be undone.`)) return;
+    const confirmed = await dialogConfirm({
+      title: 'Confirm payment',
+      message: 'On-chain transfers cannot be undone. Check the recipient carefully.',
+      details: [
+        { label: 'Amount', value: `${amountValue} ${payChainLabel(chainValue as never)}` },
+        { label: 'To', value: toValue },
+      ],
+      confirmLabel: 'Send',
+      danger: true,
+    });
+    if (!confirmed) return;
 
     submit.disabled = true;
     status.textContent = 'Sending…';

--- a/packages/extension/src/popup/dialog.ts
+++ b/packages/extension/src/popup/dialog.ts
@@ -1,0 +1,231 @@
+/**
+ * Modal dialogs built on <dialog>.
+ *
+ * window.alert/confirm/prompt are a bad fit for an extension popup: they render
+ * as browser chrome outside the popup's own styling, block the whole tab, and
+ * in some Chromium builds dismissing them steals focus and closes the popup —
+ * losing whatever the user had typed. <dialog> keeps the interaction inside our
+ * own DOM, styled like the rest of the wallet.
+ *
+ * Each helper resolves when the dialog closes, so call sites read the same way
+ * the native calls did (`await dialogConfirm(...)`).
+ */
+
+export interface ConfirmOptions {
+  title: string;
+  message?: string;
+  /** Lines rendered as a definition list — e.g. amount / chain / recipient. */
+  details?: { label: string; value: string }[];
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Styles the confirm button as destructive/irreversible. */
+  danger?: boolean;
+}
+
+export interface PromptOptions {
+  title: string;
+  label?: string;
+  value?: string;
+  placeholder?: string;
+  confirmLabel?: string;
+}
+
+export interface AlertOptions {
+  title: string;
+  message?: string;
+  details?: { label: string; value: string }[];
+  tone?: 'ok' | 'error';
+}
+
+/**
+ * Close a dialog, tolerating engines without the <dialog> methods (jsdom, and
+ * anything predating the element). Removing `open` plus firing `close` matches
+ * what a real implementation does, so the same code path drives both.
+ */
+function closeDialog(dialog: HTMLDialogElement): void {
+  if (typeof dialog.close === 'function') {
+    dialog.close();
+    return;
+  }
+  dialog.removeAttribute('open');
+  dialog.dispatchEvent(new Event('close'));
+}
+
+/** Open a <dialog>, run `wire`, and resolve with whatever `wire` reports. */
+function open<T>(
+  build: (dialog: HTMLDialogElement, done: (value: T) => void) => void,
+): Promise<T> {
+  return new Promise<T>((resolve) => {
+    const dialog = document.createElement('dialog');
+    dialog.className = 'modal';
+
+    let settled = false;
+    const done = (value: T) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      closeDialog(dialog);
+    };
+
+    build(dialog, done);
+    document.body.append(dialog);
+
+    // Removing on close keeps the popup DOM clean across repeated opens.
+    dialog.addEventListener('close', () => {
+      dialog.remove();
+      // Closed via Esc or the backdrop rather than a button.
+      if (!settled) {
+        settled = true;
+        resolve(undefined as T);
+      }
+    });
+
+    // jsdom (and very old engines) lack showModal; the open attribute still
+    // renders and keeps the helpers testable.
+    if (typeof dialog.showModal === 'function') dialog.showModal();
+    else dialog.setAttribute('open', '');
+  });
+}
+
+function detailList(details: { label: string; value: string }[]): HTMLElement {
+  const dl = document.createElement('dl');
+  dl.className = 'modal-details';
+  for (const d of details) {
+    const dt = document.createElement('dt');
+    dt.textContent = d.label;
+    const dd = document.createElement('dd');
+    dd.textContent = d.value;
+    dl.append(dt, dd);
+  }
+  return dl;
+}
+
+function heading(title: string): HTMLElement {
+  const h = document.createElement('h2');
+  h.className = 'modal-title';
+  h.textContent = title;
+  return h;
+}
+
+function paragraph(text: string): HTMLElement {
+  const p = document.createElement('p');
+  p.className = 'modal-text';
+  p.textContent = text;
+  return p;
+}
+
+export function dialogConfirm(opts: ConfirmOptions): Promise<boolean> {
+  return open<boolean>((dialog, done) => {
+    const form = document.createElement('form');
+    form.method = 'dialog';
+
+    const actions = document.createElement('div');
+    actions.className = 'modal-actions';
+
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn';
+    cancel.textContent = opts.cancelLabel ?? 'Cancel';
+    cancel.addEventListener('click', () => done(false));
+
+    const ok = document.createElement('button');
+    ok.type = 'button';
+    ok.className = `btn ${opts.danger ? 'danger' : 'primary'}`;
+    ok.textContent = opts.confirmLabel ?? 'Confirm';
+    ok.addEventListener('click', () => done(true));
+
+    actions.append(cancel, ok);
+    form.append(heading(opts.title));
+    if (opts.message) form.append(paragraph(opts.message));
+    if (opts.details?.length) form.append(detailList(opts.details));
+    form.append(actions);
+    dialog.append(form);
+
+    // Enter confirms; Esc cancels via the dialog's own close event.
+    queueMicrotask(() => ok.focus());
+  }).then((v) => v === true);
+}
+
+export function dialogPrompt(opts: PromptOptions): Promise<string | null> {
+  return open<string | null>((dialog, done) => {
+    const form = document.createElement('form');
+    form.method = 'dialog';
+
+    const input = document.createElement('input');
+    input.className = 'input';
+    input.type = 'text';
+    input.value = opts.value ?? '';
+    if (opts.placeholder) input.placeholder = opts.placeholder;
+
+    const label = document.createElement('label');
+    label.className = 'field';
+    if (opts.label) {
+      const span = document.createElement('span');
+      span.className = 'label';
+      span.textContent = opts.label;
+      label.append(span);
+    }
+    label.append(input);
+
+    const actions = document.createElement('div');
+    actions.className = 'modal-actions';
+
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn';
+    cancel.textContent = 'Cancel';
+    cancel.addEventListener('click', () => done(null));
+
+    const ok = document.createElement('button');
+    ok.type = 'button';
+    ok.className = 'btn primary';
+    ok.textContent = opts.confirmLabel ?? 'Save';
+    const submit = () => {
+      const value = input.value.trim();
+      done(value ? value : null);
+    };
+    ok.addEventListener('click', submit);
+    input.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Enter') {
+        e.preventDefault();
+        submit();
+      }
+    });
+
+    actions.append(cancel, ok);
+    form.append(heading(opts.title), label, actions);
+    dialog.append(form);
+
+    queueMicrotask(() => {
+      input.focus();
+      input.select();
+    });
+  }).then((v) => (typeof v === 'string' ? v : null));
+}
+
+export function dialogAlert(opts: AlertOptions): Promise<void> {
+  return open<void>((dialog, done) => {
+    const form = document.createElement('form');
+    form.method = 'dialog';
+
+    const actions = document.createElement('div');
+    actions.className = 'modal-actions';
+    const ok = document.createElement('button');
+    ok.type = 'button';
+    ok.className = 'btn primary';
+    ok.textContent = 'OK';
+    ok.addEventListener('click', () => done(undefined));
+    actions.append(ok);
+
+    const title = heading(opts.title);
+    if (opts.tone) title.classList.add(opts.tone === 'error' ? 'error' : 'ok');
+
+    form.append(title);
+    if (opts.message) form.append(paragraph(opts.message));
+    if (opts.details?.length) form.append(detailList(opts.details));
+    form.append(actions);
+    dialog.append(form);
+
+    queueMicrotask(() => ok.focus());
+  });
+}

--- a/packages/extension/src/popup/index.html
+++ b/packages/extension/src/popup/index.html
@@ -77,6 +77,20 @@
       .ok { color: #5ad19b; }
       .error { color: #ff8f8f; }
       .account .btn.small { margin-top: 6px; }
+
+      /* ── <dialog> modals (replacing alert/confirm/prompt) ── */
+      .modal { border: 1px solid #2a3444; background: #0f1723; color: #e8eef7; border-radius: 12px; padding: 0; max-width: 300px; width: calc(100% - 32px); }
+      .modal::backdrop { background: rgba(3, 7, 12, 0.66); }
+      .modal form { padding: 16px; }
+      .modal-title { margin: 0 0 8px; font-size: 15px; font-weight: 700; }
+      .modal-title.error { color: #ff8f8f; }
+      .modal-title.ok { color: #5ad19b; }
+      .modal-text { margin: 0 0 10px; font-size: 12px; color: #9fb0c7; line-height: 1.45; }
+      .modal-details { margin: 0 0 12px; display: grid; grid-template-columns: auto 1fr; gap: 4px 10px; font-size: 12px; }
+      .modal-details dt { color: #9fb0c7; }
+      .modal-details dd { margin: 0; word-break: break-all; font-family: ui-monospace, Menlo, monospace; }
+      .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+      .btn.danger { background: #b3382f; color: #fff; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Native dialogs are a bad fit for an extension popup: they render as browser chrome outside the wallet's styling, block the whole tab, and in some Chromium builds dismissing one steals focus and **closes the popup**, taking whatever was typed with it. A send confirmation that looks like a browser warning is also the wrong shape for the one irreversible action in the wallet.

Adds `popup/dialog.ts` — `dialogConfirm` / `dialogPrompt` / `dialogAlert`, built on `<dialog>` with `form[method=dialog]`, resolving like the calls they replace so the call sites read the same.

Replaces all five native calls: add account, rename account (both `prompt`), their two error `alert`s, and the send `confirm`. The send confirmation now renders amount and recipient as a definition list rather than a `\n`-joined string, with a destructive-styled confirm button.

`closeDialog()` falls back to toggling `open` and firing `close` where the `<dialog>` methods are missing — jsdom 23 implements neither `showModal` nor `close` — so the same code path runs in tests and in a real browser.

**Verification:** 10 new tests (confirm/cancel/Esc, prompt trimming, prefill, empty→null, Enter-to-submit, error tone, one-dialog-per-call + DOM cleanup). 173 pass overall. The built bundle greps clean of `alert`/`confirm`/`prompt` and contains `createElement("dialog")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)