### PR TITLE
feat(extension): show what the paying address holds before approving a batch

### DIFF
--- a/packages/extension/src/approval/app.ts
+++ b/packages/extension/src/approval/app.ts
@@ -14,7 +14,7 @@
 import { el, mount, button, note, brand } from '../popup/dom.js';
 import { call } from '../popup/rpc.js';
 import type { PendingApproval } from '../messages.js';
-import type { BatchProgress } from '../core/batch.js';
+import type { BatchProgress, BatchFunding } from '../core/batch.js';
 
 const params = new URLSearchParams(window.location.search);
 const requestId = params.get('requestId') ?? '';
@@ -97,6 +97,7 @@ function renderBatch(request: Extract<PendingApproval, { kind: 'payBatch' }>): v
       text: `This sends ${request.payments.length} separate transactions. They cannot be reversed.`,
     }),
     totals,
+    ...(request.funding?.length ? [buildFunding(request.funding)] : []),
     buildList(request),
     ...(password ? [password.row] : []),
     status,
@@ -109,6 +110,48 @@ function renderBatch(request: Extract<PendingApproval, { kind: 'payBatch' }>): v
       ),
     ]),
   );
+}
+
+/**
+ * What each funding address holds, against what the run needs.
+ *
+ * A short balance does not announce itself: the run starts, and each payment
+ * fails with a chain-level message ("No UTXOs available", "simulation failed")
+ * that never mentions money. Showing it here turns that into something the user
+ * can see before approving 80 transactions.
+ */
+function buildFunding(funding: BatchFunding[]): HTMLElement {
+  const short = funding.filter((f) => !f.sufficient);
+  return el('div', { class: 'funding' }, [
+    el('div', { class: 'funding-head', text: 'Paying from' }),
+    ...funding.map((f) =>
+      el('div', { class: f.sufficient ? 'funding-row' : 'funding-row short' }, [
+        el('span', { class: 'who' }, [
+          el('span', { class: 'chain', text: f.chain }),
+          ...(f.address ? [el('span', { class: 'addr', text: shortenAddress(f.address) })] : []),
+        ]),
+        el('span', {
+          class: 'amt',
+          text: `need ${f.required} · have ${f.available}`,
+        }),
+      ]),
+    ),
+    ...(short.length
+      ? [
+          el('p', {
+            class: 'warn',
+            text:
+              short.length === funding.length
+                ? 'This address cannot cover the run. Fund it, or pick the address that holds the money, before approving.'
+                : `Not enough ${short.map((f) => f.chain).join(', ')} to cover every payment — those will fail.`,
+          }),
+        ]
+      : []),
+    el('p', {
+      class: 'muted',
+      text: 'Balances exclude network fees, so a run can still come up short.',
+    }),
+  ]);
 }
 
 function buildList(request: Extract<PendingApproval, { kind: 'payBatch' }>): HTMLElement {

--- a/packages/extension/src/approval/index.html
+++ b/packages/extension/src/approval/index.html
@@ -48,6 +48,16 @@
       .total-row { display: flex; justify-content: space-between; align-items: baseline; font-size: 13px; padding: 3px 0; }
       .total-row .chain { font-weight: 600; }
       .grand { border-top: 1px solid var(--border); margin-top: 6px; padding-top: 8px; font-size: 15px; font-weight: 700; }
+      /* What the paying address holds. A short balance otherwise only shows up
+         as per-payment chain errors that never mention money. */
+      .funding { border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; margin: 0 0 10px; display: grid; gap: 6px; }
+      .funding-head { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+      .funding-row { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; font-size: 13px; }
+      .funding-row .who { display: flex; gap: 8px; align-items: baseline; min-width: 0; }
+      .funding-row .chain { font-weight: 600; }
+      .funding-row .addr { color: var(--muted); font-size: 11px; overflow: hidden; text-overflow: ellipsis; }
+      .funding-row .amt { white-space: nowrap; }
+      .funding-row.short .amt { color: var(--err); font-weight: 700; }
       /* The payment list is the part that scrolls; header and buttons stay put
          so "Approve" is always reachable even with 62 rows. */
       .list { flex: 1; min-height: 80px; overflow-y: auto; border: 1px solid var(--border); border-radius: 10px; }

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -31,7 +31,15 @@ import { CoinPayApi, compressedPublicKey } from '../core/api.js';
 import { RateCache } from '../core/rates.js';
 import { toFiatCurrency, type FiatCurrency } from '../core/fiat.js';
 import { derivePrivateKey, derivationPath, deriveIdentityKey } from '../core/private-keys.js';
-import { runBatchPayments, summarizeBatch, parseBatchRequests, type BatchItemResult } from '../core/batch.js';
+import {
+  runBatchPayments,
+  summarizeBatch,
+  parseBatchRequests,
+  computeFunding,
+  type BatchItemResult,
+  type BatchPaymentRequest,
+  type BatchFunding,
+} from '../core/batch.js';
 import { PAY_CHAINS, signingChain, toPayChain } from '../core/pay-chains.js';
 import type { NativeChain } from '../core/chains.js';
 import type { WalletRequest, WalletResponse, PendingApproval, WalletEvent } from '../messages.js';
@@ -379,6 +387,35 @@ function senderOrigin(sender: chrome.runtime.MessageSender): string | null {
   return normalizeOrigin(sender.origin ?? sender.url ?? null);
 }
 
+/**
+ * What the funding addresses hold, for the approval screen to show alongside
+ * what the run needs.
+ *
+ * Advisory only: a failure here must never block a payment the user asked for,
+ * so everything is swallowed and the screen simply omits the section. Returns
+ * undefined while locked, since balances need the seed and the approval window
+ * is what collects the password.
+ */
+async function fundingFor(
+  payments: BatchPaymentRequest[],
+  from?: string,
+): Promise<BatchFunding[] | undefined> {
+  if (!(await wallet.isUnlocked())) return undefined;
+
+  let authKey: Uint8Array | undefined;
+  try {
+    const seed = await wallet.requireSeed();
+    const walletId = await ensurePortalWallet(seed);
+    authKey = deriveIdentityKey(seed);
+    const balances = await api.getBalances(walletId, authKey);
+    return computeFunding(payments, await sendersFor(from), balances);
+  } catch {
+    return undefined;
+  } finally {
+    authKey?.fill(0);
+  }
+}
+
 async function handleSitePayBatch(
   origin: string,
   rawPayments: unknown,
@@ -401,6 +438,7 @@ async function handleSitePayBatch(
     needsUnlock: !(await wallet.isUnlocked()),
     payments,
     summary: summarizeBatch(payments),
+    funding: await fundingFor(payments, from),
   };
 
   const approved = await requestApproval(approval);

--- a/packages/extension/src/core/__tests__/funding.test.ts
+++ b/packages/extension/src/core/__tests__/funding.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A short balance is the failure mode that hides best: the run starts, and each
+ * payment dies with a chain-level error ("No UTXOs available", "Transaction
+ * simulation failed") that never says the word "balance". These pin down what
+ * the approval screen is told, so the user sees it before approving.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeFunding } from '../batch.js';
+import type { BatchPaymentRequest } from '../batch.js';
+
+const SOL_SENDER = { address: 'SoLSenderAddress1111111111111111111111111', index: 0 };
+const BTC_SENDER = { address: '14s74H7UHi68aGFxKQD2enMYmBKVFjVRFs', index: 0 };
+
+function payment(over: Partial<BatchPaymentRequest> = {}): BatchPaymentRequest {
+  return { id: 'inv-1', chain: 'SOL', to: 'recipient', amount: '1', ...over };
+}
+
+describe('computeFunding', () => {
+  it('sums a chain across payments and compares against the funding address', () => {
+    const funding = computeFunding(
+      [payment({ id: 'a', amount: '0.5' }), payment({ id: 'b', amount: '0.25' })],
+      { SOL: SOL_SENDER },
+      [{ chain: 'SOL', address: SOL_SENDER.address, balance: '2' }],
+    );
+
+    expect(funding).toEqual([
+      { chain: 'SOL', address: SOL_SENDER.address, required: '0.75', available: '2', sufficient: true },
+    ]);
+  });
+
+  it('flags a run the paying address cannot cover', () => {
+    const funding = computeFunding(
+      [payment({ amount: '5' })],
+      { SOL: SOL_SENDER },
+      [{ chain: 'SOL', address: SOL_SENDER.address, balance: '0.01' }],
+    );
+
+    expect(funding[0]?.sufficient).toBe(false);
+  });
+
+  // The bug this is really for: a wallet holds several addresses per chain and
+  // the batch spends exactly one. Counting the others makes an empty sender
+  // look funded, which is precisely the report we could not explain.
+  it('ignores balances held on the wallet\'s other addresses', () => {
+    const funding = computeFunding(
+      [payment({ amount: '1' })],
+      { SOL: SOL_SENDER },
+      [
+        { chain: 'SOL', address: SOL_SENDER.address, balance: '0' },
+        { chain: 'SOL', address: 'SomeOtherAddressWithAllTheMoney2222222222', balance: '100' },
+      ],
+    );
+
+    expect(funding[0]).toMatchObject({ available: '0', sufficient: false });
+  });
+
+  it('keeps chains separate', () => {
+    const funding = computeFunding(
+      [payment({ id: 'a', chain: 'SOL', amount: '1' }), payment({ id: 'b', chain: 'BTC', amount: '0.5' })],
+      { SOL: SOL_SENDER, BTC: BTC_SENDER },
+      [
+        { chain: 'SOL', address: SOL_SENDER.address, balance: '10' },
+        { chain: 'BTC', address: BTC_SENDER.address, balance: '0' },
+      ],
+    );
+
+    expect(funding.find((f) => f.chain === 'SOL')?.sufficient).toBe(true);
+    expect(funding.find((f) => f.chain === 'BTC')?.sufficient).toBe(false);
+  });
+
+  it('treats a chain with no balance row as empty rather than unknown', () => {
+    const funding = computeFunding([payment({ amount: '1' })], { SOL: SOL_SENDER }, []);
+    expect(funding[0]).toMatchObject({ available: '0', sufficient: false });
+  });
+
+  it('does not credit a token balance to its base chain', () => {
+    // USDC_SOL rides on the SOL address but is not SOL, and spending SOL needs SOL.
+    const funding = computeFunding(
+      [payment({ chain: 'SOL', amount: '1' })],
+      { SOL: SOL_SENDER },
+      [{ chain: 'USDC_SOL', address: SOL_SENDER.address, balance: '500' }],
+    );
+
+    expect(funding[0]).toMatchObject({ available: '0', sufficient: false });
+  });
+
+  it('survives malformed amounts and balances without producing NaN', () => {
+    const funding = computeFunding(
+      [payment({ amount: 'not-a-number' })],
+      { SOL: SOL_SENDER },
+      [{ chain: 'SOL', address: SOL_SENDER.address, balance: undefined }],
+    );
+
+    expect(funding[0]?.required).toBe('0');
+    expect(funding[0]?.available).toBe('0');
+  });
+});

--- a/packages/extension/src/core/batch.ts
+++ b/packages/extension/src/core/batch.ts
@@ -379,3 +379,69 @@ export function summarizeBatch(
     totalUsd: group.totalUsd,
   }));
 }
