### PR TITLE
fix(extension): fail loudly when the content script is gone

### DIFF
--- a/packages/extension/src/content/__tests__/bridge.test.ts
+++ b/packages/extension/src/content/__tests__/bridge.test.ts
@@ -217,3 +217,39 @@ describe('background → page events', () => {
     expect(posted).toHaveLength(0);
   });
 });
+
+/**
+ * The page cannot tell "the wallet is busy" from "the content script is gone"
+ * without an early signal, so the bridge acknowledges every request it accepts
+ * before it starts relaying. See ACK_TIMEOUT_MS in inpage/provider.ts.
+ */
+describe('request acknowledgement', () => {
+  const CHANNEL_ACK = 'coinpay:page-ack';
+
+  it('acknowledges a site: request before the background answers', async () => {
+    const posted = capturePosts();
+    // Never resolves — the ack must not be waiting on the background worker.
+    sendMessage.mockReturnValue(new Promise(() => {}));
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r-ack',
+      payload: { type: 'site:getState' },
+    });
+
+    expect(posted).toContainEqual({ channel: CHANNEL_ACK, requestId: 'r-ack' });
+  });
+
+  it('does not acknowledge a request it refuses to relay', async () => {
+    const posted = capturePosts();
+
+    await postFromPage({
+      channel: CHANNEL_REQUEST,
+      requestId: 'r-nope',
+      payload: { type: 'approval:approve' },
+    });
+
+    expect(posted).not.toContainEqual({ channel: CHANNEL_ACK, requestId: 'r-nope' });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/content/bridge.ts
+++ b/packages/extension/src/content/bridge.ts
@@ -15,6 +15,7 @@
 const CHANNEL_REQUEST = 'coinpay:page-request';
 const CHANNEL_RESPONSE = 'coinpay:page-response';
 const CHANNEL_EVENT = 'coinpay:page-event';
+const CHANNEL_ACK = 'coinpay:page-ack';
 
 function injectProvider(): void {
   const script = document.createElement('script');
@@ -37,6 +38,12 @@ window.addEventListener('message', (event: MessageEvent) => {
   // Only the page-facing surface is reachable from here; popup and approval
   // messages must never be invocable by a web page.
   if (!payload.type.startsWith('site:')) return;
+
+  // Tell the page we exist before doing anything slow. The provider object
+  // outlives this content script — an extension update orphans us while
+  // `window.coinpay` stays in the page — so silence has to be distinguishable
+  // from a user taking their time at the approval window.
+  window.postMessage({ channel: CHANNEL_ACK, requestId }, window.location.origin);
 
   const reply = (result: unknown, error?: string): void => {
     window.postMessage(

--- a/packages/extension/src/inpage/__tests__/provider.test.ts
+++ b/packages/extension/src/inpage/__tests__/provider.test.ts
@@ -12,7 +12,7 @@
  * per-test reload would be impossible, which is the property being defended.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 const CHANNEL_REQUEST = 'coinpay:page-request';
 const CHANNEL_RESPONSE = 'coinpay:page-response';
@@ -265,5 +265,54 @@ describe('onProgress subscription', () => {
     off();
     emitProgress({ id: 'a', stage: 'sent', completed: 1, total: 1 });
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The provider is injected into the page's world, so it outlives the content
+ * script that put it there. Installing or updating the extension orphans that
+ * content script in already-open tabs while `window.coinpay` stays behind —
+ * every call then posts into the void. Hanging forever is the worst possible
+ * answer: the site cannot tell it apart from a user who is slow to approve.
+ */
+describe('unresponsive content script', () => {
+  const CHANNEL_ACK = 'coinpay:page-ack';
+
+  function ack(requestId: string): void {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: CHANNEL_ACK, requestId },
+        source: window,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with a reload hint when nothing acknowledges', async () => {
+    const promise = coinpay.getState();
+    const rejection = expect(promise).rejects.toThrow(/not responding|reload the page/i);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await rejection;
+  });
+
+  it('does not time out a long batch once the content script acknowledges', async () => {
+    const promise = coinpay.payBatch([
+      { id: 'a', chain: 'SOL', to: 'addr', amount: '1' },
+    ]);
+    ack(posted.at(-1).requestId);
+
+    // A real approval plus 30 payments can take far longer than the ack window.
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    respondTo(posted.at(-1).requestId, { results: [{ id: 'a', status: 'sent' }] });
+    await expect(promise).resolves.toEqual({ results: [{ id: 'a', status: 'sent' }] });
   });
 });

--- a/packages/extension/src/inpage/provider.ts
+++ b/packages/extension/src/inpage/provider.ts
@@ -17,6 +17,26 @@
 const CHANNEL_REQUEST = 'coinpay:page-request';
 const CHANNEL_RESPONSE = 'coinpay:page-response';
 const CHANNEL_EVENT = 'coinpay:page-event';
+const CHANNEL_ACK = 'coinpay:page-ack';
+
+/**
+ * How long to wait for the content script to acknowledge a request.
+ *
+ * This provider object lives in the page's world, so it outlives the content
+ * script that injected it: installing, updating or reloading the extension
+ * orphans the content script in tabs that are already open, while
+ * `window.coinpay` stays put. Every call then posts into the void. Without this
+ * timeout the promise simply never settles — a site sits on "waiting for your
+ * wallet" forever with no error to show, which is indistinguishable from the
+ * user being slow to approve.
+ *
+ * It bounds only the acknowledgement. Once the content script answers, the
+ * request runs untimed, because a legitimate `payBatch` can take many minutes.
+ */
+const ACK_TIMEOUT_MS = 3000;
+
+const RELOAD_HINT =
+  'The CoinPay extension is not responding. This usually means it was updated or reloaded while this page was open — reload the page and try again.';
 
 export interface CoinPayPayment {
   /** Your correlation id — echoed back on the matching result. */
@@ -51,16 +71,33 @@ export interface CoinPayProgress {
   total: number;
 }
 
-type Pending = { resolve: (value: any) => void; reject: (error: Error) => void };
+type Pending = {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+  ackTimer?: ReturnType<typeof setTimeout>;
+};
 
 const pending = new Map<string, Pending>();
 const progressListeners = new Set<(progress: CoinPayProgress) => void>();
 let counter = 0;
 
+/** Stop waiting for an acknowledgement — it arrived, or the request is over. */
+function clearAck(entry: Pending): void {
+  if (entry.ackTimer === undefined) return;
+  clearTimeout(entry.ackTimer);
+  entry.ackTimer = undefined;
+}
+
 function send<T>(payload: Record<string, unknown>): Promise<T> {
   const requestId = `cp-${Date.now()}-${++counter}`;
   return new Promise<T>((resolve, reject) => {
-    pending.set(requestId, { resolve, reject });
+    const entry: Pending = { resolve, reject };
+    entry.ackTimer = setTimeout(() => {
+      // Nothing on the other end. Fail loudly rather than hanging forever.
+      if (!pending.delete(requestId)) return;
+      reject(new Error(RELOAD_HINT));
+    }, ACK_TIMEOUT_MS);
+    pending.set(requestId, entry);
     window.postMessage({ channel: CHANNEL_REQUEST, requestId, payload }, window.location.origin);
   });
 }
@@ -72,9 +109,18 @@ window.addEventListener('message', (event: MessageEvent) => {
   const data = event.data as Record<string, any> | null;
   if (!data) return;
 
+  // The content script is alive and has taken the request. Everything past
+  // this point is the user's own pace, so stop timing it.
+  if (data.channel === CHANNEL_ACK) {
+    const entry = pending.get(data.requestId);
+    if (entry) clearAck(entry);
+    return;
+  }
+
   if (data.channel === CHANNEL_RESPONSE) {
     const entry = pending.get(data.requestId);
     if (!entry) return;
+    clearAck(entry);
     pending.delete(data.requestId);
     if (data.error) entry.reject(new Error(String(data.error)));
     else entry.resolve(data.result);


### PR DESCRIPTION
## The bug

The payer clicked **Pay all** on ugig.net and got no approval window, no password prompt, no wallet/balance picker — and no error either. The dashboard just sat on *"Sending 0 of 30… Approve and keep the wallet window open."*

`window.coinpay` is injected into the **page's world**, so it outlives the content script that injected it. Installing, updating or reloading the extension orphans the content script in tabs that are already open, while the provider object stays exactly where it was. The page still feature-detects a wallet (`isCoinPay` is true), still renders its pay button, and every call `postMessage`s into a void.

`send()` (`inpage/provider.ts`) created a promise, stored it in `pending`, posted the message — and had **no timeout and no rejection path**. Nothing ever settled it.

That is the worst available failure mode: a site cannot distinguish it from a user who is slow to approve, so it shows a spinner forever.

## The fix

- `content/bridge.ts` acknowledges every request it accepts, **before** relaying to the background worker.
- `inpage/provider.ts` rejects with a reload hint if no acknowledgement arrives within 3s.

The bound covers **only the acknowledgement**. Once the content script answers, the request runs untimed — a legitimate `payBatch` can sit at the approval window for many minutes, and a blanket completion timeout would break exactly the flow this is meant to rescue.

A request the bridge refuses to relay (e.g. a page trying to invoke `approval:approve`) is not acknowledged either, so the existing scoping guarantee is unchanged.

## Tests

`packages/extension` — 282 passed, 23 files.

New coverage:
- provider rejects with a reload hint when nothing acknowledges
- provider does **not** time out a long batch once acknowledged (advances 120s of fake time, then resolves)
- bridge acknowledges before the background answers (backed by a `sendMessage` that never resolves, so a passing ack cannot be coming from the worker)
- bridge does not acknowledge a request it refuses to relay

## Note on rollout

This ships in the extension, so it needs a store republish to reach users. It does not fix an already-orphaned tab — the user-facing workaround for that is a page reload, which is precisely what the new error message now tells them to do.

Third in the bulk-payout chain after #211 (web-wallet tx caps) and #212 (proxy per-credential bucket), both merged and verified in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)