### PR TITLE
Make the hero stats actually render, and lock down the stats function

### DIFF
--- a/src/app/api/public-stats/route.test.ts
+++ b/src/app/api/public-stats/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetPublicStats = vi.fn();
+
+vi.mock('@/lib/stats/public-stats', () => ({
+  getPublicStats: () => mockGetPublicStats(),
+}));
+
+import { GET } from './route';
+
+const STATS = { paymentsSettled: 544, activeBusinesses: 103, settledVolumeUsd: 11360.15 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/public-stats', () => {
+  it('returns the counters', async () => {
+    mockGetPublicStats.mockResolvedValue(STATS);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, stats: STATS });
+  });
+
+  it('lets the edge hold the answer briefly rather than hitting the database per visitor', async () => {
+    mockGetPublicStats.mockResolvedValue(STATS);
+
+    const res = await GET();
+
+    expect(res.headers.get('Cache-Control')).toContain('s-maxage=300');
+  });
+
+  it('503s when the counters are unavailable, without inventing them', async () => {
+    mockGetPublicStats.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.success).toBe(false);
+    // No zeros, no last-known values, no placeholder shape at all.
+    expect(body).not.toHaveProperty('stats');
+  });
+
+  it('does not let a cache memoise an absence as data', async () => {
+    mockGetPublicStats.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/src/app/api/public-stats/route.ts
+++ b/src/app/api/public-stats/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getPublicStats } from '@/lib/stats/public-stats';
+
+/**
+ * GET /api/public-stats — the hero counters.
+ *
+ * Exists because the landing page could not read them itself. The page is
+ * prerendered during `pnpm build`, and the Dockerfile only forwards
+ * `NEXT_PUBLIC_*` build args — `SUPABASE_SERVICE_ROLE_KEY` is deliberately not
+ * among them, since baking a service key into an image layer would be worse
+ * than a missing statistic. So the build-time render always failed closed and
+ * the homepage shipped with no stats at all.
+ *
+ * A route handler runs at request time, where the key is present. That keeps
+ * the landing page fully static — it is the marketing page, and per-request
+ * rendering of it to fetch three integers would be a poor trade — while the
+ * numbers stay live.
+ *
+ * No authentication: this publishes exactly what the homepage publishes. The
+ * underlying Postgres function stays `service_role`-only so the browser reaches
+ * these figures through here rather than through PostgREST, where an anonymous
+ * caller would run it under RLS and receive a well-formed set of zeros.
+ */
+export async function GET() {
+  const stats = await getPublicStats();
+
+  if (!stats) {
+    // 503 rather than 200-with-nulls: the client renders nothing on failure,
+    // and a caching layer should not memoise an absence as though it were data.
+    return NextResponse.json(
+      { success: false, error: 'Stats temporarily unavailable' },
+      { status: 503, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  return NextResponse.json(
+    { success: true, stats },
+    {
+      // The counters move slowly; five minutes at the edge keeps the database
+      // out of the request path for essentially every visitor.
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600' },
+    },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,21 +2,15 @@ import Link from 'next/link';
 import { PaymentDemo } from '@/components/demo/PaymentDemo';
 import { Partners } from '@/components/Partners';
 import { SUPPORTED_CHAINS, STABLECOIN_RAILS } from '@/lib/wallets/supported-chains';
-import { getPublicStats } from '@/lib/stats/public-stats';
 import { HeroStats } from '@/components/HeroStats';
 
 const GITHUB_REPO_URL = 'https://github.com/profullstack/coinpayportal';
 
-/**
- * Hourly. The hero counters move slowly enough that anything tighter would be
- * spending database round trips to render the same number, and slowly enough
- * that a stale hour is invisible.
- */
-export const revalidate = 3600;
-
-export default async function Home() {
-  const stats = await getPublicStats();
-
+// Stays statically prerendered. The hero counters cannot be read at build time
+// — the service-role key is deliberately not a Docker build arg — so HeroStats
+// fetches them from /api/public-stats at request time instead of forcing this
+// whole page to render per request for the sake of three integers.
+export default function Home() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       {/* Hero Section */}
@@ -136,7 +130,7 @@ export default async function Home() {
 
           {/* Read from the database at revalidation rather than typed in, and
               omitted entirely when that read fails. */}
-          <HeroStats stats={stats} />
+          <HeroStats />
 
           {/* Claims that hold without a query — pricing, licence, custody model.
               "Avg. Processing <1 min" and "Uptime 99.9%" used to sit here; both

--- a/src/components/HeroStats.test.tsx
+++ b/src/components/HeroStats.test.tsx
@@ -1,20 +1,32 @@
 /**
- * Pins the two behaviours that matter for the hero counters: measured numbers
- * are rendered as measured, and an unreadable database renders nothing rather
- * than a comforting placeholder.
+ * @vitest-environment jsdom
  */
 
-import { describe, it, expect } from 'vitest';
+/**
+ * Two behaviours matter for the hero counters: measured numbers render as
+ * measured, and everything else renders nothing. "Everything else" now includes
+ * the window before the fetch resolves and every way it can fail — the previous
+ * server-rendered version failed closed correctly and still shipped a homepage
+ * with no stats on it, so the fetch path deserves the same scrutiny.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { HeroStats } from './HeroStats';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { HeroStats, HeroStatsView } from './HeroStats';
 import { SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
 
 // The real production figures at the time of writing.
 const STATS = { paymentsSettled: 544, activeBusinesses: 103, settledVolumeUsd: 11360.15 };
 
-describe('HeroStats', () => {
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('HeroStatsView', () => {
   it('renders the measured figures', () => {
-    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+    const html = renderToStaticMarkup(<HeroStatsView stats={STATS} />);
 
     expect(html).toContain('544');
     expect(html).toContain('103');
@@ -25,11 +37,11 @@ describe('HeroStats', () => {
   });
 
   it('renders nothing when the stats could not be read', () => {
-    expect(renderToStaticMarkup(<HeroStats stats={null} />)).toBe('');
+    expect(renderToStaticMarkup(<HeroStatsView stats={null} />)).toBe('');
   });
 
   it('never emits the fabricated figures it replaced', () => {
-    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+    const html = renderToStaticMarkup(<HeroStatsView stats={STATS} />);
 
     for (const bogus of ['47K', '1,200+', '8.2M', '45+', '99.9%']) {
       expect(html, `${bogus} must not reappear on the hero`).not.toContain(bogus);
@@ -37,9 +49,71 @@ describe('HeroStats', () => {
   });
 
   it('does not round a small figure up to a friendlier magnitude', () => {
-    const html = renderToStaticMarkup(<HeroStats stats={STATS} />);
+    const html = renderToStaticMarkup(<HeroStatsView stats={STATS} />);
 
     expect(html).not.toContain('$11K');
     expect(html).not.toContain('M+');
+  });
+});
+
+describe('HeroStats (fetching)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the figures the API returns', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, stats: STATS }),
+      }),
+    );
+
+    render(<HeroStats />);
+
+    await waitFor(() => expect(screen.getByText('544')).toBeDefined());
+    expect(screen.getByText('$11,360')).toBeDefined();
+    expect(screen.getByText('103')).toBeDefined();
+  });
+
+  it('renders nothing before the fetch resolves', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const { container } = render(<HeroStats />);
+
+    // No skeleton and no placeholder digits: an unmeasured number must not
+    // appear even for a frame.
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when the endpoint is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+    const { container } = render(<HeroStats />);
+
+    await waitFor(() => expect(container.innerHTML).toBe(''));
+  });
+
+  it('renders nothing when the request rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    const { container } = render(<HeroStats />);
+
+    await waitFor(() => expect(container.innerHTML).toBe(''));
+  });
+
+  it('renders nothing when the payload reports failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: false, error: 'Stats temporarily unavailable' }),
+      }),
+    );
+
+    const { container } = render(<HeroStats />);
+
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 });

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -1,16 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { SETTLEMENT_ASSET_COUNT } from '@/lib/wallets/supported-chains';
 import { formatCount, formatUsd, type PublicStats } from '@/lib/stats/public-stats';
 
 /**
  * The hero counters.
  *
- * Split out of `page.tsx` so the fail-closed rule is testable rather than
- * merely intended: when the database cannot be read, this renders nothing at
- * all. The numbers it used to hold were literals — 47K+ transactions, $8.2M+
- * volume — that had drifted between 9x and 720x from reality, so the one
- * behaviour worth pinning is that no number appears unless it was measured.
+ * Fetched from `/api/public-stats` at request time rather than rendered on the
+ * server. The landing page is prerendered during `pnpm build`, where
+ * `SUPABASE_SERVICE_ROLE_KEY` is intentionally absent — the Dockerfile forwards
+ * only `NEXT_PUBLIC_*` build args — so a server render could only ever fail
+ * closed. That is exactly what shipped: a homepage with no stats on it. The
+ * route handler runs where the key exists, and fetching from the client keeps
+ * the page itself static.
+ *
+ * The numbers these replaced were literals overstated between 9x and 720x, so
+ * the rule worth holding is unchanged: nothing renders unless it was measured.
+ * No skeleton, no placeholder, no last-known value — while loading, and on any
+ * failure, this is empty.
  */
-export function HeroStats({ stats }: { stats: PublicStats | null }) {
+
+/** Pure renderer, split out so the fail-closed rule stays directly testable. */
+export function HeroStatsView({ stats }: { stats: PublicStats | null }) {
   if (!stats) return null;
 
   const tiles = [
@@ -35,4 +47,25 @@ export function HeroStats({ stats }: { stats: PublicStats | null }) {
       ))}
     </div>
   );
+}
+
+export function HeroStats() {
+  const [stats, setStats] = useState<PublicStats | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch('/api/public-stats', { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (body?.success && body.stats) setStats(body.stats as PublicStats);
+      })
+      .catch(() => {
+        // Includes the abort on unmount. Nothing to show either way.
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  return <HeroStatsView stats={stats} />;
 }

--- a/supabase/migrations/20260804093000_lock_down_public_landing_stats.sql
+++ b/supabase/migrations/20260804093000_lock_down_public_landing_stats.sql
@@ -1,0 +1,34 @@
+-- Restrict public_landing_stats() to the service role, for real this time.
+--
+-- The previous migration said "service_role only" and did:
+--
+--   revoke all on function public.public_landing_stats() from public;
+--   grant execute on function public.public_landing_stats() to service_role;
+--
+-- which does not achieve that on Supabase. `revoke ... from public` only drops
+-- the PUBLIC pseudo-role's grant. Supabase ships default privileges that grant
+-- EXECUTE on new functions in `public` to `anon` and `authenticated`, and those
+-- are separate, explicit grants that survive the revoke. The resulting ACL was:
+--
+--   postgres=X/postgres  anon=X/postgres  authenticated=X/postgres  service_role=X/postgres
+--
+-- The function is SECURITY INVOKER, so an anonymous caller ran it under RLS,
+-- saw no rows, and got a well-formed answer back:
+--
+--   {"payments_settled": 0, "settled_volume_usd": 0, "active_businesses": 0}
+--
+-- A public endpoint reporting the business as zero is the same failure the
+-- landing-page work set out to remove — a number that looks measured and is
+-- not. Revoked explicitly rather than trusting the default.
+--
+-- Kept SECURITY INVOKER deliberately: with anon and authenticated revoked, the
+-- only caller is the service role, which bypasses RLS anyway. Adding DEFINER
+-- would buy nothing and would make an accidental future re-grant far worse,
+-- since it would then return the real figures instead of zeros.
+
+revoke execute on function public.public_landing_stats() from anon, authenticated;
+
+comment on function public.public_landing_stats() is
+  'Aggregate-only counters for the public landing page. service_role only — see '
+  'src/app/api/public-stats/route.ts. Do not grant to anon/authenticated: the '
+  'function is SECURITY INVOKER and would silently return zeros under RLS.';


### PR DESCRIPTION
Two defects from #230, both found by checking the **deployed site** rather than the build. The landing page shipped correctly; the stats on it did not.

## 1. The stats never rendered in production

`coinpayportal.com` went live with no stats grid at all.

The page is prerendered during `pnpm build`, and the Dockerfile forwards only `NEXT_PUBLIC_*` build args — `SUPABASE_SERVICE_ROLE_KEY` is deliberately **not** among them, since baking a service key into an image layer is worse than a missing statistic. So `getPublicStats()` failed at build time, the fail-closed path omitted the grid, and that empty render was baked into the static HTML.

The mechanism worked exactly as designed. The design just didn't fit the deploy topology.

**Fix:** moved the read to `GET /api/public-stats`, which runs at request time where the key exists. `HeroStats` fetches it client-side. The page stays statically prerendered — rendering the whole marketing page per request to obtain three integers would be a poor trade — and the counters stay live, refreshed at the edge every 5 minutes.

Fail-closed is unchanged and now covers more ground: nothing renders before the fetch resolves, on a non-ok response, on a rejected request, or on a payload reporting failure. No skeleton, no placeholder, no last-known value.

## 2. The access control didn't do what its comment claimed

The previous migration said "service_role only" and used `revoke all ... from public`. That doesn't achieve it on Supabase: default privileges grant `EXECUTE` on new public functions to `anon` and `authenticated`, and those are separate explicit grants the revoke doesn't touch. Actual ACL:

```
postgres=X/postgres  anon=X/postgres  authenticated=X/postgres  service_role=X/postgres
```

The function is `SECURITY INVOKER`, so an anonymous caller ran it under RLS, saw no rows, and got a well-formed answer:

```json
{"payments_settled": 0, "settled_volume_usd": 0, "active_businesses": 0}
```

A public endpoint reporting the business as zero is the same failure this work set out to remove — a number that looks measured and isn't.

**Fix:** revoked explicitly. Verified against production — ACL is now `postgres=X, service_role=X`, anon gets `42501 permission denied`, `service_role` retains execute.

Kept `SECURITY INVOKER` deliberately: with anon revoked the only caller is the service role, which bypasses RLS anyway, and `DEFINER` would make an accidental future re-grant leak the real figures instead of zeros.

## Testing

- 21 tests across `HeroStats`, `public-stats`, and the new route — including all four fetch-failure paths and the pre-resolve window
- Full suite: **3695 passed**, 3 skipped, 263 files
- `tsc --noEmit` clean; eslint 0 errors; `next build` passes — homepage still prerendered, `/api/public-stats` built as a runtime route
- Production ACL and the anon denial verified directly against the live database

## Deploy note

The grant migration is **already applied to production**. The render fix ships with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)