### PR TITLE
feat(extension): pin the Chrome id so a store install replaces a sideload

### DIFF
--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -2,7 +2,8 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.2",
+  "version": "0.9.3",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvd6F0ByGMFO/ZfxK/kyuYMrlBlmwY0u2I9MfRRYf88YA2YQVmiUqM2444gPxyI4rhTyejAZX9IwMDwY0N+kgclQArkfTmbs+mo7E/RCgrMFy+FreMlrqEm5LACIKPgVZjzWUEjDxQGnmpNtvXWUN2ZN9srKF+Efr2tFKVZMwBKd3cJeh+4XGw0+AN6CKDbURWvgm6op+5bL4lTv+aJ8LbfC45ouEOsxHZgdN2HuC3x4kE232oStYYjmigr2NSKgE835U2nKO+hY7fCzBntMp8VI9hUkCDBwZwxbcWFQmtMKqJa6Mu3lgcwJQPYRzx9hujehn2OSsPE6b2k/jOYVtcwIDAQAB",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",


### PR DESCRIPTION
## Why

Follow-up to the "still shows v0.9.0 after installing 0.9.2" report. The popup renders `chrome.runtime.getManifest().version`, which reports whichever copy is *running* — so that popup genuinely was 0.9.0. Two copies were installed at once.

Cause: with no `key` in the manifest, Chrome derives an unpacked extension's id from its **install path**, while the store's `.crx` gets an id derived from the **store's signing key**. They never match, so a store install lands beside an existing sideload rather than replacing it — two entries, two toolbar icons, and the stale one keeps answering.

Firefox never had this problem: it already pins its id via `browser_specific_settings.gecko.id`. This is the missing Chrome counterpart.

## What

Adds `key` to `manifest.chrome.json`, set to the store's own signing public key for this listing. Both an unpacked build and the store `.crx` now resolve to `jmojjohoigoecfkjlobdmiejcdjjbhnb`, so Chrome treats them as one extension and an install replaces the other.

Version bumped 0.9.2 → 0.9.3 across `package.json` and both manifests, since the change only reaches anyone through a new `extension-v*` release.

## Verification

- Built `dist/manifest.json` carries the key; an unpacked install of it derives **exactly** the store id.
- The manifest key is **byte-identical** (294 bytes) to the public key in the `.crx` tronbrowser.dev serves today — Chrome rejects a CRX whose `key` disagrees with its signature, so this had to match and does.
- Extension suite: **290/290 pass**, build clean.

## Caveat

This cannot merge copies **already** installed — an existing sideload keeps its old path-derived id, so the stale entry has to be removed by hand once. After that, store and sideload stay a single extension.

Note the id is now load-bearing: `signing.ts` in tronbrowser.dev warns it can never be rotated without orphaning every install, so this key should be treated as permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)