### PR TITLE
chore(extension): 0.9.1 -> 0.9.2 (funding shown before approval)

### DIFF
--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",


### PR DESCRIPTION
Ships #221 — the batch approval window now shows what the funding address holds against what the run needs, and flags any chain that cannot cover its share.

Bumped in all three places: `package.json`, `manifest.chrome.json`, `manifest.firefox.json`.

Build verified from this commit — `dist/manifest.json` reads 0.9.2, and both shipped fixes are confirmed present in the built bundles: the `page-ack` transport fix from 0.9.1 and the "Paying from" funding panel from #221. 290 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)