### PR TITLE
Stop recurring invoice schedules surviving revocation

### DIFF
--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -150,6 +150,21 @@ export async function PUT(
       return NextResponse.json({ success: false, error: 'Update failed' }, { status: 400 });
     }
 
+    // Cancelling an invoice revokes the series it seeds. The scheduler used to
+    // stop only on max_occurrences/end_date — neither of which can be set after
+    // creation — so a cancelled template kept minting invoices into the
+    // merchant's dashboard with no way to stop it short of database access.
+    if (allowedFields.status === 'cancelled') {
+      const { error: schedError } = await supabase
+        .from('invoice_schedules')
+        .update({ active: false })
+        .eq('invoice_id', id);
+
+      if (schedError) {
+        console.error(`Failed to deactivate schedules for cancelled invoice ${id}:`, schedError);
+      }
+    }
+
     return NextResponse.json({ success: true, invoice });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/invoices/[id]/schedule/route.test.ts
+++ b/src/app/api/invoices/[id]/schedule/route.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/jwt', () => ({
+  verifyToken: vi.fn().mockReturnValue({ userId: 'merch-1' }),
+}));
+
+vi.mock('@/lib/secrets', () => ({
+  getJwtSecret: vi.fn().mockReturnValue('test-secret'),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const mockAuthorizeBusiness = vi.fn();
+
+vi.mock('@/lib/auth/merchant', () => ({
+  resolveMerchant: vi.fn().mockResolvedValue({ merchantId: 'merch-1', apiKeyBusinessId: null }),
+}));
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: (...args: any[]) => mockAuthorizeBusiness(...args),
+}));
+
+import { GET, PATCH, DELETE } from './route';
+
+const SCHEDULE = {
+  id: 'sched-1',
+  invoice_id: 'inv-1',
+  recurrence: 'monthly',
+  active: true,
+  occurrences_count: 2,
+};
+
+type Ctx = { table: string; op: string; payload?: any; filters: Record<string, any> };
+
+let recorded: Ctx[] = [];
+
+function installSupabase(opts: { scheduleRows?: any[] } = {}) {
+  mockFrom.mockImplementation((table: string) => {
+    const ctx: Ctx = { table, op: 'select', filters: {} };
+    recorded.push(ctx);
+    const builder: any = {
+      select: () => builder,
+      update: (payload: any) => { ctx.op = 'update'; ctx.payload = payload; return builder; },
+      delete: () => { ctx.op = 'delete'; return builder; },
+      eq: (col: string, val: any) => { ctx.filters[col] = val; return builder; },
+      order: () => builder,
+      single: () => builder,
+      then: (resolve: any, reject: any) => {
+        let result: any = { data: null, error: null };
+        if (ctx.table === 'invoices') {
+          result = { data: { id: 'inv-1', business_id: 'biz-1' }, error: null };
+        } else if (ctx.table === 'invoice_schedules') {
+          result = { data: opts.scheduleRows ?? [SCHEDULE], error: null };
+        }
+        return Promise.resolve(result).then(resolve, reject);
+      },
+    };
+    return builder;
+  });
+}
+
+function makeRequest(method: string, body?: any): NextRequest {
+  return new NextRequest('http://localhost/api/invoices/inv-1/schedule', {
+    method,
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+const params = Promise.resolve({ id: 'inv-1' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recorded = [];
+  mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'owner' });
+  installSupabase();
+});
+
+describe('PATCH /api/invoices/[id]/schedule', () => {
+  it('pauses a schedule', async () => {
+    const res = await PATCH(makeRequest('PATCH', { active: false }), { params });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+
+    const update = recorded.find(c => c.table === 'invoice_schedules' && c.op === 'update');
+    expect(update?.payload).toEqual({ active: false });
+    // Always scoped to this invoice, so a foreign schedule_id cannot be reached.
+    expect(update?.filters.invoice_id).toBe('inv-1');
+  });
+
+  it('scopes a targeted schedule_id to the invoice as well', async () => {
+    await PATCH(makeRequest('PATCH', { active: false, schedule_id: 'sched-other' }), { params });
+
+    const update = recorded.find(c => c.table === 'invoice_schedules' && c.op === 'update');
+    expect(update?.filters).toEqual({ invoice_id: 'inv-1', id: 'sched-other' });
+  });
+
+  it('rejects a non-boolean active', async () => {
+    const res = await PATCH(makeRequest('PATCH', { active: 'yes' }), { params });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty update', async () => {
+    const res = await PATCH(makeRequest('PATCH', {}), { params });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-positive max_occurrences', async () => {
+    const res = await PATCH(makeRequest('PATCH', { max_occurrences: 0 }), { params });
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the invoice has no matching schedule', async () => {
+    installSupabase({ scheduleRows: [] });
+    const res = await PATCH(makeRequest('PATCH', { active: false }), { params });
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses a caller without write access to the business', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({ ok: false, status: 403, error: 'Forbidden' });
+    const res = await PATCH(makeRequest('PATCH', { active: false }), { params });
+
+    expect(res.status).toBe(403);
+    expect(recorded.some(c => c.table === 'invoice_schedules')).toBe(false);
+  });
+
+  it('hides existence from a caller with no access at all', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({ ok: false, status: 404, error: 'Not found' });
+    const res = await PATCH(makeRequest('PATCH', { active: false }), { params });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/invoices/[id]/schedule', () => {
+  it('lists the schedules on the invoice', async () => {
+    const res = await GET(makeRequest('GET'), { params });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.schedules).toHaveLength(1);
+    expect(json.schedules[0].id).toBe('sched-1');
+  });
+});
+
+describe('DELETE /api/invoices/[id]/schedule', () => {
+  it('removes the recurrence for the invoice', async () => {
+    const res = await DELETE(makeRequest('DELETE'), { params });
+    expect(res.status).toBe(200);
+
+    const del = recorded.find(c => c.table === 'invoice_schedules' && c.op === 'delete');
+    expect(del?.filters.invoice_id).toBe('inv-1');
+  });
+
+  it('refuses a caller without write access', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({ ok: false, status: 403, error: 'Forbidden' });
+    const res = await DELETE(makeRequest('DELETE'), { params });
+
+    expect(res.status).toBe(403);
+    expect(recorded.some(c => c.table === 'invoice_schedules')).toBe(false);
+  });
+});

