### PR TITLE
fix(monitor): batch SOL balance checks instead of one RPC call per payment

### DIFF
--- a/src/lib/payments/monitor-balance.test.ts
+++ b/src/lib/payments/monitor-balance.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkBalance, primeSolanaBalances, resetSolBalanceCache } from './monitor-balance';
+
+/**
+ * The failure these guard: the monitor checked pending payments one at a time
+ * and each SOL payment cost its own `getBalance` call. Roughly 50 pending
+ * payments every 15 seconds sat permanently on Solana's public-endpoint limit,
+ * so nearly every balance check came back "Connection rate limits exceeded" —
+ * and a rate-limited check reports a funded address as empty.
+ */
+
+const ADDRESSES = [
+  '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+  'BxtftDrpgc8PwqWmuaBYW2ofBcwoQh9WS2rq5ern1Z98',
+  '3xd6Zs25BRV67cVo5MEHyYZzEaAq9RWNUpFHDn3Q44ed',
+];
+
+function jsonOk(body: unknown) {
+  return { ok: true, status: 200, json: async () => body, text: async () => '' };
+}
+
+describe('primeSolanaBalances', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    resetSolBalanceCache();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a whole cycle of addresses in one RPC call', async () => {
+    mockFetch.mockResolvedValue(
+      jsonOk({ jsonrpc: '2.0', result: { value: ADDRESSES.map(() => ({ lamports: 0 })) }, id: 1 })
+    );
+
+    await primeSolanaBalances(ADDRESSES, 'https://rpc.example');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.method).toBe('getMultipleAccounts');
+    expect(body.params[0]).toEqual(ADDRESSES);
+  });
+
+  it('serves primed balances without another RPC call', async () => {
+    mockFetch.mockResolvedValue(
+      jsonOk({
+        jsonrpc: '2.0',
+        result: { value: [{ lamports: 0 }, { lamports: 0 }, { lamports: 0 }] },
+        id: 1,
+      })
+    );
+    await primeSolanaBalances(ADDRESSES, 'https://rpc.example');
+    mockFetch.mockClear();
+
+    for (const address of ADDRESSES) {
+      const result = await checkBalance(address, 'SOL');
+      expect(result.balance).toBe(0);
+    }
+
+    // Three balance checks, zero extra requests — the whole point.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('reports a primed non-zero balance in SOL, not lamports', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({ jsonrpc: '2.0', result: { value: [{ lamports: 1_500_000_000 }] }, id: 1 })
+    );
+    await primeSolanaBalances([ADDRESSES[0]], 'https://rpc.example');
+
+    // Funded addresses still look up their signature, which is a small
+    // fraction of the pending set.
+    mockFetch.mockResolvedValue(
+      jsonOk({ jsonrpc: '2.0', result: [{ signature: 'sig-1' }], id: 1 })
+    );
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+    expect(result.balance).toBe(1.5);
+    expect(result.txHash).toBe('sig-1');
+  });
+
+  it('treats a missing account as an empty address', async () => {
+    // getMultipleAccounts returns null for accounts that do not exist yet,
+    // which for a payment address just means nothing has arrived.
+    mockFetch.mockResolvedValue(
+      jsonOk({ jsonrpc: '2.0', result: { value: [null] }, id: 1 })
+    );
+    await primeSolanaBalances([ADDRESSES[0]], 'https://rpc.example');
+    mockFetch.mockClear();
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+    expect(result.balance).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('chunks past the 100-account limit rather than sending one huge request', async () => {
+    mockFetch.mockImplementation(async (_url: string, init: any) => {
+      const ids = JSON.parse(init.body).params[0] as string[];
+      return jsonOk({ jsonrpc: '2.0', result: { value: ids.map(() => ({ lamports: 0 })) }, id: 1 });
+    });
+
+    const many = Array.from({ length: 250 }, (_, i) => `addr-${i}`);
+    await primeSolanaBalances(many, 'https://rpc.example');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    for (const call of mockFetch.mock.calls) {
+      expect(JSON.parse(call[1].body).params[0].length).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('falls back to a single lookup when priming fails', async () => {
+    // A failed prime is an optimisation miss, not an outage — the per-address
+    // path must still work.
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429, text: async () => 'rate limited' });
+    await primeSolanaBalances([ADDRESSES[0]], 'https://rpc.example');
+    mockFetch.mockClear();
+
+    mockFetch.mockResolvedValue(
+      jsonOk({ jsonrpc: '2.0', result: { value: 0 }, id: 1 })
+    );
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+
+    expect(result.balance).toBe(0);
+    expect(mockFetch).toHaveBeenCalled();
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).method).toBe('getBalance');
+  });
+
+  it('ignores duplicate and empty addresses', async () => {
+    mockFetch.mockImplementation(async (_url: string, init: any) => {
+      const ids = JSON.parse(init.body).params[0] as string[];
+      return jsonOk({ jsonrpc: '2.0', result: { value: ids.map(() => ({ lamports: 0 })) }, id: 1 });
+    });
+
+    await primeSolanaBalances([ADDRESSES[0], ADDRESSES[0], '', ADDRESSES[1]], 'https://rpc.example');
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).params[0]).toEqual([
+      ADDRESSES[0],
+      ADDRESSES[1],
+    ]);
+  });
+
+  it('does nothing at all when there is nothing to prime', async () => {
+    await primeSolanaBalances([], 'https://rpc.example');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/payments/monitor-balance.ts
+++ b/src/lib/payments/monitor-balance.ts
@@ -239,11 +239,110 @@ async function checkEVMTokenBalance(
   }
 }
 
+// ──────────────────────────────────────────────
+// Batched SOL balance lookups
+// ──────────────────────────────────────────────
+
+/**
+ * The monitor checks pending payments one at a time, and each SOL payment used
+ * to cost its own `getBalance` call. A cycle with 48 pending payments therefore
+ * made 48 sequential RPC requests, every cycle, forever — enough to sit on
+ * Solana's public-endpoint limit permanently and answer nearly every call with
+ * "Connection rate limits exceeded".
+ *
+ * `getMultipleAccounts` returns up to 100 accounts in a single request, so a
+ * whole cycle's worth of addresses costs one call instead of N. The cycle primes
+ * this cache up front and the per-address checks read from it.
+ *
+ * The TTL is short on purpose. This cache exists to collapse one cycle's lookups,
+ * not to remember balances between cycles — the monitor's entire job is noticing
+ * when a balance changes, and stale data here delays exactly that.
+ */
+const SOL_BALANCE_TTL_MS = 20_000;
+const SOL_ACCOUNTS_PER_CALL = 100;
+
+const solBalanceCache = new Map<string, { lamports: number; at: number }>();
+
+/** Test seam: forget any primed balances. */
+export function resetSolBalanceCache(): void {
+  solBalanceCache.clear();
+}
+
+/**
+ * Fetch every given address's lamport balance in as few RPC calls as possible
+ * and cache the results for the current cycle. Failures are swallowed: a primed
+ * cache is an optimisation, and any address left unprimed simply falls back to
+ * its own `getBalance` call.
+ */
+export async function primeSolanaBalances(
+  addresses: string[],
+  rpcUrl: string = RPC_ENDPOINTS.SOL
+): Promise<void> {
+  const unique = [...new Set(addresses.filter(Boolean))];
+  if (unique.length === 0) return;
+
+  for (let i = 0; i < unique.length; i += SOL_ACCOUNTS_PER_CALL) {
+    const chunk = unique.slice(i, i + SOL_ACCOUNTS_PER_CALL);
+    try {
+      const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'getMultipleAccounts',
+          params: [chunk, { encoding: 'base64', commitment: 'confirmed' }],
+          id: 1,
+        }),
+      });
+
+      if (!response.ok) {
+        await drainResponse(response);
+        console.warn(`[Monitor] Batch SOL balance prime failed: ${response.status}`);
+        continue;
+      }
+
+      const data = await response.json();
+      if (data.error) {
+        console.warn('[Monitor] Batch SOL balance RPC error:', data.error);
+        continue;
+      }
+
+      const values = data.result?.value;
+      if (!Array.isArray(values)) continue;
+
+      const at = Date.now();
+      chunk.forEach((address, index) => {
+        // A null entry means the account does not exist on chain, which for a
+        // payment address is simply "nothing has arrived yet".
+        const lamports = values[index]?.lamports ?? 0;
+        solBalanceCache.set(address, { lamports, at });
+      });
+    } catch (error) {
+      console.warn('[Monitor] Batch SOL balance prime threw:', error);
+    }
+  }
+}
+
+function cachedSolLamports(address: string): number | null {
+  const hit = solBalanceCache.get(address);
+  if (!hit) return null;
+  if (Date.now() - hit.at >= SOL_BALANCE_TTL_MS) {
+    solBalanceCache.delete(address);
+    return null;
+  }
+  return hit.lamports;
+}
+
 /**
  * Check balance for a Solana address
  */
 async function checkSolanaBalance(address: string, rpcUrl: string): Promise<BalanceResult> {
   try {
+    const primed = cachedSolLamports(address);
+    if (primed !== null) {
+      return solanaBalanceResult(address, primed, rpcUrl);
+    }
+
     const response = await fetch(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -254,54 +353,68 @@ async function checkSolanaBalance(address: string, rpcUrl: string): Promise<Bala
         id: 1,
       }),
     });
