### PR TITLE
fix(escrow): align creation flow with auth requirements (#206)

### DIFF
--- a/docs/ESCROW.md
+++ b/docs/ESCROW.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-Anonymous, non-custodial-style escrow for crypto payments. Both humans and AI agents can use it to hold funds in escrow during jobs/gigs. Funds are held in platform-generated HD wallet addresses (same system wallet infrastructure as payments) and released based on escrow conditions.
+Authenticated, non-custodial-style escrow for crypto payments. Both humans and AI agents can use it to hold funds in escrow during jobs/gigs. Funds are held in platform-generated HD wallet addresses (same system wallet infrastructure as payments) and released based on escrow conditions.
 
 **Key properties:**
-- No KYC — anonymous by default
+- Authenticated creation — merchant JWT or API key required
 - API-first — agents can create/fund/release/dispute via API keys
 - Multi-chain — supports all chains CoinPayPortal already supports (BTC, BCH, ETH, POL, SOL, USDC_*)
 - Platform fee — same 0.5-1% fee structure as payments
@@ -168,13 +168,13 @@ CREATE INDEX idx_escrow_events_type ON escrow_events(event_type);
 
 ## API Endpoints
 
-### Public (no auth required — anonymous escrow creation)
+### Authenticated endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/escrow` | Create new escrow |
-| `GET` | `/api/escrow/:id` | Get escrow status (public view) |
-| `GET` | `/api/escrow/:id/events` | Get escrow event log |
+| `POST` | `/api/escrow` | Create new escrow (merchant JWT or API key required) |
+| `GET` | `/api/escrow/:id` | Get escrow status (party token, merchant JWT, or API key required) |
+| `GET` | `/api/escrow/:id/events` | Get escrow event log (party token, merchant JWT, or API key required) |
 
 ### Depositor Actions (auth via release_token or API key)
 
@@ -205,14 +205,14 @@ CREATE INDEX idx_escrow_events_type ON escrow_events(event_type);
 
 ## Auth Model
 
-Escrows are **anonymous by default**:
+Escrow creation requires a standard merchant JWT or API key. After creation, party actions use scoped credentials:
 - `release_token` — random secret returned on creation, used by depositor to release/refund
 - `beneficiary_api_key` — optional, for agents to poll status
 - Wallet signature — alternative auth by signing a challenge with the party's wallet key
 
 For merchants with CoinPayPortal accounts:
-- Standard JWT/API key auth works
-- Escrow tied to their `business_id`
+- Standard JWT/API key auth is required for creation
+- Escrow can be tied to their `business_id`
 
 ## SDK Integration
 
@@ -255,6 +255,7 @@ Agents create escrows via the REST API or SDK:
 ```bash
 # Create escrow for a gig
 curl -X POST https://coinpayportal.com/api/escrow \
+  -H "Authorization: Bearer $COINPAY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "chain": "SOL",

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -96,7 +96,7 @@ export default function DocsPage() {
             <div>
               <h2 className="text-xl font-bold text-white mb-2">🔐 Escrow Service</h2>
               <p className="text-gray-300 text-sm">
-                Trustless crypto escrow — hold funds until both sides are satisfied. Token-based auth, no accounts needed.
+                Trustless crypto escrow — authenticate to create, then manage release and disputes with role-specific tokens.
               </p>
             </div>
             <a
@@ -661,8 +661,8 @@ curl -H "X-Payment: $(echo -n '{"scheme":"exact","network":"bitcoin","asset":"BT
         <div id="escrow">
           <DocSection title="Escrow Service">
             <p className="text-gray-300 mb-6">
-              Anonymous, trustless escrow for crypto transactions. Hold funds until both parties are satisfied. 
-              No accounts required — authentication is handled via unique tokens returned at creation time.
+              Trustless escrow for crypto transactions. Creation requires a merchant session or API key;
+              unique tokens returned at creation authorize each party&apos;s later actions.
             </p>
 
             <div className="mb-8 p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg">
@@ -712,7 +712,7 @@ curl -H "X-Payment: $(echo -n '{"scheme":"exact","network":"bitcoin","asset":"BT
               ))}
             </div>
 
-            <ApiEndpoint method="POST" path="/api/escrow" description="Create a new escrow. No authentication required (anonymous). Optionally authenticate to associate with a business and get paid-tier fees.">
+            <ApiEndpoint method="POST" path="/api/escrow" description="Create a new escrow. Requires a merchant JWT or API key. Include business_id to associate it with a business and apply eligible paid-tier fees.">
               <div className="mb-4 p-4 bg-blue-500/10 border border-blue-500/20 rounded-lg">
                 <p className="text-blue-300 text-sm">
                   <strong>Fiat Support:</strong> While this API accepts crypto amounts directly, you can now specify amounts in fiat when using the SDK/CLI, which will auto-convert via the rates API before creating the escrow.
@@ -733,6 +733,7 @@ curl -H "X-Payment: $(echo -n '{"scheme":"exact","network":"bitcoin","asset":"BT
 
               <CodeBlock title="cURL Example" language="curl">
 {`curl -X POST https://coinpayportal.com/api/escrow \\
+  -H "Authorization: Bearer $COINPAY_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
     "chain": "ETH",
@@ -806,9 +807,9 @@ offset       — Pagination offset`}
               </CodeBlock>
             </ApiEndpoint>
 
-            <ApiEndpoint method="GET" path="/api/escrow/:id" description="Get escrow details by ID. Public endpoint — no auth required.">
+            <ApiEndpoint method="GET" path="/api/escrow/:id" description="Get escrow details by ID. Requires a party token query parameter, merchant JWT, or API key.">
               <CodeBlock title="cURL Example" language="curl">
-{`curl https://coinpayportal.com/api/escrow/a1b2c3d4-...`}
+{`curl "https://coinpayportal.com/api/escrow/a1b2c3d4-...?token=esc_abc123..."`}
               </CodeBlock>
             </ApiEndpoint>
 
@@ -892,7 +893,7 @@ offset       — Pagination offset`}
               </p>
             </ApiEndpoint>
 
-            <ApiEndpoint method="GET" path="/api/escrow/:id/events" description="Get the audit log for an escrow — all status changes, deposits, releases, disputes, and settlements.">
+            <ApiEndpoint method="GET" path="/api/escrow/:id/events" description="Get the authenticated audit log for an escrow — all status changes, deposits, releases, disputes, and settlements. Requires a party token, merchant JWT, or API key.">
               <CodeBlock title="Response">
 {`{
   "success": true,

--- a/src/app/docs/sdk/page.tsx
+++ b/src/app/docs/sdk/page.tsx
@@ -674,7 +674,7 @@ businesses.forEach(biz => {
         <div id="escrow">
           <DocSection title="Escrow API">
             <p className="text-gray-300 mb-6">
-              Create and manage trustless crypto escrows. No accounts required — authentication uses unique tokens returned at creation.
+              Create trustless crypto escrows with an authenticated SDK client, then use the unique tokens returned at creation to authorize each party&apos;s actions.
             </p>
 
             <h3 className="text-xl font-semibold text-white mb-4">Create Escrow</h3>

--- a/src/app/escrow/create/page.test.tsx
+++ b/src/app/escrow/create/page.test.tsx
@@ -34,7 +34,7 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     
-    // Mock auth fetch to return null (not logged in, triggers anonymous fallback)
+    // Mock auth fetch to return null (not logged in)
     vi.mocked(authFetch).mockResolvedValue(null);
     
     // Mock rates API response with a typical exchange rate
@@ -384,6 +384,38 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
 
   it('should submit form with crypto amount regardless of input mode', async () => {
     const user = userEvent.setup();
+    const createdEscrow = {
+      id: 'test-escrow-id',
+      escrow_address: 'test-address',
+      depositor_address: 'test-depositor',
+      beneficiary_address: 'test-beneficiary',
+      chain: 'USDC_POL',
+      amount: 100,
+      amount_usd: 100,
+      fee_amount: 1,
+      deposited_amount: 0,
+      status: 'pending',
+      release_token: 'test-release-token',
+      beneficiary_token: 'test-beneficiary-token',
+      expires_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+      metadata: {},
+      business_id: null,
+    };
+
+    vi.mocked(authFetch).mockImplementation(async (url) => {
+      if (url === '/api/businesses') {
+        return {
+          response: { ok: true } as Response,
+          data: { success: true, businesses: [] },
+        };
+      }
+
+      return {
+        response: { ok: true } as Response,
+        data: createdEscrow,
+      };
+    });
     
     // Mock successful escrow creation
     mockFetch.mockImplementation((url: string) => {
@@ -393,25 +425,6 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
           json: () => Promise.resolve({
             success: true,
             rate: 1.0
-          })
-        });
-      }
-      if (url.includes('/api/escrow') && url !== '/api/escrow') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({
-            id: 'test-escrow-id',
-            escrow_address: 'test-address',
-            depositor_address: 'test-depositor',
-            beneficiary_address: 'test-beneficiary',
-            chain: 'USDC_POL',
-            amount: 100,
-            status: 'pending',
-            release_token: 'test-release-token',
-            beneficiary_token: 'test-beneficiary-token',
-            expires_at: new Date().toISOString(),
-            created_at: new Date().toISOString(),
-            metadata: {}
           })
         });
       }
@@ -442,14 +455,38 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
     const submitButton = screen.getByRole('button', { name: 'Create Escrow' });
     await user.click(submitButton);
     
-    // Check that the API was called with crypto amount (100)
+    // Check that the authenticated API call includes the crypto amount (100)
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/escrow', {
+      expect(authFetch).toHaveBeenCalledWith('/api/escrow', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: expect.stringContaining('"amount":100')
       });
     });
