### PR TITLE
chore(extension): 0.9.0 -> 0.9.1 (content-script hang fix)

### DIFF
--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",


### PR DESCRIPTION
Ships #213 to users.

Browsers only pick up an extension update when the manifest version increases, so that fix has been sitting in `master` unreachable by anyone who already has the extension installed — including the payer hitting the bulk-payout hang it fixes.

Patch, not minor: #213 is the **only** change to `packages/extension` since `0.9.0` was set (in `0a70259`), and it is a bug fix.

Bumped in all three places that carry the version:
- `packages/extension/package.json`
- `packages/extension/manifest/manifest.chrome.json`
- `packages/extension/manifest/manifest.firefox.json`

## Builds

Both targets build clean from this commit, and the fix is verified present in the **built** bundles, not just source:

- `dist/manifest.json` → `0.9.1`
- `page-ack` channel present in both `dist/inpage/provider.js` and `dist/content/bridge.js`
- reload-hint string present in the built provider

Packaged store artifacts (20 files each, Chrome using `background.service_worker`, Firefox using `background.scripts`):

```
/home/anthony/coinpay-extension-builds/coinpay-wallet-0.9.1-chrome.zip
/home/anthony/coinpay-extension-builds/coinpay-wallet-0.9.1-firefox.zip
```

## Still needs a human

There is no extension release workflow in `.github/workflows/` — Railway deploys only the website. Publishing these zips to the Chrome Web Store and AMO requires store credentials, so it can't be automated from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)