### PR TITLE
fix(escrow): authenticate event timeline requests (#208)

### DIFF
--- a/src/app/escrow/manage/page.test.tsx
+++ b/src/app/escrow/manage/page.test.tsx
@@ -146,6 +146,7 @@ describe('EscrowManagePage', () => {
     
     expect(screen.getByText('depositor')).toBeInTheDocument();
     expect(screen.getByText('100 USDC_POL')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/api/escrow/esc_123/events?token=valid_token');
   });
 
   it('should show error for invalid credentials', async () => {

--- a/src/app/escrow/manage/page.tsx
+++ b/src/app/escrow/manage/page.tsx
@@ -139,7 +139,7 @@ function EscrowManagePage() {
 
       const data = await response.json();
       setAuthenticatedData(data);
-      fetchEvents(currentId);
+      fetchEvents(currentId, currentToken);
 
       // Update URL without triggering a page reload
       const url = new URL(window.location.href);
@@ -154,10 +154,11 @@ function EscrowManagePage() {
     }
   };
 
-  const fetchEvents = async (escrowId: string) => {
+  const fetchEvents = async (escrowId: string, authToken: string) => {
     try {
       setEventsLoading(true);
-      const response = await fetch(`/api/escrow/${escrowId}/events`);
+      const params = new URLSearchParams({ token: authToken });
+      const response = await fetch(`/api/escrow/${escrowId}/events?${params.toString()}`);
       if (response.ok) {
         const data = await response.json();
         setEvents(data.events || []);
@@ -195,7 +196,7 @@ function EscrowManagePage() {
         ...authenticatedData,
         escrow: updatedEscrow,
       });
-      fetchEvents(authenticatedData.escrow.id);
+      fetchEvents(authenticatedData.escrow.id, actionToken || token);
     } catch (err) {
       setError(`Failed to ${action} escrow. Please try again.`);
       console.error(err);
@@ -236,7 +237,7 @@ function EscrowManagePage() {
         ...authenticatedData,
         escrow: updatedEscrow,
       });
-      fetchEvents(authenticatedData.escrow.id);
+      fetchEvents(authenticatedData.escrow.id, token);
       setShowDispute(false);
       setDisputeReason('');
     } catch (err) {
@@ -273,7 +274,7 @@ function EscrowManagePage() {
         ...authenticatedData,
         escrow: data,
       });
-      fetchEvents(authenticatedData.escrow.id);
+      fetchEvents(authenticatedData.escrow.id, token);
     } catch (err) {
       setError('Failed to update auto-release. Please try again.');
       console.error(err);


### PR DESCRIPTION
Closes #208

## Summary

- forward the already validated party token to the protected escrow event endpoint
- preserve the token when refreshing events after release, refund, dispute, or auto-release actions
- add regression coverage for the authenticated event URL

## Verification

- `vitest run src/app/escrow/manage/page.test.tsx` — 12 passed
- `tsc --noEmit` — passed
- ESLint on changed files — 0 errors