### PR TITLE
feat(extension): let a site choose which account funds a batch

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -383,6 +383,7 @@ async function handleSitePayBatch(
   origin: string,
   rawPayments: unknown,
   sender: chrome.runtime.MessageSender,
+  from?: string,
 ): Promise<WalletResponse> {
   if (!(await connections.isConnected(origin))) {
     return { ok: false, error: 'Site is not connected to this wallet' };
@@ -413,7 +414,7 @@ async function handleSitePayBatch(
     // Approving requires unlocking, so by here the seed is available.
     const seed = await wallet.requireSeed();
     const walletId = await ensurePortalWallet(seed);
-    const senders = await sendersFor();
+    const senders = await sendersFor(from);
 
     const authKey = deriveIdentityKey(seed);
     try {
@@ -770,7 +771,7 @@ async function handle(
       case 'site:payBatch': {
         const origin = senderOrigin(sender);
         if (!origin) return { ok: false, error: 'Unknown origin' };
-        return handleSitePayBatch(origin, req.payments, sender);
+        return handleSitePayBatch(origin, req.payments, sender, req.from);
       }
 
       // ── approval window ──

--- a/packages/extension/src/inpage/__tests__/provider.test.ts
+++ b/packages/extension/src/inpage/__tests__/provider.test.ts
@@ -178,12 +178,33 @@ describe('payBatch', () => {
   it('sends the payments through and resolves with per-item results', async () => {
     const promise = coinpay.payBatch(payments);
 
-    expect(posted.at(-1).payload).toEqual({ type: 'site:payBatch', payments });
+    expect(posted.at(-1).payload).toEqual({
+      type: 'site:payBatch',
+      payments,
+      from: undefined,
+    });
 
     respond({ results: [{ id: 'inv-1', status: 'sent', txHash: '0xhash' }] });
     await expect(promise).resolves.toEqual({
       results: [{ id: 'inv-1', status: 'sent', txHash: '0xhash' }],
     });
+  });
+
+  it('passes the chosen source account through to the wallet', async () => {
+    // A wallet can hold several addresses per chain. Without `from` the batch
+    // always spent the first one, so a site could not pay from the account
+    // that actually holds the money — which silently failed whole runs with
+    // "not enough SOL" while the funds sat one address over.
+    const promise = coinpay.payBatch(payments, { from: 'B3zn7yeoL6NP8JCpis9ikGX8U4uCbrybCu5QeFyqkKpr' });
+
+    expect(posted.at(-1).payload).toEqual({
+      type: 'site:payBatch',
+      payments,
+      from: 'B3zn7yeoL6NP8JCpis9ikGX8U4uCbrybCu5QeFyqkKpr',
+    });
+
+    respond({ results: [] });
+    await promise;
   });
 
   it('resolves — not rejects — when some payments failed', async () => {

--- a/packages/extension/src/inpage/provider.ts
+++ b/packages/extension/src/inpage/provider.ts
@@ -168,11 +168,20 @@ const provider = {
    */
   async payBatch(
     payments: CoinPayPayment[],
-    options: { onProgress?: (progress: CoinPayProgress) => void } = {},
+    options: {
+      onProgress?: (progress: CoinPayProgress) => void;
+      /**
+       * Which of the wallet's addresses funds the run. A wallet can hold
+       * several per chain, and without this the batch always spent the first —
+       * so a site had no way to pay from the account that actually holds the
+       * money. Omit to keep that first-address default.
+       */
+      from?: string;
+    } = {},
   ): Promise<{ results: CoinPayPaymentResult[] }> {
     if (options.onProgress) progressListeners.add(options.onProgress);
     try {
-      return await send({ type: 'site:payBatch', payments });
+      return await send({ type: 'site:payBatch', payments, from: options.from });
     } finally {
       if (options.onProgress) progressListeners.delete(options.onProgress);
     }

--- a/packages/extension/src/messages.ts
+++ b/packages/extension/src/messages.ts
@@ -63,7 +63,8 @@ export type WalletRequest =
   | { type: 'site:getState' }
   | { type: 'site:connect' }
   | { type: 'site:getAccounts' }
-  | { type: 'site:payBatch'; payments: BatchPaymentRequest[] }
+  /** `from` picks which of a chain's addresses pays, as for `send`. */
+  | { type: 'site:payBatch'; payments: BatchPaymentRequest[]; from?: string }
   // ── approval window ──
   | { type: 'approval:get'; requestId: string }
   | { type: 'approval:approve'; requestId: string; password?: string }


### PR DESCRIPTION
## The bug

A wallet can hold several addresses per chain. `send` has always taken a `from` to pick one — the type even documents it:

```ts
/** `from` picks which of a chain's addresses pays; omit for its first. */
| { type: 'send'; chain: string; to: string; amount: string; from?: string }
```

`payBatch` had **no such parameter**, so every batch spent whichever address happened to be first.

That is not a cosmetic default. A real 80-payment run failed almost entirely with *"not enough SOL"* — while the payer's funds sat one address over:

| Account | Address | Balance |
|---|---|---|
| index 0 | `B3zn7yeoL6NP…` | **0.00103 SOL** ← batch drew from here |
| index 1 | `7tKgJsSWPQGK…` | 0.1757 SOL |

The site had no way to say otherwise.

## The fix

The plumbing already existed — `sendersFor(from)` resolves the sender per chain and honours a requested address. The batch path was simply **the one caller invoking it as `sendersFor()`**, with no argument:

```diff
- const senders = await sendersFor();
+ const senders = await sendersFor(from);
```

`payBatch` now accepts `options.from` and threads it through the same resolver `send` uses. Omitting it keeps the previous first-address behaviour, so this is purely additive.

## Verification

- **283 tests pass across 23 files** (extension suite)
- New test asserts the chosen account reaches the wallet in the `site:payBatch` payload
- `tsc --noEmit` reports only 20 pre-existing errors in `src/lib/web-wallet/signing.ts`, confirmed identical on clean master and untouched here

## Companion

ugig.net needs an account picker to make use of this — without a way to choose, the parameter has no caller. That is being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)