### PR TITLE
fix(web-wallet): size tx rate limits for the extension's bulk payouts

### DIFF
--- a/src/app/api/web-wallet/[id]/broadcast/route.ts
+++ b/src/app/api/web-wallet/[id]/broadcast/route.ts
@@ -9,7 +9,8 @@ import { checkRateLimit } from '@/lib/web-wallet/rate-limit';
  * POST /api/web-wallet/:id/broadcast
  * Broadcast a signed transaction to the network.
  * Requires authentication.
- * Rate limited: 10 requests/minute per IP.
+ * Rate limited: 60 requests/minute per IP, then 1000/hour per authenticated
+ * wallet — sized so the extension's bulk payouts can run to completion.
  *
  * Body:
  *   tx_id     - ID of the prepared transaction
@@ -60,6 +61,15 @@ export async function POST(
 
     if (auth.walletId !== id) {
       return WalletErrors.forbidden('Cannot access another wallet');
+    }
+
+    // The per-wallet budget is the one that actually bounds abuse: the IP above
+    // is shared by everyone behind a NAT, so it has to stay loose enough for a
+    // legitimate batch. Checked here because it needs a verified wallet id.
+    const walletRateCheck = checkRateLimit(id, 'broadcast_tx_wallet');
+    if (!walletRateCheck.allowed) {
+      console.log(`[Broadcast] POST /broadcast rate limited for wallet ${id}`);
+      return WalletErrors.rateLimited(walletRateCheck.resetAt - Math.floor(Date.now() / 1000));
     }
 
     // Parse body

--- a/src/app/api/web-wallet/[id]/prepare-tx/route.ts
+++ b/src/app/api/web-wallet/[id]/prepare-tx/route.ts
@@ -12,7 +12,8 @@ import { isValidChain } from '@/lib/web-wallet/identity';
  * POST /api/web-wallet/:id/prepare-tx
  * Prepare an unsigned transaction for client-side signing.
  * Requires authentication.
- * Rate limited: 20 requests/minute per IP.
+ * Rate limited: 60 requests/minute per IP, then 1000/hour per authenticated
+ * wallet — sized so the extension's bulk payouts can run to completion.
  *
  * Body:
  *   from_address - Sender address (must belong to wallet)
@@ -65,6 +66,15 @@ export async function POST(
 
     if (auth.walletId !== id) {
       return WalletErrors.forbidden('Cannot access another wallet');
+    }
+
+    // The per-wallet budget is the one that actually bounds abuse: the IP above
+    // is shared by everyone behind a NAT, so it has to stay loose enough for a
+    // legitimate batch. Checked here because it needs a verified wallet id.
+    const walletRateCheck = checkRateLimit(id, 'prepare_tx_wallet');
+    if (!walletRateCheck.allowed) {
+      console.log(`[PrepareTx] POST /prepare-tx rate limited for wallet ${id}`);
+      return WalletErrors.rateLimited(walletRateCheck.resetAt - Math.floor(Date.now() / 1000));
     }
 
     // Parse body

--- a/src/lib/web-wallet/rate-limit.test.ts
+++ b/src/lib/web-wallet/rate-limit.test.ts
@@ -99,6 +99,53 @@ describe('rate-limit', () => {
       expect(result.limit).toBe(RATE_LIMITS['broadcast_tx'].limit);
     });
 
+    // The extension's payBatch sends up to MAX_BATCH_SIZE payments behind one
+    // approval (packages/extension/src/background/index.ts), and each payment
+    // costs one prepare-tx plus one broadcast. Limits below that silently kill
+    // a bulk run partway through, which reads to the payer as "some invoices
+    // just didn't pay" — so the budget is asserted against the batch size.
+    describe('bulk payouts', () => {
+      const MAX_BATCH_SIZE = 500;
+      /** Payments/minute the batch runner tops out at (~4s settle on EVM/SOL). */
+      const RUNNER_PACE_PER_MIN = 15;
+
+      it('lets one wallet prepare and broadcast a full batch', () => {
+        for (let i = 0; i < MAX_BATCH_SIZE; i++) {
+          expect(checkRateLimit('wallet-1', 'prepare_tx_wallet').allowed).toBe(true);
+          expect(checkRateLimit('wallet-1', 'broadcast_tx_wallet').allowed).toBe(true);
+        }
+      });
+
+      it('leaves per-wallet headroom for the runner retries', () => {
+        expect(RATE_LIMITS['prepare_tx_wallet'].limit).toBeGreaterThan(MAX_BATCH_SIZE);
+        expect(RATE_LIMITS['broadcast_tx_wallet'].limit).toBeGreaterThan(MAX_BATCH_SIZE);
+      });
+
+      it('does not trip the per-IP cap at the runner pace', () => {
+        for (let i = 0; i < RUNNER_PACE_PER_MIN; i++) {
+          expect(checkRateLimit('1.2.3.4', 'prepare_tx').allowed).toBe(true);
+          expect(checkRateLimit('1.2.3.4', 'broadcast_tx').allowed).toBe(true);
+        }
+      });
+
+      it('still bounds a wallet that blows past a full batch', () => {
+        const limit = RATE_LIMITS['broadcast_tx_wallet'].limit;
+        for (let i = 0; i < limit; i++) {
+          checkRateLimit('wallet-2', 'broadcast_tx_wallet');
+        }
+        expect(checkRateLimit('wallet-2', 'broadcast_tx_wallet').allowed).toBe(false);
+      });
+
+      it('budgets each wallet separately', () => {
+        const limit = RATE_LIMITS['prepare_tx_wallet'].limit;
+        for (let i = 0; i < limit; i++) {
+          checkRateLimit('wallet-3', 'prepare_tx_wallet');
+        }
+        expect(checkRateLimit('wallet-3', 'prepare_tx_wallet').allowed).toBe(false);
+        expect(checkRateLimit('wallet-4', 'prepare_tx_wallet').allowed).toBe(true);
+      });
+    });
+
     it('should reset properly', () => {
       const limit = RATE_LIMITS['wallet_creation'].limit;
 
@@ -179,10 +226,20 @@ describe('rate-limit', () => {
       expect(RATE_LIMITS['auth_verify'].windowSeconds).toBe(60);
     });
 
-    it('should have broadcast_tx limits (strictest)', () => {
+    // Was 10/min, which was below the batch runner's pace and cut bulk payouts
+    // off after ~10 payments. The per-IP cap is now a shared-NAT-safe shield;
+    // broadcast_tx_wallet is what actually bounds a single wallet.
+    it('should have broadcast_tx limits', () => {
       expect(RATE_LIMITS['broadcast_tx']).toBeDefined();
-      expect(RATE_LIMITS['broadcast_tx'].limit).toBe(10);
+      expect(RATE_LIMITS['broadcast_tx'].limit).toBe(60);
       expect(RATE_LIMITS['broadcast_tx'].windowSeconds).toBe(60);
+    });
+
+    it('should have per-wallet transaction limits', () => {
+      expect(RATE_LIMITS['prepare_tx_wallet']).toBeDefined();
+      expect(RATE_LIMITS['prepare_tx_wallet'].windowSeconds).toBe(3600);
+      expect(RATE_LIMITS['broadcast_tx_wallet']).toBeDefined();
+      expect(RATE_LIMITS['broadcast_tx_wallet'].windowSeconds).toBe(3600);
     });
 
     it('should have all expected categories defined', () => {

--- a/src/lib/web-wallet/rate-limit.ts
+++ b/src/lib/web-wallet/rate-limit.ts
@@ -62,8 +62,20 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'auth_verify': { limit: 30, windowSeconds: 60 },            // 30/min (wallet switches trigger auth)
   'balance_query': { limit: 60, windowSeconds: 60 },          // 60/min
   'tx_history': { limit: 30, windowSeconds: 60 },             // 30/min
-  'prepare_tx': { limit: 20, windowSeconds: 60 },             // 20/min
-  'broadcast_tx': { limit: 10, windowSeconds: 60 },           // 10/min
+  // Sized for the extension's bulk runs, not for one human clicking Send.
+  // `payBatch` sends up to MAX_BATCH_SIZE (500) payments as one approval, and
+  // each payment costs one prepare-tx plus one broadcast. The runner serializes
+  // per account with a settle delay, so it tops out around 15 payments/minute —
+  // the old 20/min and 10/min caps stopped a batch dead after ~10 payments, and
+  // the runner treats a 429 as transient and burns its retries inside the same
+  // window. These are the pre-auth per-IP shield; the real budget is per wallet.
+  'prepare_tx': { limit: 60, windowSeconds: 60 },             // 60/min per IP
+  'broadcast_tx': { limit: 60, windowSeconds: 60 },           // 60/min per IP
+  // Per authenticated wallet, checked after the signature verifies. One full
+  // 500-payment batch costs 500 of each; the 2x headroom absorbs the runner's
+  // retries without letting a single wallet run batches back to back forever.
+  'prepare_tx_wallet': { limit: 1000, windowSeconds: 3600 },   // 1000/hour per wallet
+  'broadcast_tx_wallet': { limit: 1000, windowSeconds: 3600 }, // 1000/hour per wallet
   'estimate_fee': { limit: 60, windowSeconds: 60 },           // 60/min
   'settings': { limit: 30, windowSeconds: 60 },               // 30/min
   'sync_history': { limit: 10, windowSeconds: 60 },           // 10/min


### PR DESCRIPTION
## Why

Bulk pay on ugig.net (`/dashboard/invoices?tab=received` → **Pay all accepted invoices**) could not complete, and the failure looked like "the wallet never prompted" / "some invoices just didn't pay".

The cause is server-side. The extension's `payBatch` sends up to `MAX_BATCH_SIZE` (500) payments behind one approval, and **each payment costs one `prepare-tx` plus one `broadcast`**. The API capped those per IP at:

| category | old | 
|---|---|
| `prepare_tx` | 20/min |
| `broadcast_tx` | **10/min** |

The batch runner serializes per account with a settle delay, so it paces around 15 payments/minute. A 62-invoice run therefore tripped the broadcast cap roughly 40 seconds in, after ~10 payments; the remaining ~52 returned 429.

It compounds: `isTransientChainError` matches `/rate limit/`, so every 429 also burned its three retry attempts inside the same 60-second window instead of waiting the window out.

## What changed

- **Per-IP caps raised to 60/min** for `prepare_tx` and `broadcast_tx`. These are a pre-auth shield shared by everyone behind a NAT, so they have to stay loose enough for one legitimate batch.
- **New per-wallet budget** — `prepare_tx_wallet` and `broadcast_tx_wallet`, 1000/hour — keyed by the authenticated wallet id and checked *after* the request signature verifies. This is what actually bounds a single payer, and it has 2x headroom over a full 500-payment batch to absorb the runner's retries.

## Tests

`src/lib/web-wallet/rate-limit.test.ts` gains a `bulk payouts` block asserting the limits against the batch size rather than against hardcoded numbers: a full batch runs uncapped, the runner's pace clears the per-IP cap, a wallet that blows past a batch is still cut off, and wallets are budgeted independently.

`vitest run src/lib/web-wallet/` — 437 passed. Typecheck and eslint clean on the changed files.

## Not fixed here (follow-up)

The batch runner backs off `settleDelayMs(chain) * attempt` (1.5s/3s on EVM) on a transient error, which is far shorter than a rate-limit window — so if a batch ever does hit a 429, all three attempts still burn inside it. Honoring the `retry-after` from `WalletErrors.rateLimited` would make that self-healing. Left out because it changes `packages/extension` and would need a store republish to take effect, whereas this API change takes effect on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)