### PR TITLE
fix(web-wallet): say why a SOL broadcast failed, and stop retrying rejections

### DIFF
--- a/src/lib/web-wallet/broadcast.test.ts
+++ b/src/lib/web-wallet/broadcast.test.ts
@@ -357,6 +357,75 @@ describe('broadcastTransaction', () => {
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toContain('insufficient funds for rent');
     });
+
+    /**
+     * Every rejected Solana transaction carries the same `message` —
+     * "Transaction simulation failed" — so a payer used to get one
+     * indistinguishable error whether their wallet was empty, their blockhash
+     * had aged out, or something else entirely. The cause lives in
+     * `error.data`, which was being thrown away.
+     */
+    async function solError(data: unknown) {
+      const supabase = createMockSupabase({
+        txRecord: {
+          id: 'tx-123',
+          wallet_id: 'w1',
+          chain: 'SOL',
+          status: 'pending',
+          metadata: { expires_at: new Date(Date.now() + 300_000).toISOString() },
+        },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          error: { code: -32002, message: 'Transaction simulation failed', data },
+          id: 1,
+        }),
+      });
+      const result = await broadcastTransaction(supabase, 'w1', {
+        tx_id: 'tx-123',
+        signed_tx: 'base64encodedtx',
+        chain: 'SOL',
+      });
+      expect(result.success).toBe(false);
+      return result.success ? '' : result.error;
+    }
+
+    it('names an empty wallet instead of "simulation failed"', async () => {
+      const error = await solError({
+        err: { InstructionError: [0, { Custom: 1 }] },
+        logs: ['Program 11111111111111111111111111111111 failed: insufficient lamports 1000, need 5000'],
+      });
+      expect(error).toMatch(/enough SOL/i);
+    });
+
+    it('names an expired blockhash, which is worth retrying', async () => {
+      const error = await solError({ err: 'BlockhashNotFound', logs: [] });
+      expect(error).toMatch(/blockhash expired/i);
+    });
+
+    it('passes through an unfamiliar chain error rather than hiding it', async () => {
+      const error = await solError({
+        err: { InstructionError: [0, 'ProgramFailedToComplete'] },
+        logs: ['Program log: something specific and unexpected'],
+      });
+      expect(error).toContain('ProgramFailedToComplete');
+      expect(error).toContain('something specific and unexpected');
+    });
+
+    it('still reports something useful when the chain sends no detail', async () => {
+      const error = await solError(undefined);
+      expect(error).toContain('Transaction simulation failed');
+    });
+
+    it('does not retry a rejected simulation', async () => {
+      // The chain has already decided about these exact bytes. Re-sending them
+      // cannot change the verdict — it just costs the payer seconds of backoff
+      // and four RPC calls on an endpoint we are rationing.
+      await solError({ err: 'BlockhashNotFound', logs: [] });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ──────────────────────────────────────────────

--- a/src/lib/web-wallet/broadcast.ts
+++ b/src/lib/web-wallet/broadcast.ts
@@ -96,6 +96,15 @@ async function withRetry<T>(
         msg.includes('insufficient funds') ||
         msg.includes('TATUM_API_KEY required') ||
         msg.includes('Invalid transaction') ||
+        // A rejected simulation is the chain's deterministic verdict on this
+        // exact signed transaction: an empty wallet, an aged-out blockhash, a
+        // failing instruction. Re-sending the identical bytes cannot change the
+        // answer, so retrying only costs the payer ~7s of backoff and spends
+        // four RPC calls where one would do — across a large batch, enough to
+        // help exhaust the endpoint we are already rationing.
+        msg.includes('simulation failed') ||
+        msg.includes('enough SOL') ||
+        msg.includes('blockhash expired') ||
         attempt === retries
       ) {
         throw err;
@@ -210,10 +219,52 @@ async function broadcastSOL(signedTxBase64: string, rpcUrl: string): Promise<str
 
   const data = await resp.json();
   if (data.error) {
-    throw new Error(`SOL broadcast error: ${data.error.message}`);
+    throw new Error(`SOL broadcast error: ${describeSolError(data.error)}`);
   }
 
   return data.result; // Returns signature
+}
+
+/**
+ * Turn a Solana RPC error into something a payer can act on.
+ *
+ * `error.message` for a rejected transaction is always the same sentence —
+ * "Transaction simulation failed" — regardless of whether the wallet is short
+ * on SOL, the blockhash aged out, or the account does not exist. The reason is
+ * in `error.data`, which we used to discard, so every distinct cause reached
+ * the payer as one indistinguishable failure they could do nothing about.
+ */
+function describeSolError(error: {
+  message?: string;
+  data?: { err?: unknown; logs?: string[] };
+}): string {
+  const base = error.message || 'unknown error';
+  const err = error.data?.err;
+  const logs = error.data?.logs ?? [];
+
+  // The common causes are worth naming outright rather than making someone
+  // read program logs to discover their wallet is empty.
+  const haystack = `${JSON.stringify(err ?? '')} ${logs.join(' ')}`;
+  if (/InsufficientFundsForRent|insufficient lamports|InsufficientFunds/i.test(haystack)) {
+    return `${base}: the sending wallet does not have enough SOL to cover this transfer plus fees`;
+  }
+  if (/BlockhashNotFound/i.test(haystack)) {
+    return `${base}: the transaction's blockhash expired before it was broadcast — try again`;
+  }
+  if (/AccountNotFound|could not find account/i.test(haystack)) {
+    return `${base}: the sending account does not exist on chain yet`;
+  }
+
+  // Anything else: pass through what the chain actually said, so an unfamiliar
+  // failure is still diagnosable from the payer's screen and the server log.
+  const detail = [
+    err !== undefined && err !== null ? JSON.stringify(err) : null,
+    logs.length > 0 ? logs.slice(-3).join(' | ') : null,
+  ]
+    .filter(Boolean)
+    .join(' — ');
+
+  return detail ? `${base}: ${detail}` : base;
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Symptom

Every failed payment in a batch reported the identical, useless line:

```
failed · Broadcast failed: SOL broadcast error: Transaction simulation failed
```

## Cause 1 — the reason was being discarded

That sentence is Solana's generic `error.message` for *any* rejected transaction. The actual cause lives in `error.data.err` and `error.data.logs`, and `broadcast.ts:213` threw only `error.message`.

So an empty wallet, an expired blockhash, and a failing instruction all reached the payer as one indistinguishable failure they could do nothing about — and the server log was no better, which is why diagnosing the current batch required guessing.

Now the common causes are named outright:

> the sending wallet does not have enough SOL to cover this transfer plus fees

and anything unrecognised passes through the chain's own `err` plus the last few program logs, so an unfamiliar failure stays diagnosable rather than being flattened.

## Cause 2 — surfaced by fixing the first

`withRetry` treats anything outside its permanent-error list as retryable, and `"Transaction simulation failed"` was **not** on that list. So **every rejected payment was re-broadcast three times with exponential backoff.**

A rejected simulation is the chain's deterministic verdict on those exact signed bytes — re-sending them cannot change the answer. It only cost:

- **~7 seconds of backoff per failed payment**, and
- **4 RPC calls where 1 would do**

Across an 80-payment batch that is a meaningful share of the very endpoint budget being rationed elsewhere in this repo. Re-broadcast was at least idempotent (Solana dedupes by signature), so this was waste rather than a double-spend risk.

## Verification

- **3636 tests pass across 257 files** (full suite), `tsc --noEmit` clean, pre-commit gate passed
- 5 new tests: empty wallet named, expired blockhash named, unfamiliar errors passed through intact, no-detail case still useful, and a rejected simulation issuing exactly **1** fetch instead of 4

## Context

Found while diagnosing an 80-invoice masspay. This does not by itself make those payments succeed — it makes them **say why they didn't**, which is currently the blocker to knowing whether the remaining failures are an under-funded wallet or something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)