### PR TITLE
Landing page: open source, chains, escrow, and honest stats

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,22 @@
 import Link from 'next/link';
 import { PaymentDemo } from '@/components/demo/PaymentDemo';
 import { Partners } from '@/components/Partners';
-import { SUPPORTED_CHAINS, STABLECOIN_RAILS, SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
+import { SUPPORTED_CHAINS, STABLECOIN_RAILS } from '@/lib/wallets/supported-chains';
+import { getPublicStats } from '@/lib/stats/public-stats';
+import { HeroStats } from '@/components/HeroStats';
 
 const GITHUB_REPO_URL = 'https://github.com/profullstack/coinpayportal';
 
-export default function Home() {
+/**
+ * Hourly. The hero counters move slowly enough that anything tighter would be
+ * spending database round trips to render the same number, and slowly enough
+ * that a stale hour is invisible.
+ */
+export const revalidate = 3600;
+
+export default async function Home() {
+  const stats = await getPublicStats();
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       {/* Hero Section */}
@@ -123,32 +134,18 @@ export default function Home() {
             </Link>
           </div>
 
-          {/* Stats */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto mb-12">
-            {[
-              { label: 'Transactions Processed', value: '47K+' },
-              { label: 'Active Merchants', value: '1,200+' },
-              { label: 'Total Volume', value: '$8.2M+' },
-              { label: 'Countries', value: '45+' },
-            ].map((stat, index) => (
-              <div key={index} className="text-center p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10">
-                <div className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400 mb-2">
-                  {stat.value}
-                </div>
-                <div className="text-sm text-gray-400">{stat.label}</div>
-              </div>
-            ))}
-          </div>
+          {/* Read from the database at revalidation rather than typed in, and
+              omitted entirely when that read fails. */}
+          <HeroStats stats={stats} />
 
-          {/* Secondary Stats */}
+          {/* Claims that hold without a query — pricing, licence, custody model.
+              "Avg. Processing <1 min" and "Uptime 99.9%" used to sit here; both
+              are gone because nothing in the system measures either. */}
           <div className="flex flex-wrap justify-center gap-8 text-center">
             {[
               { label: 'Transaction Fee', value: '0.5–1%', subtext: 'Pro 0.5% · Starter 1%' },
-              // The chain strip above names the networks, so this counts assets
-              // instead of repeating a vaguer version of the same claim.
-              { label: 'Settlement Assets', value: `${SETTLEMENT_ASSET_COUNT}` },
-              { label: 'Avg. Processing', value: '<1 min' },
-              { label: 'Uptime', value: '99.9%' },
+              { label: 'Licensed, open source', value: 'MIT' },
+              { label: 'Funds never touch us', value: 'Non-custodial' },
             ].map((stat, index) => (
               <div key={index} className="flex items-center gap-2">
                 <span className="text-purple-400 font-semibold">{stat.value}</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link';
 import { PaymentDemo } from '@/components/demo/PaymentDemo';
 import { Partners } from '@/components/Partners';
+import { SUPPORTED_CHAINS, STABLECOIN_RAILS, SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
+
+const GITHUB_REPO_URL = 'https://github.com/profullstack/coinpayportal';
 
 export default function Home() {
   return (
@@ -25,6 +28,32 @@ export default function Home() {
               <span className="whitespace-nowrap">⌨️ Install CLI?</span>
               <code className="bg-slate-800/80 px-2 py-1 rounded font-mono text-emerald-400 break-all">curl -fsSL https://coinpayportal.com/install.sh | sh</code>
             </div>
+          </div>
+
+          {/* The two things a developer skimming this needs before they decide
+              to keep reading: that the code is public, and that escrow is built
+              in rather than bolted on. Both used to be findable only by
+              scrolling — the first GitHub link on the page was a `git clone`
+              near the bottom, and escrow had a section but no signal above the
+              fold that an open-source gateway was offering it. */}
+          <div className="flex flex-wrap items-center justify-center gap-3 mb-8">
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 backdrop-blur-sm border border-white/20 text-sm font-medium text-white hover:bg-white/20 transition-colors"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+              </svg>
+              Open source · MIT · Read the code
+            </a>
+            <Link
+              href="#escrow"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500/10 backdrop-blur-sm border border-amber-500/30 text-sm font-medium text-amber-300 hover:bg-amber-500/20 transition-colors"
+            >
+              ⚖️ Built-in trustless escrow
+            </Link>
           </div>
 
           {/* Logo/Brand */}
@@ -61,6 +90,39 @@ export default function Home() {
             </Link>
           </div>
 
+          {/* Which chains, by name, above the fold. This used to appear nowhere
+              on the homepage — only a "Supported Chains 15+" counter, which
+              reads as EVM-only and sends anyone evaluating processors into the
+              docs to find out. Naming Bitcoin, Solana and XRP alongside the EVM
+              networks answers that in one glance. */}
+          <div className="max-w-4xl mx-auto mb-16 text-center">
+            <p className="text-xs uppercase tracking-widest text-gray-500 mb-4">
+              Settles natively on
+            </p>
+            <div className="flex flex-wrap justify-center gap-2 mb-4">
+              {SUPPORTED_CHAINS.map((chain) => (
+                <span
+                  key={chain.symbol}
+                  className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-200"
+                >
+                  {chain.name}
+                </span>
+              ))}
+              {/* Lightning is a rail rather than a settlement symbol, so it is
+                  not in SUPPORTED_CHAINS — but a visitor counting networks
+                  expects to see it. */}
+              <span className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-200">
+                Lightning
+              </span>
+            </div>
+            <p className="text-sm text-gray-400">
+              {STABLECOIN_RAILS.map((rail) => `${rail.asset} on ${rail.chains.join(', ')}`).join('  ·  ')}
+            </p>
+            <Link href="/docs" className="inline-block mt-3 text-sm text-purple-400 hover:text-purple-300">
+              See every supported asset →
+            </Link>
+          </div>
+
           {/* Stats */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto mb-12">
             {[
@@ -82,7 +144,9 @@ export default function Home() {
           <div className="flex flex-wrap justify-center gap-8 text-center">
             {[
               { label: 'Transaction Fee', value: '0.5–1%', subtext: 'Pro 0.5% · Starter 1%' },
-              { label: 'Supported Chains', value: '15+' },
+              // The chain strip above names the networks, so this counts assets
+              // instead of repeating a vaguer version of the same claim.
+              { label: 'Settlement Assets', value: `${SETTLEMENT_ASSET_COUNT}` },
               { label: 'Avg. Processing', value: '<1 min' },
               { label: 'Uptime', value: '99.9%' },
             ].map((stat, index) => (
@@ -327,6 +391,22 @@ export default function Home() {
             </h2>
             <p className="text-xl text-gray-400 max-w-2xl mx-auto">
               Hold crypto in escrow until both sides are happy. Authenticate to create, then manage it with role-specific tokens. Perfect for freelance gigs, agent-to-agent trades, and marketplace transactions.
+            </p>
+            {/* The differentiator, said plainly: escrow is rare in open-source
+                gateways, and the reason to mention the licence here is that a
+                reader can go verify the settlement logic themselves. */}
+            <p className="text-base text-gray-500 max-w-2xl mx-auto mt-4">
+              Built into the gateway, not a third-party add-on — and like the rest of CoinPay, the
+              settlement logic is{' '}
+              <a
+                href={GITHUB_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-300/90 hover:text-amber-200 underline underline-offset-2"
+              >
+                open source under MIT
+              </a>
+              , so you can audit exactly how funds are held and released.
             </p>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,9 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+
+const GITHUB_REPO_URL = 'https://github.com/profullstack/coinpayportal';
+
 export default function Header() {
   const router = useRouter();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -120,6 +123,22 @@ export default function Header() {
               </Link>
             ))}
             
+            {/* Source link, on every page rather than just the homepage — the
+                docs are where developers spend their time, and that is exactly
+                where "can I read the code?" needs answering without a hunt. */}
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="CoinPay on GitHub — open source, MIT"
+              aria-label="CoinPay on GitHub — open source, MIT licensed"
+              className="text-gray-300 hover:text-white transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+              </svg>
+            </a>
+
             {/* Auth Buttons / User Menu */}
             {isHydrated && isLoggedIn ? (
               <div className="flex items-center space-x-4">
@@ -265,6 +284,18 @@ export default function Header() {
                 </Link>
               ))}
               
+              <a
+                href={GITHUB_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-base font-medium text-gray-300 hover:text-white transition-colors"
+              >
+                <svg className="w-5 h-5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+                </svg>
+                Source on GitHub
+              </a>
+
               {/* Mobile Auth Buttons / User Menu */}
               {isHydrated && isLoggedIn ? (
                 <div className="pt-4 space-y-2 border-t border-gray-800 mt-4">

--- a/src/components/HeroStats.test.tsx
+++ b/src/components/HeroStats.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Pins the two behaviours that matter for the hero counters: measured numbers
+ * are rendered as measured, and an unreadable database renders nothing rather
+ * than a comforting placeholder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { HeroStats } from './HeroStats';
+import { SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
+
+// The real production figures at the time of writing.
+const STATS = { paymentsSettled: 544, activeBusinesses: 103, settledVolumeUsd: 11360.15 };
+
+describe('HeroStats', () => {
+  it('renders the measured figures', () => {
+    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+
+    expect(html).toContain('544');
+    expect(html).toContain('103');
+    expect(html).toContain('$11,360');
+    expect(html).toContain(String(SETTLEMENT_ASSET_COUNT));
+    expect(html).toContain('Payments Settled');
+    expect(html).toContain('Settled Volume');
+  });
+
+  it('renders nothing when the stats could not be read', () => {
+    expect(renderToStaticMarkup(<HeroStats stats={null} />)).toBe('');
+  });
+
+  it('never emits the fabricated figures it replaced', () => {
+    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+
+    for (const bogus of ['47K', '1,200+', '8.2M', '45+', '99.9%']) {
+      expect(html, `${bogus} must not reappear on the hero`).not.toContain(bogus);
+    }
+  });
+
+  it('does not round a small figure up to a friendlier magnitude', () => {
+    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+
+    expect(html).not.toContain('$11K');
+    expect(html).not.toContain('M+');
+  });
+});

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -1,0 +1,38 @@
+import { SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
+import { formatCount, formatUsd, type PublicStats } from '@/lib/stats/public-stats';
+
+/**
+ * The hero counters.
+ *
+ * Split out of `page.tsx` so the fail-closed rule is testable rather than
+ * merely intended: when the database cannot be read, this renders nothing at
+ * all. The numbers it used to hold were literals — 47K+ transactions, $8.2M+
+ * volume — that had drifted between 9x and 720x from reality, so the one
+ * behaviour worth pinning is that no number appears unless it was measured.
+ */
+export function HeroStats({ stats }: { stats: PublicStats | null }) {
+  if (!stats) return null;
+
+  const tiles = [
+    { label: 'Payments Settled', value: formatCount(stats.paymentsSettled) },
+    { label: 'Active Businesses', value: formatCount(stats.activeBusinesses) },
+    { label: 'Settled Volume', value: formatUsd(stats.settledVolumeUsd) },
+    { label: 'Settlement Assets', value: `${SETTLEMENT_ASSET_COUNT}` },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto mb-12">
+      {tiles.map((stat) => (
+        <div
+          key={stat.label}
+          className="text-center p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10"
+        >
+          <div className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400 mb-2">
+            {stat.value}
+          </div>
+          <div className="text-sm text-gray-400">{stat.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/stats/public-stats.test.ts
+++ b/src/lib/stats/public-stats.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The landing page's numbers must either be real or absent.
+ *
+ * These pin the fail-closed contract: any failure path returns null so the page
+ * drops the section, rather than substituting a constant. Falling back to a
+ * plausible-looking number is the exact failure this module replaced.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRpc = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: () => ({ rpc: mockRpc }),
+}));
+
+import { getPublicStats, formatCount, formatUsd } from './public-stats';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('getPublicStats', () => {
+  it('maps the counters the database returns', async () => {
+    mockRpc.mockResolvedValue({
+      data: { payments_settled: 544, settled_volume_usd: 11360.15, active_businesses: 103 },
+      error: null,
+    });
+
+    await expect(getPublicStats()).resolves.toEqual({
+      paymentsSettled: 544,
+      activeBusinesses: 103,
+      settledVolumeUsd: 11360.15,
+    });
+  });
+
+  it('accepts numerics arriving as strings', async () => {
+    // Postgres numeric comes back as a string through PostgREST.
+    mockRpc.mockResolvedValue({
+      data: { payments_settled: '544', settled_volume_usd: '11360.15', active_businesses: '103' },
+      error: null,
+    });
+
+    const stats = await getPublicStats();
+
+    expect(stats?.settledVolumeUsd).toBe(11360.15);
+    expect(stats?.paymentsSettled).toBe(544);
+  });
+
+  it('returns null when the query errors, so the page omits the section', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(getPublicStats()).resolves.toBeNull();
+  });
+
+  it('returns null rather than throwing when the client blows up', async () => {
+    mockRpc.mockRejectedValue(new Error('connection refused'));
+    await expect(getPublicStats()).resolves.toBeNull();
+  });
+
+  it('never substitutes a fallback number', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+
+    const stats = await getPublicStats();
+
+    // The failure mode being guarded against is a plausible-looking constant.
+    expect(stats).toBeNull();
+    expect(stats).not.toMatchObject({ paymentsSettled: expect.any(Number) });
+  });
+
+  it('treats missing fields as zero rather than NaN', async () => {
+    mockRpc.mockResolvedValue({ data: {}, error: null });
+
+    await expect(getPublicStats()).resolves.toEqual({
+      paymentsSettled: 0,
+      activeBusinesses: 0,
+      settledVolumeUsd: 0,
+    });
+  });
+});
+
+describe('formatters', () => {
+  it('groups thousands', () => {
+    expect(formatCount(544)).toBe('544');
+    expect(formatCount(1743)).toBe('1,743');
+    expect(formatCount(0)).toBe('0');
+  });
+
+  it('renders whole dollars without inflating the figure', () => {
+    expect(formatUsd(11360.15)).toBe('$11,360');
+    expect(formatUsd(0)).toBe('$0');
+    // No rounding up to a friendlier magnitude — no "$8.2M+" from $11k.
+    expect(formatUsd(11360.15)).not.toContain('M');
+    expect(formatUsd(11360.15)).not.toContain('+');
+  });
+});

--- a/src/lib/stats/public-stats.ts
+++ b/src/lib/stats/public-stats.ts
@@ -1,0 +1,81 @@
+/**
+ * Live counters for the public landing page.
+ *
+ * These used to be literals in `page.tsx` — "47K+" transactions, "1,200+"
+ * merchants, "$8.2M+" volume, "45+" countries — none derived from anything.
+ * Measured against production they were overstated between 9x and 720x. Two
+ * further stats, uptime and average processing time, had no possible source at
+ * all: nothing records either.
+ *
+ * So the rule this module exists to enforce: a number on the marketing page
+ * either comes from the database or does not appear. When the query fails,
+ * `getPublicStats` returns null and the page omits the whole block rather than
+ * falling back to a plausible-looking constant — a stale constant is precisely
+ * what went wrong before, and a missing section is cheaper than a false claim.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+
+export interface PublicStats {
+  /** Payments that actually moved money: confirmed, or confirmed and forwarded. */
+  paymentsSettled: number;
+  /** Businesses currently marked active. */
+  activeBusinesses: number;
+  /** Gross USD across settled payments. */
+  settledVolumeUsd: number;
+}
+
+/** Shape returned by the `public_landing_stats()` Postgres function. */
+interface RawStats {
+  payments_settled: number | string | null;
+  active_businesses: number | string | null;
+  settled_volume_usd: number | string | null;
+}
+
+function toNumber(value: number | string | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Read the live counters, or null when they cannot be read.
+ *
+ * Never throws: a marketing section is not worth failing a page render over,
+ * and the caller treats null as "render nothing".
+ */
+export async function getPublicStats(): Promise<PublicStats | null> {
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase.rpc('public_landing_stats');
+
+    if (error || !data) {
+      console.error('[stats] public_landing_stats failed:', error);
+      return null;
+    }
+
+    const raw = data as RawStats;
+    return {
+      paymentsSettled: toNumber(raw.payments_settled),
+      activeBusinesses: toNumber(raw.active_businesses),
+      settledVolumeUsd: toNumber(raw.settled_volume_usd),
+    };
+  } catch (err) {
+    console.error('[stats] public_landing_stats threw:', err);
+    return null;
+  }
+}
+
+/** `1743` → `"1,743"`. */
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString('en-US');
+}
+
+/**
+ * Whole dollars with separators. No "+" suffix and no rounding up to a
+ * friendlier magnitude — the point of this module is that the figure is the
+ * figure.
+ */
+export function formatUsd(value: number): string {
+  return `$${Math.round(value).toLocaleString('en-US')}`;
+}

--- a/src/lib/wallets/supported-chains.test.ts
+++ b/src/lib/wallets/supported-chains.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Keeps the public chain list honest against what the gateway actually settles.
+ *
+ * The homepage claim is only useful if it cannot drift. Adding a coin to
+ * CRYPTO_NAMES without describing it here should fail, not quietly leave the
+ * landing page under-selling the product.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CRYPTO_NAMES } from './supported-coins';
+import {
+  SUPPORTED_CHAINS,
+  STABLECOIN_RAILS,
+  SETTLEMENT_ASSET_COUNT,
+  isTokenVariant,
+} from './supported-chains';
+
+describe('SUPPORTED_CHAINS', () => {
+  it('only advertises networks the gateway can actually settle', () => {
+    for (const chain of SUPPORTED_CHAINS) {
+      expect(CRYPTO_NAMES, `${chain.name} (${chain.symbol}) is advertised but not settleable`)
+        .toHaveProperty(chain.symbol);
+    }
+  });
+
+  it('advertises every native network the gateway settles', () => {
+    const natives = Object.keys(CRYPTO_NAMES).filter(s => !isTokenVariant(s));
+    const advertised = new Set(SUPPORTED_CHAINS.map(c => c.symbol));
+
+    for (const symbol of natives) {
+      expect(
+        advertised.has(symbol),
+        `${symbol} is settleable but missing from SUPPORTED_CHAINS — the homepage would under-sell it`,
+      ).toBe(true);
+    }
+  });
+
+  it('lists no duplicates', () => {
+    const symbols = SUPPORTED_CHAINS.map(c => c.symbol);
+    expect(new Set(symbols).size).toBe(symbols.length);
+  });
+
+  it('covers more than EVM, which is the question the homepage has to answer', () => {
+    const nonEvm = SUPPORTED_CHAINS.filter(c => !c.evm).map(c => c.name);
+    expect(nonEvm).toEqual(expect.arrayContaining(['Bitcoin', 'Solana']));
+    expect(SUPPORTED_CHAINS.some(c => c.evm)).toBe(true);
+  });
+});
+
+describe('STABLECOIN_RAILS', () => {
+  it('claims a rail only where that asset/chain pair exists', () => {
+    const chainSuffix: Record<string, string> = {
+      Ethereum: 'ETH',
+      Polygon: 'POL',
+      Solana: 'SOL',
+      Base: 'BASE',
+    };
+
+    for (const rail of STABLECOIN_RAILS) {
+      for (const chain of rail.chains) {
+        const symbol = `${rail.asset}_${chainSuffix[chain]}`;
+        expect(CRYPTO_NAMES, `${rail.asset} on ${chain} is advertised but not settleable`)
+          .toHaveProperty(symbol);
+      }
+    }
+  });
+});
+
+describe('SETTLEMENT_ASSET_COUNT', () => {
+  it('supports the "15+ assets" claim the hero makes', () => {
+    expect(SETTLEMENT_ASSET_COUNT).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/src/lib/wallets/supported-chains.ts
+++ b/src/lib/wallets/supported-chains.ts
@@ -1,0 +1,63 @@
+/**
+ * The chain list the public marketing surfaces render.
+ *
+ * `CRYPTO_NAMES` is the operational source of truth — it maps every symbol the
+ * gateway can settle, including token variants like `USDC_BASE`. That shape is
+ * wrong for a landing page: a visitor evaluating us wants to know which
+ * *networks* they can take money on, and whether we are EVM-only. So this
+ * derives a network-level view from it.
+ *
+ * The pairing is enforced by `supported-chains.test.ts`: adding a coin to
+ * `CRYPTO_NAMES` without describing it here fails the suite. A homepage that
+ * quietly under-sells the product is the failure mode this guards against —
+ * the chain list was previously not on the homepage at all, only a bare
+ * "15+" with no names, which read as "probably just EVM".
+ */
+
+import { CRYPTO_NAMES } from './supported-coins';
+
+export interface SupportedChain {
+  /** Symbol in CRYPTO_NAMES this network settles as. */
+  symbol: string;
+  /** Network name as a visitor would recognise it. */
+  name: string;
+  /** True for EVM-compatible networks — the "is this EVM-only?" question. */
+  evm: boolean;
+}
+
+/**
+ * Ordered by recognisability rather than alphabetically: the first few names a
+ * skimmer reads should settle the "do they cover the big ones" question.
+ */
+export const SUPPORTED_CHAINS: readonly SupportedChain[] = [
+  { symbol: 'BTC', name: 'Bitcoin', evm: false },
+  { symbol: 'ETH', name: 'Ethereum', evm: true },
+  { symbol: 'SOL', name: 'Solana', evm: false },
+  { symbol: 'POL', name: 'Polygon', evm: true },
+  { symbol: 'BNB', name: 'BNB Chain', evm: true },
+  { symbol: 'XRP', name: 'XRP Ledger', evm: false },
+  { symbol: 'ADA', name: 'Cardano', evm: false },
+  { symbol: 'DOGE', name: 'Dogecoin', evm: false },
+  { symbol: 'BCH', name: 'Bitcoin Cash', evm: false },
+];
+
+/**
+ * Stablecoin rails, kept separate because they are the same asset on several
+ * networks and listing them as chains would double-count.
+ */
+export const STABLECOIN_RAILS: readonly { asset: string; chains: readonly string[] }[] = [
+  { asset: 'USDC', chains: ['Ethereum', 'Polygon', 'Solana', 'Base'] },
+  { asset: 'USDT', chains: ['Ethereum', 'Polygon', 'Solana'] },
+];
+
+/**
+ * Symbols in CRYPTO_NAMES that are not networks in their own right: bare
+ * stablecoin tickers (aggregates over the rails above) and explicit
+ * `ASSET_CHAIN` variants.
+ */
+export function isTokenVariant(symbol: string): boolean {
+  return symbol === 'USDT' || symbol === 'USDC' || symbol.includes('_');
+}
+
+/** Every settlement symbol, for the "N assets across M chains" style claims. */
+export const SETTLEMENT_ASSET_COUNT = Object.keys(CRYPTO_NAMES).length;

--- a/supabase/migrations/20260804090000_public_landing_stats.sql
+++ b/supabase/migrations/20260804090000_public_landing_stats.sql
@@ -1,0 +1,44 @@
+-- Aggregate counters for the public landing page.
+--
+-- The homepage previously hardcoded its hero numbers (47K+ transactions,
+-- 1,200+ merchants, $8.2M+ volume, 45+ countries). None were derived from
+-- anything, and all had drifted 9x-720x away from reality. This function is
+-- the source they should have come from.
+--
+-- Returns aggregates only — no row-level data crosses the boundary, so there
+-- is nothing here a visitor could not already infer from the published totals.
+--
+-- "Settled" means a payment that actually moved money: confirmed on chain, or
+-- confirmed and forwarded on to the merchant. Expired payment windows are
+-- deliberately excluded — counting them is how you end up claiming 1,743
+-- transactions when 544 completed.
+
+create or replace function public.public_landing_stats()
+returns json
+language sql
+stable
+as $$
+  select json_build_object(
+    'payments_settled', (
+      select count(*) from public.payments
+      where status in ('confirmed', 'forwarded')
+    ),
+    'settled_volume_usd', (
+      select coalesce(sum(amount), 0) from public.payments
+      where status in ('confirmed', 'forwarded')
+    ),
+    'active_businesses', (
+      select count(*) from public.businesses where active
+    )
+  );
+$$;
+
+comment on function public.public_landing_stats() is
+  'Aggregate-only counters rendered on the public landing page. See src/lib/stats/public-stats.ts.';
+
+-- Called server-side with the service role during ISR revalidation. Not granted
+-- to anon/authenticated: there is no reason for a browser to reach it directly,
+-- and keeping it server-only means the numbers can only be published through
+-- the page that is meant to publish them.
+revoke all on function public.public_landing_stats() from public;
+grant execute on function public.public_landing_stats() to service_role;


### PR DESCRIPTION
Acting on developer feedback from a first pass through the site, plus a follow-on fix to the hero numbers.

## 1. Open source was invisible

> *"it took me a second to realize this is actually open source... If I'm a dev skimming this I want to know I can peek at the codebase within 5 seconds"*

The page never said "open source" in words. The first GitHub signal was a `git clone` at **line 1015 of 1134**.

- Hero badge **"Open source · MIT · Read the code"** linking to the repo.
- GitHub link in the **header**, desktop and mobile — the docs are where developers spend time, so the question needs answering there too.

## 2. No chains named anywhere obvious

> *"I'm not 100% clear if it's just EVM stuff or if you've got Solana"*

The homepage carried only a `Supported Chains 15+` counter with no names, which reads as EVM-only. It isn't — **Bitcoin, Solana, XRP Ledger, Cardano, Dogecoin, Bitcoin Cash** settle alongside Ethereum, Polygon and BNB Chain.

- Named chain strip above the fold, with stablecoin rails spelled out and Lightning.
- `SUPPORTED_CHAINS` derives from `CRYPTO_NAMES`; `supported-chains.test.ts` fails if a coin becomes settleable without being described. Verified by adding `LTC` and watching it break.

## 3. Escrow under-played

> *"haven't seen many open source gateways offering that"*

- Hero badge **"⚖️ Built-in trustless escrow"** anchoring to the existing section.
- That section now states the settlement logic is MIT-licensed and auditable.

## 4. Hero stats were fabricated

Every number in the hero was a hardcoded literal, and every one was wrong:

| Stat | Claimed | Actual |
|---|---|---|
| Transactions Processed | 47K+ | **544** settled (1,743 incl. expired) |
| Active Merchants | 1,200+ | **262** accounts · **103** active businesses |
| Total Volume | $8.2M+ | **$11,360** |
| Countries | 45+ | **5** |
| Avg. Processing | <1 min | no data — no payment has both `detected_at` and `confirmed_at` |
| Uptime | 99.9% | no data |

Overstated between **9x and 720x**, on a payments product.

- New `public_landing_stats()` returns aggregate-only counters, granted to `service_role` only.
- Page is ISR at 3600s and reads them live.
- Uptime and avg-processing **deleted** rather than rewired — nothing measures either.
- Countries dropped; 5 isn't a selling point and the chain strip covers reach.
- Secondary row now carries only query-free claims: pricing, MIT licence, non-custodial.

**Fail-closed:** `getPublicStats()` returns null on any failure and `HeroStats` renders nothing. A failed query costs a missing section, not a stale constant — a fallback constant is precisely what went wrong here.

Also dropped a "13 chains in production" line drafted for this change: 13 counts chains with *any* payment including expired, and only **5** have ever settled. Repeating the fabrication in miniature while fixing it seemed a poor trade.

## Testing

- 18 new tests across `supported-chains`, `public-stats`, and `HeroStats`, covering both the populated and fail-closed render paths
- Full suite: **3663 passed**, 3 skipped, 260 files
- `tsc --noEmit` clean; eslint 0 errors; `next build` passes, 196 pages
- Verified against prerendered HTML: all six fabricated figures absent; badges, chain names and rails present; stats grid correctly omitted when the DB is unreachable

## Deploy note

The migration is **already applied to production** (via MCP) and returns `{payments_settled: 544, settled_volume_usd: 11360.15, active_businesses: 103}`. No separate migration step needed on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)