+
+/** What the approval screen shows about whether a run can actually be paid. */
+export interface BatchFunding {
+  chain: PayChain;
+  /** The address that will fund this chain's payments, if one is derived. */
+  address?: string;
+  /** Sum of this chain's payments, in display units. */
+  required: string;
+  /** What that address holds, in display units. */
+  available: string;
+  /** False when the balance cannot cover the total. Fees are NOT included. */
+  sufficient: boolean;
+}
+
+/**
+ * Compare what a batch needs against what the funding addresses hold.
+ *
+ * A wallet can hold several addresses per chain, and a batch spends exactly one
+ * of them — so "the wallet has enough" is not the question. The question is
+ * whether *the address that will pay* has enough, which is what this answers
+ * and what the approval screen shows. A run that is short fails one payment at
+ * a time with chain-level errors ("No UTXOs available", "simulation failed")
+ * that never say the word "balance".
+ *
+ * `sufficient` deliberately ignores transaction fees: the exact cost is not
+ * known until each transaction is built, and quietly padding it would report a
+ * shortfall that is not real. Treat it as necessary, not sufficient.
+ */
+export function computeFunding(
+  payments: BatchPaymentRequest[],
+  senders: Partial<Record<NativeChain, { address: string; index: number }>>,
+  balances: { chain?: string; address?: string; balance?: string }[],
+): BatchFunding[] {
+  const required = new Map<PayChain, number>();
+  for (const payment of payments) {
+    const amount = Number(payment.amount);
+    required.set(
+      payment.chain,
+      (required.get(payment.chain) ?? 0) + (Number.isFinite(amount) ? amount : 0),
+    );
+  }
+
+  return [...required.entries()].map(([chain, amount]) => {
+    const address = senders[signingChain(chain)]?.address;
+    // Only the funding address counts. Summing every address on the chain is
+    // what makes an empty sender look funded.
+    const available = balances
+      .filter(
+        (b) =>
+          (b.chain ?? '').toUpperCase() === chain &&
+          (!address || (b.address ?? '').toLowerCase() === address.toLowerCase()),
+      )
+      .reduce((sum, b) => {
+        const value = Number(b.balance);
+        return sum + (Number.isFinite(value) ? value : 0);
+      }, 0);
+
+    return {
+      chain,
+      address,
+      required: String(amount),
+      available: String(available),
+      sufficient: available >= amount,
+    };
+  });
+}