+  });
+
+  it('should not retry escrow creation without authentication', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateEscrowPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Create Escrow' })).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 USDC_POL = \$1/)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText(/0\.00 USD/), '100');
+    await user.type(screen.getByPlaceholderText('Your wallet address (sender)'), 'test-depositor-address');
+    await user.type(screen.getByPlaceholderText('Recipient wallet address'), 'test-beneficiary-address');
+    await user.click(screen.getByRole('button', { name: 'Create Escrow' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Authentication is required to create an escrow. Please log in and try again.')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalledWith('/api/escrow', expect.anything());
   });
 
   it('should handle empty inputs gracefully', async () => {
@@ -633,7 +670,7 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
     expect(screen.getByText(/Platform fee: 0\.5% \(paid tier\)/)).toBeInTheDocument();
   });
 
-  it('should show anonymous user commission rate (1%)', async () => {
+  it('should show personal escrow commission rate (1%)', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/api/rates')) {
         return Promise.resolve({
@@ -653,8 +690,7 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
       expect(screen.getByRole('heading', { name: 'Create Escrow' })).toBeInTheDocument();
     });
 
-    // Should show 1% for anonymous users
-    expect(screen.getByText(/Platform fee: 1% \(0\.5% for logged-in merchants\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Platform fee: 1% \(0\.5% with a paid business\)/)).toBeInTheDocument();
   });
 
   it('should show correct commission estimate for different user types', async () => {
@@ -679,8 +715,7 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
       expect(screen.getByRole('heading', { name: 'Create Escrow' })).toBeInTheDocument();
     });
 
-    // Check initial state shows anonymous rate (1%)
-    expect(screen.getByText(/Platform fee: 1% \(0\.5% for logged-in merchants\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Platform fee: 1% \(0\.5% with a paid business\)/)).toBeInTheDocument();
   });
 
   it('should skip wallet email lookup on blur in multisig mode', async () => {
@@ -803,7 +838,7 @@ describe('CreateEscrowPage - Dual Input Feature', () => {
     await user.click(screen.getByRole('button', { name: 'Create Escrow' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Multisig escrow creation requires authentication. Please log in and try again.')).toBeInTheDocument();
+      expect(screen.getByText('Authentication is required to create an escrow. Please log in and try again.')).toBeInTheDocument();
     });
 
     const anonymousMultisigCalls = mockFetch.mock.calls.filter((call: any[]) =>

--- a/src/app/escrow/create/page.tsx
+++ b/src/app/escrow/create/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { authFetch } from '@/lib/auth/client';
 import { SUPPORTED_FIAT_CURRENCIES, type FiatCurrency } from '@/lib/web-wallet/settings';
@@ -109,7 +108,6 @@ function multisigSignerPlaceholder(role: 'Depositor' | 'Beneficiary' | 'Arbiter'
 }
 
 export default function CreateEscrowPage() {
-  const router = useRouter();
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState('');
   const [createdEscrow, setCreatedEscrow] = useState<CreatedEscrow | null>(null);
@@ -166,7 +164,7 @@ export default function CreateEscrowPage() {
         }
       }
     } catch {
-      // Not logged in — that's fine, escrow works anonymously
+      // Not logged in
     } finally {
       setLoadingAuth(false);
     }
@@ -386,21 +384,7 @@ export default function CreateEscrowPage() {
         } else if (result) {
           setError(result.data?.error || 'Failed to create recurring escrow series');
         } else {
-          const res = await fetch('/api/escrow/series', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(seriesBody),
-          });
-          if (!res.ok) {
-            const errData = await res.json().catch(() => ({}));
-            setError(errData?.error || `Failed to create series (${res.status})`);
-          } else {
-            const data = await res.json();
-            setCreatedSeries(data.series || data);
-            if (data.escrow) {
-              setCreatedEscrow(data.escrow);
-            }
-          }
+          setError('Authentication is required to create a recurring escrow. Please log in and try again.');
         }
       } else {
         // Use authFetch to include credentials (for logged-in merchants)
@@ -417,23 +401,7 @@ export default function CreateEscrowPage() {
         } else if (result) {
           setError(result.data?.error || 'Failed to create escrow');
         } else {
-          if (isMultisig) {
-            setError('Multisig escrow creation requires authentication. Please log in and try again.');
-            return;
-          }
-
-          // authFetch returned null (redirect to login) — try anonymous for custodial only
-          const res = await fetch(createEndpoint, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-          });
-          if (!res.ok) {
-            const errData = await res.json().catch(() => ({}));
-            setError(errData?.error || `Failed to create escrow (${res.status})`);
-          } else {
-            setCreatedEscrow(await res.json());
-          }
+          setError('Authentication is required to create an escrow. Please log in and try again.');
         }
       }
     } catch (err) {
@@ -853,7 +821,7 @@ export default function CreateEscrowPage() {
                 onChange={(e) => setFormData({ ...formData, business_id: e.target.value })}
                 className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
               >
-                <option value="">No business (anonymous)</option>
+                <option value="">Personal escrow</option>
                 {businesses.map((b) => (
                   <option key={b.id} value={b.id}>{b.name}</option>
                 ))}
@@ -866,7 +834,7 @@ export default function CreateEscrowPage() {
 
           {!loadingAuth && !isLoggedIn && (
             <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 text-sm text-blue-700 dark:text-blue-300">
-              <Link href="/login" className="font-medium underline hover:text-blue-900">Log in</Link> to associate this escrow with your business and get reduced fees (0.5% vs 1%).
+              <Link href="/login?redirect=%2Fescrow%2Fcreate" className="font-medium underline hover:text-blue-900">Log in</Link> to create an escrow. Authentication is required for both personal and business escrows.
             </div>
           )}
 
@@ -1323,7 +1291,7 @@ export default function CreateEscrowPage() {
               )}
             </ol>
             <p className="text-xs text-blue-600 dark:text-blue-500 mt-2">
-              Platform fee: {isLoggedIn && formData.business_id ? '0.5% (paid tier)' : '1% (0.5% for logged-in merchants)'}. No fee on refunds.
+              Platform fee: {isLoggedIn && formData.business_id ? '0.5% (paid tier)' : '1% (0.5% with a paid business)'}. No fee on refunds.
             </p>
           </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -180,7 +180,7 @@ export default function Home() {
                   </svg>
                 ),
                 title: 'Trustless Escrow',
-                description: 'Hold funds until both parties are satisfied. Token-based auth — no accounts, no KYC. Dispute resolution built in.',
+                description: 'Hold funds until both parties are satisfied. Authenticated creation and role-specific action tokens. Dispute resolution built in.',
               },
               {
                 icon: (
@@ -326,7 +326,7 @@ export default function Home() {
               Trustless Escrow for Any Deal
             </h2>
             <p className="text-xl text-gray-400 max-w-2xl mx-auto">
-              Hold crypto in escrow until both sides are happy. No accounts needed — just tokens. Perfect for freelance gigs, agent-to-agent trades, and marketplace transactions.
+              Hold crypto in escrow until both sides are happy. Authenticate to create, then manage it with role-specific tokens. Perfect for freelance gigs, agent-to-agent trades, and marketplace transactions.
             </p>
           </div>
 
@@ -353,7 +353,7 @@ export default function Home() {
 
               <div className="grid grid-cols-2 gap-4 pt-2">
                 {[
-                  { label: 'Anonymous', desc: 'Token-based auth, no KYC' },
+                  { label: 'Secure Access', desc: 'Authenticated creation + party tokens' },
                   { label: 'Multi-Chain', desc: 'BTC, ETH, SOL, POL + more' },
                   { label: 'Auto-Detect', desc: 'Deposits confirmed on-chain' },
                   { label: 'Dispute Flow', desc: 'Built-in arbiter support' },
@@ -379,6 +379,7 @@ export default function Home() {
                 <pre className="p-4 text-sm overflow-x-auto">
                   <code className="text-gray-300">
 {`curl -X POST https://coinpayportal.com/api/escrow \\
+  -H "Authorization: Bearer $COINPAY_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
     "chain": "ETH",


### PR DESCRIPTION
Closes #206

## Summary

- remove unauthenticated fallback requests for single and recurring escrow creation
- show logged-out users clear login guidance and rename the authenticated personal option
- align homepage, API, SDK, and escrow reference docs with the JWT/API-key requirement
- document party tokens as post-creation credentials for status and actions
- add regression coverage proving the client does not retry `POST /api/escrow` with plain `fetch()`

## Verification

- `vitest run src/app/escrow/create/page.test.tsx` — 22 passed
- `tsc --noEmit` — passed
- ESLint on all changed TS/TSX files — 0 errors