--- a/src/app/api/invoices/[id]/schedule/route.ts
+++ b/src/app/api/invoices/[id]/schedule/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
+
+/**
+ * Manage the recurring schedule(s) attached to an invoice.
+ *
+ * Schedules could previously be created (POST /api/invoices with `schedule`)
+ * but never read back, paused, or removed: there was no endpoint at all, the
+ * invoice page rendered them read-only, and the only exits the scheduler
+ * honoured — `max_occurrences` and `end_date` — are settable exclusively at
+ * creation time. Deleting the template was no escape either, since DELETE
+ * refuses anything that is not still a draft. A merchant who wanted a series
+ * stopped had no way to do it from the product.
+ *
+ * Authorization matches the rest of the `/api/invoices/[id]/*` family: the
+ * caller is checked against the invoice's owning business, so team members and
+ * business-scoped API keys work the same way here as everywhere else.
+ */
+
+function serviceClient() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+}
+
+/**
+ * GET /api/invoices/[id]/schedule
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = serviceClient();
+
+    const access = await authorizeInvoice(supabase, request, id, 'business.read', 'id, business_id');
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
+    }
+
+    const { data: schedules, error } = await supabase
+      .from('invoice_schedules')
+      .select('*')
+      .eq('invoice_id', id)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Failed to load schedules' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, schedules: schedules ?? [] });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/invoices/[id]/schedule
+ *
+ * Body: { active?: boolean, end_date?: string | null, max_occurrences?: number | null,
+ *         schedule_id?: string }
+ *
+ * `schedule_id` narrows the change to one schedule; omitting it applies to every
+ * schedule on the invoice, which is the common case since invoices carry one.
+ */
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = serviceClient();
+    const body = await request.json().catch(() => ({}));
+
+    const access = await authorizeInvoice(supabase, request, id, 'invoice.write', 'id, business_id');
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (body.active !== undefined) {
+      if (typeof body.active !== 'boolean') {
+        return NextResponse.json({ success: false, error: '`active` must be a boolean' }, { status: 400 });
+      }
+      updates.active = body.active;
+    }
+
+    if (body.end_date !== undefined) {
+      if (body.end_date === null) {
+        updates.end_date = null;
+      } else if (typeof body.end_date === 'string' && !Number.isNaN(Date.parse(body.end_date))) {
+        updates.end_date = new Date(body.end_date).toISOString();
+      } else {
+        return NextResponse.json({ success: false, error: '`end_date` must be an ISO date or null' }, { status: 400 });
+      }
+    }
+
+    if (body.max_occurrences !== undefined) {
+      if (body.max_occurrences === null) {
+        updates.max_occurrences = null;
+      } else if (Number.isInteger(body.max_occurrences) && body.max_occurrences > 0) {
+        updates.max_occurrences = body.max_occurrences;
+      } else {
+        return NextResponse.json(
+          { success: false, error: '`max_occurrences` must be a positive integer or null' },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ success: false, error: 'No supported fields to update' }, { status: 400 });
+    }
+
+    // Scope the write to this invoice's schedules so a caller authorized for one
+    // invoice cannot reach another's by passing a foreign schedule_id.
+    let query = supabase.from('invoice_schedules').update(updates).eq('invoice_id', id);
+    if (typeof body.schedule_id === 'string' && body.schedule_id) {
+      query = query.eq('id', body.schedule_id);
+    }
+
+    const { data: schedules, error } = await query.select('*');
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Failed to update schedule' }, { status: 500 });
+    }
+    if (!schedules || schedules.length === 0) {
+      return NextResponse.json({ success: false, error: 'Schedule not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, schedules });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/invoices/[id]/schedule
+ *
+ * Removes the recurrence outright. Pausing via PATCH is the reversible option;
+ * this is for series that should not exist at all.
+ */
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = serviceClient();
+
+    const access = await authorizeInvoice(supabase, request, id, 'invoice.write', 'id, business_id');
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
+    }
+
+    const { error } = await supabase.from('invoice_schedules').delete().eq('invoice_id', id);
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Failed to delete schedule' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -28,6 +28,7 @@ interface Invoice {
   clients: { id: string; name: string; email: string; company_name: string; phone?: string; address?: string } | null;
   businesses: { id: string; name: string } | null;
   invoice_schedules: Array<{ id: string; recurrence: string; active: boolean; occurrences_count: number }> | null;
+  metadata: { recurring?: boolean; payee_unverified?: boolean; template_invoice_id?: string } | null;
 }
 
 const statusColors: Record<string, string> = {
@@ -128,9 +129,28 @@ export default function InvoiceDetailPage() {
       body: JSON.stringify({ status: 'cancelled' }),
     }, router);
     if (result?.data.success) {
-      setInvoice(result.data.invoice);
+      // Refetch rather than trusting the PUT payload: cancelling also stops any
+      // attached schedule, and the update response does not carry them.
+      await fetchInvoice();
     } else {
       setError(result?.data.error || 'Failed to cancel invoice');
+    }
+    setActionLoading('');
+  };
+
+  const handleToggleSchedule = async (scheduleId: string, active: boolean) => {
+    if (active && !confirm('Resume this recurring schedule? New invoices will be generated automatically.')) return;
+    if (!active && !confirm('Pause this recurring schedule? No further invoices will be generated.')) return;
+    setActionLoading(`schedule-${scheduleId}`);
+    const result = await authFetch(`/api/invoices/${invoiceId}/schedule`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ schedule_id: scheduleId, active }),
+    }, router);
+    if (result?.data.success) {
+      await fetchInvoice();
+    } else {
+      setError(result?.data.error || 'Failed to update schedule');
     }
     setActionLoading('');
   };