-    
+
     if (!response.ok) {
       const errorText = await response.text();
       console.error(`[Monitor] Failed to fetch SOL balance for ${address}: ${response.status} - ${errorText}`);
       return { balance: 0 };
     }
-    
+
     const data = await response.json();
     if (data.error) {
       console.error(`[Monitor] RPC error for ${address}:`, data.error);
       return { balance: 0 };
     }
     
-    const balanceLamports = data.result?.value || 0;
-    const balance = balanceLamports / 1e9;
-    
-    // Get the latest transaction signature if there's a balance
-    let txHash: string | undefined;
-    if (balance > 0) {
-      try {
-        const sigResponse = await fetch(rpcUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'getSignaturesForAddress',
-            params: [address, { limit: 1 }],
-            id: 1,
-          }),
-        });
-        
-        if (sigResponse.ok) {
-          const sigData = await sigResponse.json();
-          if (sigData.result && sigData.result.length > 0) {
-            txHash = sigData.result[0].signature;
-            console.log(`[Monitor] SOL tx hash for ${address}: ${txHash}`);
-          }
-        }
-      } catch (txError) {
-        console.error(`[Monitor] Error fetching SOL transactions for ${address}:`, txError);
-      }
-    }
-    
-    return { balance, txHash };
+    return solanaBalanceResult(address, data.result?.value || 0, rpcUrl);
   } catch (error) {
     console.error(`[Monitor] Error checking SOL balance for ${address}:`, error);
     return { balance: 0 };
   }
