### PR TITLE
fix: validate payout amounts as safe integers

### DIFF
--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -181,6 +181,15 @@ function parseArgs(args) {
   return result;
 }
 
+function parsePositiveInteger(value) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value.trim())) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 /**
  * Show help
  */
@@ -2398,9 +2407,9 @@ async function handlePayout(subcommand, args, flags) {
 
   switch (subcommand) {
     case 'create': {
-      const amount = parseInt(flags.amount);
-      if (!amount || amount <= 0) {
-        print.error('--amount is required (in cents, e.g., 5000 for $50.00)');
+      const amount = parsePositiveInteger(flags.amount);
+      if (amount === null) {
+        print.error('--amount must be a positive integer in cents (e.g., 5000 for $50.00)');
         print.info('Example: coinpay payout create --amount 5000 --description "Weekly payout"');
         process.exit(1);
       }

--- a/packages/sdk/test/cli-payout.test.js
+++ b/packages/sdk/test/cli-payout.test.js
@@ -2,8 +2,8 @@
  * CLI Payout Command Tests
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execFileSync, execSync } from 'child_process';
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
 import { join } from 'path';
 
 const CLI_PATH = join(import.meta.dirname, '..', 'bin', 'coinpay.js');
@@ -23,27 +23,44 @@ describe.skipIf(!hasNodeSpawn)('CLI Payout Commands', () => {
     COINPAY_BASE_URL: 'http://localhost:9999',
   };
 
+  function runCLI(args) {
+    const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return {
+      status: result.status ?? 1,
+      output: `${result.stdout || ''}${result.stderr || ''}`,
+    };
+  }
+
   it('should show error for unknown payout subcommand', () => {
-    try {
-      execSync(`node ${CLI_PATH} payout unknown`, { env, encoding: 'utf8', stdio: 'pipe' });
-    } catch (e) {
-      expect(e.stderr || e.stdout).toMatch(/unknown|Unknown/i);
-    }
+    const { output } = runCLI(['payout', 'unknown']);
+
+    expect(output).toMatch(/unknown/i);
   });
 
   it('should require --amount for payout create', () => {
-    try {
-      execSync(`node ${CLI_PATH} payout create`, { env, encoding: 'utf8', stdio: 'pipe' });
-    } catch (e) {
-      expect(e.stderr || e.stdout).toMatch(/amount/i);
-    }
+    const { output } = runCLI(['payout', 'create']);
+
+    expect(output).toMatch(/amount/i);
   });
 
-  it('should require id for payout get', () => {
-    try {
-      execSync(`node ${CLI_PATH} payout get`, { env, encoding: 'utf8', stdio: 'pipe' });
-    } catch (e) {
-      expect(e.stderr || e.stdout).toMatch(/usage|id/i);
+  it.each(['5000abc', '12.5', '1e3', '9007199254740992'])(
+    'should reject invalid payout amount %s',
+    (amount) => {
+      const { status, output } = runCLI(['payout', 'create', '--amount', amount]);
+
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/positive integer.*cents/i);
     }
+  );
+
+  it('should require id for payout get', () => {
+    const { output } = runCLI(['payout', 'get']);
+
+    expect(output).toMatch(/usage|id/i);
   });
 });

--- a/src/app/api/stripe/payouts/route.test.ts
+++ b/src/app/api/stripe/payouts/route.test.ts
@@ -144,6 +144,26 @@ describe('POST /api/stripe/payouts', () => {
     expect(response.status).toBe(400);
   });
 
+  it.each([12.5, Number.MAX_SAFE_INTEGER + 1])(
+    'should reject non-integer payout amount %s',
+    async (amount) => {
+      (verifyToken as any).mockReturnValue({ userId: 'merchant-1' });
+      const request = new NextRequest('http://localhost:3000/api/stripe/payouts', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer valid',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ amount }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(mockFrom).not.toHaveBeenCalled();
+    }
+  );
+
   it('should create a payout successfully', async () => {
     (verifyToken as any).mockReturnValue({ userId: 'merchant-1' });
     

--- a/src/app/api/stripe/payouts/route.ts
+++ b/src/app/api/stripe/payouts/route.ts
@@ -199,7 +199,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { amount, currency = 'usd', description, metadata } = body;
 
-    if (!amount || typeof amount !== 'number' || amount <= 0) {
+    if (!Number.isSafeInteger(amount) || amount <= 0) {
       return NextResponse.json(
         { success: false, error: 'amount is required and must be a positive integer (in cents)' },
         { status: 400 }


### PR DESCRIPTION
## Summary

- reject malformed, fractional, and unsafe payout amounts in the CLI instead of silently truncating them with `parseInt`
- enforce the documented positive safe-integer cents contract in the Stripe payout API before database or Stripe calls
- make payout CLI tests portable by spawning the current Node executable directly

## Tests

- focused payout tests: 17 passed
- full SDK suite: 505 passed, 12 skipped
- TypeScript: passed
- ESLint on changed files: passed with no errors
- `git diff --check`: passed

Closes #224