### PR TITLE
fix(proxy): give credentialed integrations their own rate-limit bucket

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { proxy, presentedCredential } from './proxy';
+
+/**
+ * The limiter's store is module-level with no reset hook, so every test uses a
+ * distinct IP. That is closer to reality anyway — buckets are per client.
+ */
+function post(
+  path: string,
+  ip: string,
+  headers: Record<string, string> = {}
+): NextRequest {
+  return new NextRequest(`https://coinpayportal.com${path}`, {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip, ...headers },
+  });
+}
+
+/** How many requests land before the limiter starts answering 429. */
+function countUntilLimited(
+  path: string,
+  ip: string,
+  attempts: number,
+  headers: Record<string, string> = {}
+): number {
+  let allowed = 0;
+  for (let i = 0; i < attempts; i++) {
+    const response = proxy(post(path, ip, headers));
+    if (response.status === 429) break;
+    allowed++;
+  }
+  return allowed;
+}
+
+describe('presentedCredential', () => {
+  const headersOf = (init: Record<string, string>) => new Headers(init);
+
+  it('reads a bearer token', () => {
+    expect(presentedCredential(headersOf({ authorization: 'Bearer sk_live_abc' }))).toBe(
+      'sk_live_abc'
+    );
+  });
+
+  it('is case-insensitive about the scheme', () => {
+    expect(presentedCredential(headersOf({ authorization: 'bearer sk_live_abc' }))).toBe(
+      'sk_live_abc'
+    );
+  });
+
+  it('reads x-api-key', () => {
+    expect(presentedCredential(headersOf({ 'x-api-key': 'sk_live_xyz' }))).toBe('sk_live_xyz');
+  });
+
+  it('is null when no credential is presented', () => {
+    expect(presentedCredential(headersOf({}))).toBeNull();
+  });
+
+  it('ignores a bearer header with no token', () => {
+    expect(presentedCredential(headersOf({ authorization: 'Bearer' }))).toBeNull();
+  });
+});
+
+describe('proxy rate limiting', () => {
+  it('caps an anonymous API caller at the general limit', () => {
+    const allowed = countUntilLimited('/api/rates', '10.1.0.1', 80);
+    expect(allowed).toBe(60);
+  });
+
+  // The regression that broke bulk invoice payments: ugig.net mints one payment
+  // request per accepted invoice from a single server IP, so an 80-invoice queue
+  // burst past 60/min and the rest came back "Too many requests" during prepare.
+  it('lets a credentialed integration burst well past the anonymous limit', () => {
+    const allowed = countUntilLimited('/api/payments/create', '10.1.0.2', 200, {
+      authorization: 'Bearer sk_live_ugig',
+    });
+    expect(allowed).toBe(200);
+  });
+
+  it('budgets each API key separately from the same host', () => {
+    const headersA = { authorization: 'Bearer sk_live_a' };
+    const headersB = { authorization: 'Bearer sk_live_b' };
+    // Spend key A's whole budget.
+    countUntilLimited('/api/payments/create', '10.1.0.3', 700, headersA);
+    // Key B is untouched.
+    const response = proxy(post('/api/payments/create', '10.1.0.3', headersB));
+    expect(response.status).not.toBe(429);
+  });
+
+  it('still bounds a host that rotates keys', () => {
+    const ip = '10.1.0.4';
+    let limited = false;
+    for (let i = 0; i < 1400 && !limited; i++) {
+      const response = proxy(
+        post('/api/payments/create', ip, { authorization: `Bearer sk_rotate_${i}` })
+      );
+      if (response.status === 429) limited = true;
+    }
+    expect(limited).toBe(true);
+  });
+
+  // Without this, brute-forcing a login is a matter of bolting on an unverified
+  // Authorization header to buy a 600/min budget.
+  it('keeps auth endpoints IP-limited even when a credential is presented', () => {
+    const allowed = countUntilLimited('/api/auth/login', '10.1.0.5', 40, {
+      authorization: 'Bearer sk_live_anything',
+    });
+    expect(allowed).toBe(10);
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -48,6 +48,21 @@ const rateLimitMap = new Map<string, RateLimitEntry>();
 
 const GENERAL_LIMIT = 60;
 const AUTH_LIMIT = 10;
+/**
+ * Server-to-server integrations arrive from one host, so an IP bucket sized for
+ * a single browser throttles a whole merchant. ugig.net minting payment
+ * requests for its accepted-invoice queue sends ~80 creates in a burst and got
+ * "Too many requests" partway through, which surfaced to the payer as invoices
+ * that silently would not prepare. Credentialed callers get their own bucket.
+ */
+const API_KEY_LIMIT = 600;
+/**
+ * The credential above is unverified at this layer — the route handler is what
+ * actually authenticates it. So a caller could mint buckets by rotating junk
+ * keys; this ceiling bounds that per host while staying far above any real
+ * integration's burst.
+ */
+const API_KEY_IP_CEILING = 1200;
 const WINDOW_MS = 60_000; // 1 minute
 
 // Cleanup stale entries every 5 minutes
@@ -62,13 +77,14 @@ if (typeof globalThis !== 'undefined') {
   }, 5 * 60_000);
 }
 
-function checkRateLimit(
-  ip: string,
-  isAuth: boolean
-): { allowed: boolean; limit: number; remaining: number; resetAt: number } {
-  const key = isAuth ? `auth:${ip}` : `api:${ip}`;
-  const limit = isAuth ? AUTH_LIMIT : GENERAL_LIMIT;
-  const now = Date.now();
+interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+}
+
+function bump(key: string, limit: number, now: number): RateLimitResult {
   let entry = rateLimitMap.get(key);
 
   if (!entry || entry.resetAt <= now) {
@@ -77,14 +93,57 @@ function checkRateLimit(
   }
 
   entry.count++;
-  const remaining = Math.max(0, limit - entry.count);
 
   return {
     allowed: entry.count <= limit,
     limit,
-    remaining,
+    remaining: Math.max(0, limit - entry.count),
     resetAt: entry.resetAt,
   };
+}
+
+/** FNV-1a, so a raw API key never becomes a map key we might dump or log. */
+function fingerprint(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/** The credential presented, if any. Unverified here — the route handler authenticates. */
+export function presentedCredential(
+  headers: { get(name: string): string | null }
+): string | null {
+  const authorization = headers.get('authorization');
+  if (authorization) {
+    const match = /^bearer\s+(\S+)/i.exec(authorization.trim());
+    if (match) return match[1];
+  }
+  const apiKey = headers.get('x-api-key')?.trim();
+  return apiKey ? apiKey : null;
+}
+
+function checkRateLimit(
+  ip: string,
+  isAuth: boolean,
+  credential: string | null
+): RateLimitResult {
+  const now = Date.now();
+
+  // Auth endpoints stay IP-bucketed whatever headers accompany them, or a
+  // brute-force attempt would just bolt on an Authorization header to buy a
+  // bigger budget.
+  if (isAuth) return bump(`auth:${ip}`, AUTH_LIMIT, now);
+
+  if (!credential) return bump(`api:${ip}`, GENERAL_LIMIT, now);
+
+  // Both buckets are charged; the host ceiling is what a key-rotating caller
+  // cannot escape, so a denial there wins over a healthy per-key budget.
+  const ceiling = bump(`apikey-ip:${ip}`, API_KEY_IP_CEILING, now);
+  const perKey = bump(`apikey:${fingerprint(credential)}`, API_KEY_LIMIT, now);
+  return ceiling.allowed ? perKey : ceiling;
 }
 
 // ── Proxy ───────────────────────────────────────────────────
@@ -135,7 +194,11 @@ export function proxy(request: NextRequest) {
       return response;
     }
 
-    const rl = checkRateLimit(clientIp, isAuthEndpoint);
+    const rl = checkRateLimit(
+      clientIp,
+      isAuthEndpoint,
+      presentedCredential(request.headers)
+    );
     const corsHeaders = getCorsHeaders(requestOrigin);
 
     if (!rl.allowed) {


### PR DESCRIPTION
## The bug behind "no wallet prompt"

Follow-up to #211. That PR fixed the `web-wallet` transaction caps, which was a real blocker — but it was not the one the payer was actually hitting. Bulk pay still failed with:

```
89a36dc1… — CoinPay create failed 429: Too many requests
84e78f22… — CoinPay create failed 429: Too many requests
… (16 of them)
```

`"Too many requests"` is `src/proxy.ts:144` verbatim — a **blanket per-IP bucket of 60/min in front of every `/api/*` route**.

ugig.net mints one CoinPay payment request per accepted invoice during `bulk-payment-request`. The payer has 80 accepted invoices, all with expired quotes, so all 80 need re-minting from **one server IP**. Sixty land, the rest 429.

That is also why no wallet prompt ever appeared: this happens in **prepare**, before `payBatch` is called. A batch with nothing prepared has nothing to approve, so the extension is never asked.

## The fix

A browser and a server-to-server integration are not the same client, but the bucket treated them identically.

- Callers presenting a credential (`Authorization: Bearer …` or `X-API-Key`) get a **600/min bucket keyed by a fingerprint of that credential**, not by IP.
- The credential is unverified at this layer — the route handler is what authenticates it — so a **1200/min per-host ceiling** bounds a caller that tries to mint buckets by rotating junk keys.
- Anonymous callers keep the existing 60/min IP bucket.
- **Auth endpoints stay IP-bucketed regardless of headers.** Without that, brute-forcing a login would just mean bolting on an `Authorization` header to buy a 600/min budget. There's a test pinning this.

Raw keys are never used as map keys — they're fingerprinted (FNV-1a) so they can't leak through a heap dump or log.

## Tests

New `src/proxy.test.ts` — 10 tests driving the real exported `proxy()`, no mocks: anonymous callers still cap at exactly 60; a credentialed integration clears 200 straight; two keys from one host are budgeted independently; a key-rotating host still gets cut off; auth endpoints stay at 10/min with a credential attached.

`vitest run src/proxy.test.ts src/lib/web-wallet/` — 447 passed. Typecheck and eslint clean.

## Verification of #211

Confirmed live in prod before writing this, by probing the pre-auth limiter: before deploy, `/api/web-wallet/:id/broadcast` gave 10×401 then 429 at #11 (old 10/min cap); after, 15 requests with no 429. That fix works — it just wasn't the binding constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)