### PR TITLE
fix(proxy): recognise any auth scheme, not just Bearer

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -52,6 +52,19 @@ describe('presentedCredential', () => {
     expect(presentedCredential(headersOf({ 'x-api-key': 'sk_live_xyz' }))).toBe('sk_live_xyz');
   });
 
+  it('reads the wallet extension\'s Wallet scheme, not just Bearer', () => {
+    // packages/extension/src/core/api.ts signs with this exact shape.
+    expect(
+      presentedCredential(headersOf({ authorization: 'Wallet wid-1:sig-abc:1234567890' }))
+    ).toBe('wid-1:sig-abc:1234567890');
+  });
+
+  it('distinguishes two wallets using the same scheme', () => {
+    const a = presentedCredential(headersOf({ authorization: 'Wallet wid-1:sig:1' }));
+    const b = presentedCredential(headersOf({ authorization: 'Wallet wid-2:sig:1' }));
+    expect(a).not.toBe(b);
+  });
+
   it('is null when no credential is presented', () => {
     expect(presentedCredential(headersOf({}))).toBeNull();
   });
@@ -73,6 +86,15 @@ describe('proxy rate limiting', () => {
   it('lets a credentialed integration burst well past the anonymous limit', () => {
     const allowed = countUntilLimited('/api/payments/create', '10.1.0.2', 200, {
       authorization: 'Bearer sk_live_ugig',
+    });
+    expect(allowed).toBe(200);
+  });
+
+  // The extension uses the `Wallet` scheme; a batch spends two API calls per
+  // payment, so treating it as anonymous capped a payout at ~30 payments.
+  it('gives the wallet extension the credentialed budget', () => {
+    const allowed = countUntilLimited('/api/web-wallet/w1/broadcast', '10.1.0.6', 200, {
+      authorization: 'Wallet wid-1:sig-abc:1234567890',
     });
     expect(allowed).toBe(200);
   });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -118,8 +118,13 @@ export function presentedCredential(
 ): string | null {
   const authorization = headers.get('authorization');
   if (authorization) {
-    const match = /^bearer\s+(\S+)/i.exec(authorization.trim());
-    if (match) return match[1];
+    // Any auth scheme, not just Bearer. The wallet extension signs with
+    // `Authorization: Wallet <walletId>:<signature>:<timestamp>` (see
+    // packages/extension/src/core/api.ts), and matching Bearer alone dropped it
+    // into the anonymous per-IP bucket — which a bulk payout exhausts in
+    // seconds, since every payment costs a prepare-tx plus a broadcast.
+    const match = /^(\S+)\s+(\S+)/.exec(authorization.trim());
+    if (match) return match[2];
   }
   const apiKey = headers.get('x-api-key')?.trim();
   return apiKey ? apiKey : null;


### PR DESCRIPTION
## The gap

#212 gave credentialed callers their own rate-limit bucket, keyed off `Authorization: Bearer …` or `X-API-Key`.

The wallet extension uses neither. It signs with:

```
Authorization: Wallet <walletId>:<signature>:<timestamp>
```

(`packages/extension/src/core/api.ts:176`)

So every request the extension made fell through to the **anonymous 60/min per-IP bucket** — the exact ceiling #212 was written to remove, still standing for the one caller that needed it most.

A bulk payout spends **one `prepare-tx` plus one `broadcast` per payment**, so 60 calls is roughly 30 payments. Past that the run fails with `Request failed with status 429`, which is what the payer is still seeing mid-batch.

## The fix

Match any auth scheme and take the credential that follows, rather than hardcoding `Bearer`. That covers `Wallet`, `Bearer`, and anything added later without another round of this.

A bare `Authorization: Bearer` with no token still returns null, so junk headers stay on the anonymous bucket — there's an existing test pinning that, and it still passes.

## Tests

`src/proxy.test.ts` — 13 passed. New:
- parses the extension's exact `Wallet <id>:<sig>:<ts>` shape
- two wallets on the same scheme get distinct buckets
- a `Wallet`-scheme caller clears 200 requests to `/api/web-wallet/:id/broadcast`, where it previously stopped at 60

Fourth in the chain: #211 (web-wallet caps), #212 (credentialed bucket), #213 (provider hang), this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)