@@ -187,6 +207,24 @@ export default function InvoiceDetailPage() {
 
         {error && (
           <div className="mb-6 bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg">{error}</div>
+        )}
+
+        {/* An auto-generated invoice whose payee is not one of the account's own
+            configured wallets. Legitimate when the merchant entered an external
+            address by hand, but it is also what a payee left behind by someone
+            who has since lost access looks like — so it gets checked by a human
+            before this invoice is sent, not silently trusted. */}
+        {invoice.metadata?.payee_unverified && (
+          <div className="mb-6 bg-amber-500/10 border border-amber-500/30 text-amber-300 px-4 py-3 rounded-lg">
+            <p className="font-semibold text-sm">Verify the payee before sending</p>
+            <p className="text-sm mt-1">
+              This invoice was generated automatically from a recurring schedule, and its payee
+              address is not one of this account&apos;s configured {invoice.crypto_currency} wallets.
+              Confirm{' '}
+              <span className="font-mono break-all">{invoice.merchant_wallet_address}</span>{' '}
+              is correct before sending.
+            </p>
+          </div>
         )}
 
         {/* Header */}
@@ -286,10 +324,17 @@ export default function InvoiceDetailPage() {
                 {invoice.invoice_schedules.map(s => (
                   <div key={s.id} className="flex items-center gap-3">
                     <span className={`px-2 py-1 rounded text-xs ${s.active ? 'bg-green-500/20 text-green-300' : 'bg-gray-500/20 text-gray-400'}`}>
-                      {s.active ? 'Active' : 'Inactive'}
+                      {s.active ? 'Active' : 'Paused'}
                     </span>
                     <span className="text-gray-300 text-sm capitalize">{s.recurrence}</span>
                     <span className="text-gray-500 text-xs">({s.occurrences_count} sent)</span>
+                    <button
+                      onClick={() => handleToggleSchedule(s.id, !s.active)}
+                      disabled={actionLoading === `schedule-${s.id}`}
+                      className="ml-auto px-3 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-200 disabled:opacity-50"
+                    >
+                      {actionLoading === `schedule-${s.id}` ? '...' : s.active ? 'Pause' : 'Resume'}
+                    </button>
                   </div>
                 ))}
               </div>

--- a/src/lib/payments/monitor-invoices.scheduler.test.ts
+++ b/src/lib/payments/monitor-invoices.scheduler.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Recurring invoice scheduler — revocation and payee guards.
+ *
+ * The scheduler runs unattended under the service role, so nothing downstream
+ * re-checks who authorized a series. These cover the three ways that used to go
+ * wrong: a cancelled template that kept minting, a payee copied through after
+ * the account could no longer justify it, and a series left running with no
+ * resolvable payee at all.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetPaymentReceivingWallet = vi.fn();
+
+vi.mock('../wallets/supported-coins', () => ({
+  getPaymentReceivingWallet: (...args: any[]) => mockGetPaymentReceivingWallet(...args),
+}));
+
+import { runInvoiceSchedulerCycle } from './monitor-invoices';
+
+// Valid base58 Solana addresses (32-44 chars), so the real payee validator runs.
+const TEMPLATE_PAYEE = 'CsTWZTbDryjcb229RQ9b7wny5qytH9jwoJy6Lu98xpeF';
+const CONFIGURED_PAYEE = '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin';
+
+const NOW = new Date('2026-08-04T00:00:00Z');
+
+type Ctx = { table: string; op: string; payload?: any; filters: Record<string, any> };
+
+interface Recorded {
+  inserts: any[];
+  scheduleUpdates: Array<{ payload: any; filters: Record<string, any> }>;
+}
+
+function makeSupabase(schedules: any[]) {
+  const recorded: Recorded = { inserts: [], scheduleUpdates: [] };
+
+  const from = vi.fn((table: string) => {
+    const ctx: Ctx = { table, op: 'select', filters: {} };
+    const builder: any = {
+      select: () => builder,
+      insert: (payload: any) => { ctx.op = 'insert'; ctx.payload = payload; return builder; },
+      update: (payload: any) => { ctx.op = 'update'; ctx.payload = payload; return builder; },
+      eq: (col: string, val: any) => { ctx.filters[col] = val; return builder; },
+      lte: () => builder,
+      order: () => builder,
+      limit: () => builder,
+      single: () => builder,
+      then: (resolve: any, reject: any) => {
+        let result: any = { data: null, error: null };
+        if (ctx.table === 'invoice_schedules') {
+          if (ctx.op === 'update') {
+            recorded.scheduleUpdates.push({ payload: ctx.payload, filters: ctx.filters });
+          } else {
+            result = { data: schedules, error: null };
+          }
+        } else if (ctx.table === 'invoices') {
+          if (ctx.op === 'insert') {
+            recorded.inserts.push(ctx.payload);
+            result = { data: null, error: null };
+          } else {
+            result = { data: { invoice_number: 'INV-011' }, error: null };
+          }
+        }
+        return Promise.resolve(result).then(resolve, reject);
+      },
+    };
+    return builder;
+  });
+
+  return { supabase: { from } as any, recorded };
+}
+
+function makeSchedule(overrides: Record<string, any> = {}, invoiceOverrides: Record<string, any> = {}) {
+  return {
+    id: 'sched-1',
+    invoice_id: 'inv-template',
+    recurrence: 'monthly',
+    custom_interval_days: null,
+    next_due_date: '2026-08-04T00:00:00Z',
+    end_date: null,
+    max_occurrences: null,
+    occurrences_count: 1,
+    active: true,
+    invoices: {
+      id: 'inv-template',
+      invoice_number: 'INV-003',
+      status: 'sent',
+      user_id: 'merch-1',
+      business_id: 'biz-1',
+      client_id: 'client-1',
+      currency: 'USD',
+      amount: '800.00',
+      crypto_currency: 'SOL',
+      merchant_wallet_address: TEMPLATE_PAYEE,
+      wallet_id: 'wallet-1',
+      fee_rate: '0.010000',
+      notes: null,
+      ...invoiceOverrides,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetPaymentReceivingWallet.mockResolvedValue({ walletAddress: TEMPLATE_PAYEE, source: 'business' });
+});
+
+describe('runInvoiceSchedulerCycle — template revocation', () => {
+  it('stops a series whose template invoice was cancelled, and mints nothing', async () => {
+    const { supabase, recorded } = makeSupabase([makeSchedule({}, { status: 'cancelled' })]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.created).toBe(0);
+    expect(stats.deactivated).toBe(1);
+    expect(stats.errors).toBe(0);
+    expect(recorded.inserts).toHaveLength(0);
+    expect(recorded.scheduleUpdates).toEqual([
+      { payload: { active: false }, filters: { id: 'sched-1' } },
+    ]);
+  });
+
+  it('keeps minting for a template that is still live', async () => {
+    const { supabase, recorded } = makeSupabase([makeSchedule({}, { status: 'sent' })]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.created).toBe(1);
+    expect(stats.deactivated).toBe(0);
+    expect(recorded.inserts).toHaveLength(1);
+    expect(recorded.inserts[0]).toMatchObject({
+      status: 'draft',
+      business_id: 'biz-1',
+      amount: '800.00',
+      merchant_wallet_address: TEMPLATE_PAYEE,
+    });
+  });
+
+  it.each(['draft', 'sent', 'paid', 'overdue'])('does not stop on a %s template', async status => {
+    const { supabase } = makeSupabase([makeSchedule({}, { status })]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.deactivated).toBe(0);
+    expect(stats.created).toBe(1);
+  });
+});
+
+describe('runInvoiceSchedulerCycle — payee guards', () => {
+  it('flags the invoice when the payee is not one of the account wallets', async () => {
+    mockGetPaymentReceivingWallet.mockResolvedValue({ walletAddress: CONFIGURED_PAYEE, source: 'business' });
+    const { supabase, recorded } = makeSupabase([makeSchedule()]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.created).toBe(1);
+    // The template's address is still honoured — merchants do use external
+    // payees — but it is marked for a human to confirm before sending.
+    expect(recorded.inserts[0].merchant_wallet_address).toBe(TEMPLATE_PAYEE);
+    expect(recorded.inserts[0].metadata.payee_unverified).toBe(true);
+  });
+
+  it('does not flag when the payee matches the account wallet', async () => {
+    const { supabase, recorded } = makeSupabase([makeSchedule()]);
+
+    await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(recorded.inserts[0].metadata.payee_unverified).toBeUndefined();
+    expect(recorded.inserts[0].metadata).toMatchObject({ recurring: true, schedule_id: 'sched-1' });
+  });
+
+  it('stops the series when no payee can be resolved at all', async () => {
+    mockGetPaymentReceivingWallet.mockResolvedValue({ error: 'no wallet configured' });
+    const { supabase, recorded } = makeSupabase([
+      makeSchedule({}, { merchant_wallet_address: null }),
+    ]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.created).toBe(0);
+    expect(stats.deactivated).toBe(1);
+    expect(recorded.inserts).toHaveLength(0);
+  });
+
+  it('re-resolves a blank template payee from the account wallet rather than emitting a blank one', async () => {
+    mockGetPaymentReceivingWallet.mockResolvedValue({ walletAddress: CONFIGURED_PAYEE, source: 'business' });
+    const { supabase, recorded } = makeSupabase([
+      makeSchedule({}, { merchant_wallet_address: null }),
+    ]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.created).toBe(1);
+    expect(recorded.inserts[0].merchant_wallet_address).toBe(CONFIGURED_PAYEE);
+    // wallet_id described the template's address, which is not where this landed.
+    expect(recorded.inserts[0].wallet_id).toBeNull();
+  });
+});
+
+describe('runInvoiceSchedulerCycle — existing limits still hold', () => {
+  it('stops at max_occurrences', async () => {
+    const { supabase, recorded } = makeSupabase([
+      makeSchedule({ max_occurrences: 3, occurrences_count: 3 }),
+    ]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.deactivated).toBe(1);
+    expect(recorded.inserts).toHaveLength(0);
+  });
+
+  it('stops after end_date', async () => {
+    const { supabase, recorded } = makeSupabase([
+      makeSchedule({ end_date: '2026-07-01T00:00:00Z' }),
+    ]);
+
+    const stats = await runInvoiceSchedulerCycle(supabase, NOW);
+
+    expect(stats.deactivated).toBe(1);
+    expect(recorded.inserts).toHaveLength(0);
+  });
+});

--- a/src/lib/payments/monitor-invoices.ts
+++ b/src/lib/payments/monitor-invoices.ts
@@ -5,6 +5,8 @@
 import { sendEmail } from '../email';
 import { invoicePaidMerchantTemplate, invoiceOverdueTemplate } from '../email/invoice-templates';
 import { checkBalance } from './monitor-balance';
+import { resolvePayee } from './payee';
+import { getPaymentReceivingWallet } from '../wallets/supported-coins';
 
 // Invoice Payment Monitoring
 // ────────────────────────────────────────────────────────────
@@ -214,6 +216,24 @@ interface InvoiceSchedulerStats {
   errors: number;
 }
 
+/**
+ * Template statuses that stop a series dead.
+ *
+ * A schedule is standing authority to mint invoices inside someone's business,
+ * granted once when the template was created and never re-checked afterwards —
+ * this job runs under the service role with no caller to authorize. That makes
+ * the template invoice the merchant's revocation handle, so cancelling it has
+ * to stop the series. Until this guard existed a cancelled template kept
+ * minting monthly: INV-012 was generated a month after its source, INV-003, was
+ * cancelled ten minutes into its life.
+ */
+const REVOKED_TEMPLATE_STATUSES = new Set(['cancelled']);
+
+async function deactivateSchedule(supabase: any, scheduleId: string, reason: string): Promise<void> {
+  await supabase.from('invoice_schedules').update({ active: false }).eq('id', scheduleId);
+  console.log(`[Monitor] Deactivated invoice schedule ${scheduleId}: ${reason}`);
+}
+
 function calculateNextInvoiceDueDate(current: Date, recurrence: string, customDays?: number): Date {
   const next = new Date(current);
   switch (recurrence) {
@@ -252,12 +272,21 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
 
         // Check limits
         if (schedule.max_occurrences && schedule.occurrences_count >= schedule.max_occurrences) {
-          await supabase.from('invoice_schedules').update({ active: false }).eq('id', schedule.id);
+          await deactivateSchedule(supabase, schedule.id, 'max_occurrences reached');
           stats.deactivated++;
           continue;
         }
         if (schedule.end_date && new Date(schedule.end_date) < now) {
-          await supabase.from('invoice_schedules').update({ active: false }).eq('id', schedule.id);
+          await deactivateSchedule(supabase, schedule.id, 'end_date passed');
+          stats.deactivated++;
+          continue;
+        }
+        if (REVOKED_TEMPLATE_STATUSES.has(templateInvoice.status)) {
+          await deactivateSchedule(
+            supabase,
+            schedule.id,
+            `template invoice ${templateInvoice.invoice_number} is ${templateInvoice.status}`,
+          );
           stats.deactivated++;
           continue;
         }
@@ -284,6 +313,48 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
           schedule.custom_interval_days
         );
 
+        // Re-resolve the payee every cycle rather than copying the template's
+        // address through untouched. The address was authorized once, by
+        // whoever created the template — they may since have been removed from
+        // the business or had their API key rotated, and nothing else in this
+        // job would notice. Running the same resolution the interactive paths
+        // use keeps unattended invoices under the same payee rule as manual
+        // ones, instead of exempting them from it.
+        const payee = await resolvePayee(supabase, {
+          businessId: templateInvoice.business_id,
+          merchantId: templateInvoice.user_id,
+          cryptocurrency: templateInvoice.crypto_currency,
+          requestedAddress: templateInvoice.merchant_wallet_address,
+          inherited: true,
+        });
+
+        if (!payee.ok) {
+          // Every invoice this series would mint is unpayable — or worse, would
+          // settle to the platform wallet. Stop and let the merchant re-point
+          // the schedule instead of emitting a stream of broken invoices.
+          await deactivateSchedule(supabase, schedule.id, `payee unresolvable (${payee.code})`);
+          stats.deactivated++;
+          continue;
+        }
+
+        // A payee the account can no longer derive from its own wallet config is
+        // not necessarily wrong — merchants do enter external addresses by hand.
+        // But an unattended job cannot tell that apart from an address left
+        // behind by someone who has since lost access, so flag it and let the
+        // human decide at send time rather than silently vouching for it.
+        const configured = await getPaymentReceivingWallet(supabase, {
+          businessId: templateInvoice.business_id,
+          merchantId: templateInvoice.user_id,
+          cryptocurrency: templateInvoice.crypto_currency,
+        });
+        const payeeUnverified =
+          !configured.walletAddress ||
+          configured.walletAddress.toLowerCase() !== payee.address.toLowerCase();
+
+        // The stored wallet_id only describes the template's address; if
+        // resolution landed somewhere else it no longer refers to anything.
+        const payeeMoved = payee.address !== templateInvoice.merchant_wallet_address;
+
         const { error: createError } = await supabase
           .from('invoices')
           .insert({
@@ -295,12 +366,18 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
             currency: templateInvoice.currency,
             amount: templateInvoice.amount,
             crypto_currency: templateInvoice.crypto_currency,
-            merchant_wallet_address: templateInvoice.merchant_wallet_address,
-            wallet_id: templateInvoice.wallet_id,
+            merchant_wallet_address: payee.address,
+            wallet_id: payeeMoved ? null : templateInvoice.wallet_id,
             fee_rate: templateInvoice.fee_rate,
             due_date: nextDueDate.toISOString(),
             notes: templateInvoice.notes,
-            metadata: { recurring: true, schedule_id: schedule.id, template_invoice_id: templateInvoice.id },
+            metadata: {
+              recurring: true,
+              schedule_id: schedule.id,
+              template_invoice_id: templateInvoice.id,
+              payee_source: payee.source,
+              ...(payeeUnverified ? { payee_unverified: true } : {}),
+            },
           });
 
         if (createError) {


### PR DESCRIPTION
## What

A recurring invoice schedule is standing authority to mint invoices inside a business. It is granted once at creation and never re-checked — the scheduler runs under the service-role key with no caller to authorize. Nothing revoked that authority:

- cancelling the template invoice did not stop it
- removing its creator from the business did not stop it
- rotating the business API key did not stop it
- the only exits the scheduler honoured were `max_occurrences` and `end_date`, both settable **only at creation time**
- there was no endpoint to pause a schedule, the invoice page rendered them read-only, and `DELETE /api/invoices/[id]` refuses anything past `draft`

Net effect: a merchant had no way to stop a series short of direct database access.

**Visible symptom:** `INV-012` was generated on 2026-08-04, a month after its template `INV-003` was cancelled ten minutes into its life.

**The sharper case:** a team member (or a leaked `cp_live_` key) sets an arbitrary payee — `resolvePayee` accepts any well-formed address, by design, for manual entry — is then removed from the business, and their address keeps being stamped onto new invoices in that business indefinitely.

## Changes

- Scheduler stops a series whose template invoice was cancelled.
- Scheduler re-resolves the payee each cycle instead of copying the template's address through, and stops rather than emit invoices with no resolvable payee.
- A payee the account cannot derive from its own wallet config is flagged `payee_unverified`. It is still honoured — merchants legitimately use external addresses — but an unattended job can't tell that apart from an address left behind by someone who lost access, so a human confirms before sending.
- Cancelling an invoice deactivates its schedules.
- New `GET`/`PATCH`/`DELETE /api/invoices/[id]/schedule`, authorized through `authorizeInvoice` like the rest of the family, with writes always scoped to the invoice so a foreign `schedule_id` can't be reached.
- Pause/resume control and an unverified-payee warning on the invoice page.

## Scope note

Generated invoices are `draft` and the only `draft → sent` transition is the explicit `/send` endpoint, so this was never a silent drain. What it did was plant plausible recurring payment requests that revocation could not clear.

## Testing

- 23 new tests (`monitor-invoices.scheduler.test.ts`, `schedule/route.test.ts`)
- Full suite: 3668 passed, 3 skipped, 259 files — no regressions
- `tsc --noEmit` clean; eslint 0 errors; `next build` passes

## Follow-up (not in this PR)

Three live schedules anchored to cancelled invoices are being deactivated directly in prod, since they fire before this can ship. Two belong to another merchant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)