+}
+
+/**
+ * Turn a lamport balance into a `BalanceResult`, looking up the funding
+ * signature only when there is actually something there. Shared by the primed
+ * and unprimed paths so both report identically.
+ */
+async function solanaBalanceResult(
+  address: string,
+  balanceLamports: number,
+  rpcUrl: string
+): Promise<BalanceResult> {
+  const balance = balanceLamports / 1e9;
+  if (balance <= 0) return { balance };
+
+  // Only funded addresses cost this extra call, which is a small fraction of
+  // the pending set — the rest are still waiting for money to arrive.
+  let txHash: string | undefined;
+  try {
+    const sigResponse = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'getSignaturesForAddress',
+        params: [address, { limit: 1 }],
+        id: 1,
+      }),
+    });
+
+    if (sigResponse.ok) {
+      const sigData = await sigResponse.json();
+      if (sigData.result && sigData.result.length > 0) {
+        txHash = sigData.result[0].signature;
+        console.log(`[Monitor] SOL tx hash for ${address}: ${txHash}`);
+      }
+    } else {
+      await drainResponse(sigResponse);
+    }
+  } catch (txError) {
+    console.error(`[Monitor] Error fetching SOL transactions for ${address}:`, txError);
+  }
+
+  return { balance, txHash };
 }
 
 async function checkSolanaTokenBalance(

--- a/src/lib/payments/monitor.ts
+++ b/src/lib/payments/monitor.ts
@@ -10,7 +10,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { runWalletTxCycle } from '../web-wallet/tx-finalize';
-import { processPayment, type Payment } from './monitor-balance';
+import { primeSolanaBalances, processPayment, type Payment } from './monitor-balance';
 import { runEscrowCycle, runRecurringEscrowCycle } from './monitor-escrow';
 import { runInvoiceMonitorCycle, runInvoiceSchedulerCycle } from './monitor-invoices';
 
@@ -77,7 +77,17 @@ async function runMonitorCycle(): Promise<{ checked: number; confirmed: number; 
       console.error('[Monitor] Failed to fetch pending payments:', fetchError);
     } else if (pendingPayments && pendingPayments.length > 0) {
       // Only log when there are payments to process
-      
+
+      // One batched lookup for every native-SOL address in this cycle, instead
+      // of one RPC call per payment inside the loop below. At ~50 pending
+      // payments that is the difference between 1 request and 50, which is what
+      // was keeping us permanently at the public endpoint's connection limit.
+      await primeSolanaBalances(
+        (pendingPayments as any[])
+          .filter((p) => p.blockchain === 'SOL')
+          .map((p) => p.payment_address)
+      );
+
       for (const payment of pendingPayments as any[]) {
         stats.checked++;
         try {


### PR DESCRIPTION
## Symptom

The monitor logged this for nearly every Solana address, cycle after cycle:

```
[Monitor] Failed to fetch SOL balance for BxtftDrpgc8Pwq…: 429 -
  {"code":429,"message":"Connection rate limits exceeded"}
```

## Cause

The monitor checks pending payments one at a time, and **each SOL payment cost its own `getBalance` call**. With ~50 pending payments and `MONITOR_INTERVAL_MS=15000`, that is a sustained **~3 requests/second of nothing but balance polling** — enough to sit on Solana's public-endpoint limit permanently.

The consequence is worse than noise: a rate-limited check returns `{ balance: 0 }`, so a saturated cycle **silently reports every funded address as empty**. The monitor's one job — noticing that money arrived — quietly stops happening.

## Fix

`getMultipleAccounts` returns up to 100 accounts per request, so a whole cycle's addresses now cost **one call instead of N**. The cycle primes a short-lived cache before the loop; the per-address checks read from it.

Deliberate choices:

- **Anything unprimed falls back to its own `getBalance`.** A failed prime degrades to the old behaviour rather than breaking — the cache is an optimisation, not a dependency.
- **The TTL is short (20s, against a 15s cycle).** This cache exists to collapse *one cycle's* lookups, not to remember balances between cycles. Noticing a balance change is precisely what the monitor is for, and stale data here would delay exactly that.
- **Signature lookups are unchanged**, still per-address — but only *funded* addresses pay for one, which is a small fraction of the pending set.

## Verification

- **3615 tests pass across 256 files** (full suite), `tsc --noEmit` clean, eslint clean, pre-commit gate passed
- 8 new tests: one call for a whole cycle, primed reads costing zero requests, lamports→SOL conversion, `null` accounts treated as empty, chunking past 100, and fallback when priming fails

## Why this instead of a paid RPC provider

The obvious reading of those 429s is "outgrow the free endpoint." But the endpoint was not the problem — an N+1 was. This removes roughly 50× the Solana traffic per cycle at no cost. A dedicated provider is still worth having eventually for headroom, since real money moves over this, but it should be bought against evidence rather than used to paper over a fixable query pattern.

## Related

Third in a chain of the same bug shape found while fixing an 80-invoice masspay: ugig.net's per-invoice status polls (ugig.net#514), the wallet's per-transaction blockhash fetches (#214), and now the monitor's per-payment balance checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)