--- a/packages/extension/src/messages.ts
+++ b/packages/extension/src/messages.ts
@@ -12,7 +12,12 @@
  */
 
 import type { DerivedAddress } from './core/derivation.js';
-import type { BatchPaymentRequest, BatchItemResult, BatchProgress } from './core/batch.js';
+import type {
+  BatchPaymentRequest,
+  BatchItemResult,
+  BatchProgress,
+  BatchFunding,
+} from './core/batch.js';
 import type { SiteConnection } from './core/connections.js';
 import type { FiatCurrency } from './core/fiat.js';
 import type { RateQuote } from './core/rates.js';
@@ -143,6 +148,12 @@ export type PendingApproval =
       needsUnlock: boolean;
       payments: BatchPaymentRequest[];
       summary: { chain: string; count: number; total: string; totalUsd: number }[];
+      /**
+       * Per-chain balance of the address that will actually pay, against what
+       * the run needs. Absent when the wallet is locked — reading balances needs
+       * the seed, and this window is what asks for the password.
+       */
+      funding?: BatchFunding[];
     };
 
 export type WalletResponse =


### PR DESCRIPTION
## Why

A short balance is the failure mode that hides best. The run starts, and every payment dies with a chain-level error that never says the word "balance":

```
Broadcast failed: SOL broadcast error: Transaction simulation failed   ×10
No UTXOs available for this address                                    ×3
```

