### PR TITLE
fix(web-wallet): share one blockhash across a batch instead of one RPC call each

### DIFF
--- a/src/lib/web-wallet/prepare-tx.test.ts
+++ b/src/lib/web-wallet/prepare-tx.test.ts
@@ -5,6 +5,7 @@ import {
   CHAIN_IDS,
   USDC_CONTRACTS,
   fetchUTXOs,
+  resetBlockhashCache,
 } from './prepare-tx';
 
 // ──────────────────────────────────────────────
@@ -92,6 +93,9 @@ function createMockSupabase(overrides: {
 describe('prepareTransaction', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    // The blockhash cache is deliberately shared across calls, so it has to be
+    // cleared or one test's blockhash satisfies the next test's request.
+    resetBlockhashCache();
   });
 
   // ──────────────────────────────────────────────
@@ -386,12 +390,73 @@ describe('prepareTransaction', () => {
       }
     });
 
+    it('reuses one blockhash across a batch instead of one RPC call each', async () => {
+      // The failure this guards: preparing 80 payments fired 80 back-to-back
+      // getLatestBlockhash calls, and the public RPC answered 429 and then
+      // stopped answering at all — every payment in the batch failed.
+      const supabase = createMockSupabase({
+        addressResult: { id: 'addr-1', address: '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV', chain: 'SOL' },
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          jsonrpc: '2.0',
+          result: { value: { blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N', lastValidBlockHeight: 1 } },
+          id: 1,
+        }),
+      });
+
+      const batch = await Promise.all(
+        Array.from({ length: 25 }, () =>
+          prepareTransaction(supabase, 'w1', {
+            from_address: '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+            to_address: 'FxkPpN3Nt1NHFxJ2ECE3dwXeGujhzVJAqwnMBKwfpump',
+            chain: 'SOL',
+            amount: '0.01',
+          })
+        )
+      );
+
+      expect(batch.every((r) => r.success)).toBe(true);
+      // 25 concurrent preparations, one RPC call — misses collapse onto a
+      // single in-flight request rather than stampeding the endpoint.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a rate-limited blockhash instead of failing the payment', async () => {
+      const supabase = createMockSupabase({
+        addressResult: { id: 'addr-1', address: '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV', chain: 'SOL' },
+      });
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 429, headers: { get: () => '0' } })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            jsonrpc: '2.0',
+            result: { value: { blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N', lastValidBlockHeight: 1 } },
+            id: 1,
+          }),
+        });
+
+      const result = await prepareTransaction(supabase, 'w1', {
+        from_address: '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+        to_address: 'FxkPpN3Nt1NHFxJ2ECE3dwXeGujhzVJAqwnMBKwfpump',
+        chain: 'SOL',
+        amount: '0.01',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('should handle blockhash fetch failure', async () => {
       const supabase = createMockSupabase({
         addressResult: { id: 'addr-1', address: 'SOLaddr', chain: 'SOL' },
       });
 
-      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockFetch.mockResolvedValue({ ok: false, status: 400 });
 
       const result = await prepareTransaction(supabase, 'w1', {
         from_address: 'SOLaddr',

--- a/src/lib/web-wallet/prepare-tx.ts
+++ b/src/lib/web-wallet/prepare-tx.ts
@@ -319,6 +319,122 @@ async function fetchUTXOs(address: string, chain: WalletChain): Promise<UTXOInpu
 // SOL Transaction Preparation
 // ──────────────────────────────────────────────
 
+/**
+ * Shared recent-blockhash fetch.
+ *
+ * Preparing a batch of payments used to call `getLatestBlockhash` once per
+ * transaction. An 80-payment run therefore fired 80 back-to-back RPC requests,
+ * which public Solana endpoints answer with 429 and then refuse outright — the
+ * whole batch failed with "Failed to get blockhash: 429" followed by "Failed to
+ * fetch".
+ *
+ * A blockhash stays valid for ~150 slots (about a minute), so one is good for
+ * every transaction in a batch. Two things make that safe under concurrency:
+ *
+ *   - a short TTL cache, so a batch costs one RPC call rather than N, and
+ *   - an in-flight promise, so N *simultaneous* misses collapse into a single
+ *     request instead of all stampeding the endpoint at once.
+ *
+ * The TTL is deliberately far below the real expiry: a slightly stale blockhash
+ * still confirms, but one that has aged out makes the transaction silently
+ * un-landable, which is much worse than an extra RPC call.
+ */
+const BLOCKHASH_TTL_MS = 20_000;
+const BLOCKHASH_RETRIES = 3;
+
+interface CachedBlockhash {
+  value: string;
+  fetchedAt: number;
+}
+
+const blockhashCache = new Map<string, CachedBlockhash>();
+const blockhashInFlight = new Map<string, Promise<string>>();
+
+/** Test seam: forget any cached blockhash. */
+export function resetBlockhashCache(): void {
+  blockhashCache.clear();
+  blockhashInFlight.clear();
+}
+
+async function fetchBlockhash(rpcUrl: string): Promise<string> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= BLOCKHASH_RETRIES; attempt++) {
+    try {
+      const resp = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'getLatestBlockhash',
+          params: [{ commitment: 'finalized' }],
+          id: 1,
+        }),
+      });
+
+      if (resp.status === 429 || resp.status >= 500) {
+        // Transient by definition — the endpoint is busy, not the request bad.
+        const retryAfter = Number(resp.headers?.get?.('retry-after'));
+        const wait = Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1000
+          : 250 * 2 ** (attempt - 1);
+        lastError = new Error(`Failed to get blockhash: ${resp.status}`);
+        if (attempt < BLOCKHASH_RETRIES) {
+          await new Promise((r) => setTimeout(r, Math.min(wait, 4000)));
+          continue;
+        }
+        throw lastError;
+      }
+
+      if (!resp.ok) {
+        throw new Error(`Failed to get blockhash: ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      if (data.error) {
+        throw new Error(`Blockhash RPC error: ${data.error.message}`);
+      }
+
+      const blockhash = data.result?.value?.blockhash;
+      if (!blockhash) {
+        throw new Error('Failed to get recent blockhash');
+      }
+      return blockhash;
+    } catch (err: any) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      // A dropped connection mid-batch is as transient as a 429.
+      const isLast = attempt >= BLOCKHASH_RETRIES;
+      if (isLast) throw lastError;
+      await new Promise((r) => setTimeout(r, 250 * 2 ** (attempt - 1)));
+    }
+  }
+
+  throw lastError ?? new Error('Failed to get recent blockhash');
+}
+
+async function getRecentBlockhash(rpcUrl: string): Promise<string> {
+  const cached = blockhashCache.get(rpcUrl);
+  if (cached && Date.now() - cached.fetchedAt < BLOCKHASH_TTL_MS) {
+    return cached.value;
+  }
+
+  // Collapse concurrent misses onto one request.
+  const existing = blockhashInFlight.get(rpcUrl);
+  if (existing) return existing;
+
+  const pending = fetchBlockhash(rpcUrl)
+    .then((value) => {
+      blockhashCache.set(rpcUrl, { value, fetchedAt: Date.now() });
+      return value;
+    })
+    .finally(() => {
+      blockhashInFlight.delete(rpcUrl);
+    });
+
+  blockhashInFlight.set(rpcUrl, pending);
+  return pending;
+}
+
 async function prepareSOLTransaction(
   from: string,
   to: string,
@@ -326,31 +442,7 @@ async function prepareSOLTransaction(
   chain: WalletChain,
   rpcUrl: string
 ): Promise<SOLUnsignedTx> {
-  // Get recent blockhash
-  const resp = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'getLatestBlockhash',
-      params: [{ commitment: 'finalized' }],
-      id: 1,
-    }),
-  });
-
-  if (!resp.ok) {
-    throw new Error(`Failed to get blockhash: ${resp.status}`);
-  }
-
-  const data = await resp.json();
-  if (data.error) {
-    throw new Error(`Blockhash RPC error: ${data.error.message}`);
-  }
-
-  const recentBlockhash = data.result?.value?.blockhash;
-  if (!recentBlockhash) {
-    throw new Error('Failed to get recent blockhash');
-  }
+  const recentBlockhash = await getRecentBlockhash(rpcUrl);
 
   if (chain === 'USDC_SOL' || chain === 'USDT_SOL') {
     // SPL token transfer — client needs to build the full instruction


### PR DESCRIPTION
## Symptom

Approving an 80-payment batch in the wallet failed **entirely** — first a few with:

```
failed · Failed to get blockhash: 429
```

then every remaining payment with:

```
failed · Failed to fetch
```

## Cause

`prepareSOLTransaction` called `getLatestBlockhash` **once per transaction**. An 80-payment batch therefore fired 80 back-to-back RPC requests. Public Solana endpoints answer that with `429`, then stop answering at all — which is exactly the observed degradation from a rate-limit error to a raw network failure.

## Fix

A blockhash is valid for ~150 slots (about a minute), so **one is good for every transaction in a batch**. Two things make sharing it safe:

- **A short TTL cache (20s).** Deliberately far below the real expiry: a slightly stale blockhash still confirms, but one that has aged out makes the transaction silently un-landable — much worse than an extra RPC call.
- **A single in-flight promise.** This is the part that actually matters here. The cache alone would not help, because 80 concurrent preparations all miss *simultaneously* and stampede anyway. Collapsing concurrent misses onto one request is what turns 80 calls into 1.

`429` and `5xx` are now also retried with backoff honouring `Retry-After`, since a busy endpoint says nothing about whether the payment itself is valid.

## Verification

- **3607 tests pass across 255 files** (full suite), `tsc --noEmit` clean, pre-commit gate passed
- New test prepares **25 concurrent** SOL transactions and asserts **exactly 1** `fetch` — it would be 25 without the fix
- New test covers a `429` being retried rather than failing the payment
- The pre-existing "blockhash fetch failure" test now uses a `400` so it exercises the non-retryable path deliberately

## Context

This is the downstream half of a masspay failure. ugig.net's side is already fixed and confirmed in production (81/81 payment requests created, zero rate-limit errors); the batch then reached the wallet and died here instead.

## Not addressed here

The approval UI came up as an in-page centered modal rather than the pinned browser extension. That is a separate concern from this RPC bug and is left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)