An 80-payment payout can fail end to end without once telling the payer the account was empty. That is exactly what happened on ugig.net, and it took a database dig to work out.

## What

The batch approval window now shows, per chain, **the address that will fund the run and what it holds, against what the run needs** — and flags any chain that cannot cover its share, before the user approves.

```
PAYING FROM
SOL   SoLSender1…11111111     need 0.402 · have 0.013
BTC   14s74H7UH…VFjVRFs       need 0.0004 · have 0

⚠ Not enough SOL, BTC to cover every payment — those will fail.
Balances exclude network fees, so a run can still come up short.
```

## Two things it gets deliberately right

**It compares against the funding address, not the wallet total.** A wallet holds several addresses per chain and a batch spends exactly one — summing the rest is precisely what makes an empty sender look funded. There's a test for it, and it's the case that prompted this: money sitting one address over from the one being spent.

**`sufficient` excludes network fees.** The real cost isn't known until each transaction is built, and padding a guess would report shortfalls that aren't real. The screen says so rather than implying a guarantee.

## Safety

Balances are advisory. A failed lookup, or a locked wallet (reading balances needs the seed, and this window is what collects the password), omits the section rather than blocking a payment the user asked for.

## Tests

`packages/extension` — 290 passed, 24 files. New `src/core/__tests__/funding.test.ts` covers the pure computation: sums per chain, flags shortfalls, **ignores balances on the wallet's other addresses**, keeps chains separate, treats a missing balance row as empty rather than unknown, refuses to credit a token balance (`USDC_SOL`) to its base chain, and survives malformed amounts without producing NaN.

Chrome build verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)