### PR TITLE
docs: state custody precisely instead of claiming non-custodial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CoinPay ⚡
 
-The multi-chain payment infrastructure for humans and AI agents. Non-custodial crypto payments, escrow, web wallet, Lightning, x402 protocol, and Stripe — all in one platform.
+The multi-chain payment infrastructure for humans and AI agents. Crypto payments, escrow, a non-custodial web wallet, Lightning, x402 protocol, and Stripe — all in one platform.
 
 **[coinpayportal.com](https://coinpayportal.com)** · [Docs](https://coinpayportal.com/docs) · [SDK](https://coinpayportal.com/docs/sdk) · [Discord](https://discord.gg/U7dEXfBA3s)
 
@@ -8,14 +8,16 @@ The multi-chain payment infrastructure for humans and AI agents. Non-custodial c
 
 ## What is CoinPay?
 
-CoinPay is a non-custodial payment gateway that lets merchants accept crypto, Lightning, and card payments. It's designed for both traditional e-commerce and the agent economy — AI agents can create wallets, send payments, manage escrows, and pay for APIs autonomously.
+CoinPay is a payment gateway that lets merchants accept crypto, Lightning, and card payments. It's designed for both traditional e-commerce and the agent economy — AI agents can create wallets, send payments, manage escrows, and pay for APIs autonomously.
+
+**Custody, up front:** CoinPay is not non-custodial as a whole, and we don't market it that way. The web wallet is genuinely non-custodial (keys are generated client-side and never reach the server). On-chain payments land at a CoinPay-derived address and are forwarded to the merchant, so we hold the key for that window. Default escrow is custodial for the whole escrow window; `multisig_2of3` escrow is not (we hold one key of three). Lightning is custodial until withdrawal. Full breakdown — including shutdown and dispute handling — lives at [`/custody`](src/app/custody/page.tsx), and `docs/ESCROW.md` covers the escrow model in depth. **If you change custody behaviour, update those in the same commit.**
 
 ## 🌟 Features
 
 ### 💰 Multi-Chain Payments
 - **7 blockchains**: Bitcoin, Bitcoin Cash, Ethereum, Polygon, Solana, USDC (ETH/POL/SOL/Base)
-- **Non-custodial**: Funds go directly to merchant wallets — no intermediaries
-- **Real-time processing**: Instant payment detection and forwarding
+- **Forwarded to merchant wallets**: Payments are received at a CoinPay-derived address and forwarded to the merchant's own wallet; CoinPay holds that key until the forward confirms
+- **Real-time processing**: Instant payment detection, with forwarding attempted every minute
 - **0.5% platform fee**: Automatically deducted during forwarding
 - **QR codes**: BIP21/EIP-681/Solana Pay URIs for one-tap wallet opens
 - **Webhook notifications**: Real-time payment callbacks

--- a/docs/ESCROW.md
+++ b/docs/ESCROW.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Authenticated, non-custodial-style escrow for crypto payments. Both humans and AI agents can use it to hold funds in escrow during jobs/gigs. Funds are held in platform-generated HD wallet addresses (same system wallet infrastructure as payments) and released based on escrow conditions.
+Authenticated escrow for crypto payments. Both humans and AI agents can use it to hold funds in escrow during jobs/gigs.
+
+**Custody: the default model is custodial. Say so.** Funds are held in platform-generated HD wallet addresses derived from `SYSTEM_MNEMONIC_*` (the same system wallet infrastructure as payments), so during the escrow window CoinPay can technically move the funds and the depositor is trusting the operator, not the chain. Do not describe this model as "non-custodial" or "non-custodial-style" in docs, UI, or marketing — the only non-custodial escrow model here is `multisig_2of3`, where CoinPay holds one key of three. See `/custody` (`src/app/custody/page.tsx`) for the user-facing disclosure that must stay in sync with this file.
 
 **Key properties:**
 - Authenticated creation — merchant JWT or API key required

--- a/public/skill.md
+++ b/public/skill.md
@@ -1,7 +1,7 @@
 ---
 name: coinpayportal
 version: 3.0.0
-description: Non-custodial payments, escrow, and wallets for AI agents. Send, receive, and hold funds in escrow across BTC, ETH, SOL, POL, BCH, and USDC.
+description: Payments, escrow, and a non-custodial browser wallet for AI agents. Send, receive, and hold funds in escrow across BTC, ETH, SOL, POL, BCH, and USDC.
 homepage: https://coinpayportal.com
 ---
 
@@ -11,7 +11,21 @@ curl -s https://coinpayportal.com/skill.md
 
 # CoinPayPortal — Payments, Escrow & Wallets
 
-Non-custodial crypto infrastructure for AI agents and humans. Create wallets, send payments, hold funds in escrow, and receive payments across BTC, ETH, SOL, POL, BCH, and USDC — no KYC required.
+Crypto infrastructure for AI agents and humans. Create wallets, send payments, hold funds in escrow, and receive payments across BTC, ETH, SOL, POL, BCH, and USDC — no KYC required.
+
+**Custody differs by product — do not assume non-custodial across the board:**
+
+| Product | Who can move funds |
+|---------|--------------------|
+| Web wallet (this API) | You only — keys are generated client-side and never sent to us |
+| On-chain payments | CoinPay holds the receiving key until the balance is forwarded to the merchant |
+| Escrow, `custodial` (default) | CoinPay, for the whole escrow window |
+| Escrow, `multisig_2of3` | Any 2 of depositor / beneficiary / CoinPay — CoinPay cannot act alone |
+| Lightning | CoinPay, until withdrawn on-chain |
+
+If an agent is holding value it cannot afford to lose to counterparty risk, use
+`escrow_model: 'multisig_2of3'` or withdraw to a self-held wallet. Full disclosure,
+including shutdown and dispute handling: https://coinpayportal.com/custody
 
 **Base URL:** `https://coinpayportal.com/api/web-wallet`
 **npm:** `@profullstack/coinpay`
@@ -457,7 +471,7 @@ curl -X POST https://coinpayportal.com/api/escrow \
 
 ## Key Principles
 
-- **Non-custodial**: Your private keys never touch our servers
+- **Non-custodial (this web-wallet API)**: Your private keys never touch our servers. Note this applies to the web wallet documented here — escrow and Lightning are custodial, see the custody table above
 - **Anonymous**: No email, no KYC — your seed phrase is your identity
 - **Multi-chain**: 8 assets across 5 blockchains
 - **Signature auth**: Every request is signed with your key (nonce prevents replay)

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,22 +4,37 @@ export default function AboutPage() {
       <h1 className="text-4xl font-bold mb-8 text-white">About CoinPay</h1>
       <div className="prose max-w-none">
         <p className="text-lg text-gray-300 mb-6">
-          CoinPay is a non-custodial cryptocurrency payment gateway built for modern e-commerce.
+          CoinPay is a cryptocurrency payment gateway, escrow, and wallet service built for modern
+          e-commerce and for AI agents.
         </p>
-        
+
         <h2 className="text-2xl font-bold mt-8 mb-4 text-white">What We Do</h2>
         <p className="text-gray-300 mb-4">
           We enable online merchants to accept Bitcoin, Ethereum, Solana, Polygon, and USDC payments
-          without holding customer funds. Payments go directly to your wallet with a simple 0.5% transaction fee.
+          for a 0.5% transaction fee. Customers pay to an address we derive, and our monitor forwards
+          the balance to your wallet — usually well under a minute after confirmation. We hold the key
+          to that address until the forward completes, so payments pass through us rather than around
+          us.
+        </p>
+        <p className="text-gray-300 mb-4">
+          Our web wallet is genuinely non-custodial: its keys are generated in your browser and never
+          reach our servers. Our default escrow is genuinely custodial: we hold the funds for the
+          length of the job. We describe each one as what it is, and{' '}
+          <a href="/custody" className="text-purple-400 hover:text-purple-300">
+            spell out the whole picture here
+          </a>{' '}
+          — including what happens to your funds if we shut down, and who decides disputes.
         </p>
 
         <h2 className="text-2xl font-bold mt-8 mb-4 text-white">Why CoinPay?</h2>
         <ul className="list-disc list-inside text-gray-300 space-y-2 mb-6">
-          <li>Non-custodial - You control your funds</li>
           <li>0.5% transaction fee - Lower than traditional processors</li>
+          <li>Non-custodial web wallet - Your keys never leave your browser</li>
+          <li>2-of-3 multisig escrow - We hold one key of three, never enough to act alone</li>
           <li>Real-time processing - Instant payment detection</li>
           <li>Multi-chain support - BTC, ETH, SOL, POL, USDC</li>
           <li>Simple integration - RESTful API and webhooks</li>
+          <li>MIT licensed - The server handling your funds is public and auditable</li>
         </ul>
 
         <h2 className="text-2xl font-bold mt-8 mb-4 text-white">Built By</h2>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -128,7 +128,8 @@ export default async function BlogPostPage({ params }: RouteParams) {
         <div className="rounded-lg border border-purple-500/30 bg-purple-600/5 p-6">
           <h3 className="text-lg font-semibold text-white">Try CoinPay</h3>
           <p className="mt-2 text-sm text-gray-300">
-            Non-custodial crypto payments — multi-chain, Lightning-ready, and fast to integrate.
+            Crypto payments, escrow, and wallets — multi-chain, Lightning-ready, and fast to
+            integrate.
           </p>
           <Link
             href="/register"

--- a/src/app/custody/page.tsx
+++ b/src/app/custody/page.tsx
@@ -1,0 +1,311 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Who Holds Your Money | CoinPay',
+  description:
+    'Exactly who can move funds at each step of CoinPay, what happens to your money if CoinPay shuts down, and who decides disputes. Per-product custody, stated plainly.',
+};
+
+/**
+ * Custody disclosure.
+ *
+ * This page exists because "non-custodial" is not true of CoinPay as a whole —
+ * it is true of some surfaces and false of others. Every claim here is meant to
+ * be checkable against the code, so if you change custody behaviour, change this
+ * page in the same commit:
+ *
+ *   - payment forwarding window ... src/lib/payments/forwarding.ts
+ *   - escrow key custody ......... src/lib/escrow/service.ts (platform HD address)
+ *   - 2-of-3 multisig escrow ..... src/lib/multisig/engine.ts
+ *   - expiry auto-refund/release . src/app/api/cron/monitor-payments/escrow-monitor.ts
+ *   - web wallet key handling .... src/lib/web-wallet/keys.ts (keys never sent to server)
+ */
+
+type Custody = 'none' | 'window' | 'full';
+
+const CUSTODY_ROWS: Array<{
+  product: string;
+  who: string;
+  custody: Custody;
+}> = [
+  {
+    product: 'Web wallet',
+    who: 'You, and only you. The seed is generated and encrypted in your browser and is never sent to our servers.',
+    custody: 'none',
+  },
+  {
+    product: 'On-chain payments',
+    who: 'You, after a short window. Customers pay to an address CoinPay derives, and our monitor forwards the balance to your wallet minus the fee. Between confirmation and forwarding, our infrastructure holds the key.',
+    custody: 'window',
+  },
+  {
+    product: 'Escrow — default (custodial)',
+    who: 'CoinPay, for the entire escrow. Funds sit at an address we derive from our own seed, and we move them when the depositor releases, a refund is requested, or an arbiter resolves a dispute.',
+    custody: 'full',
+  },
+  {
+    product: 'Escrow — 2-of-3 multisig',
+    who: 'Any two of depositor, beneficiary, and CoinPay. We hold one key of three, so we cannot move your funds alone.',
+    custody: 'none',
+  },
+  {
+    product: 'Lightning wallet',
+    who: 'CoinPay, until you withdraw. Lightning balances live on our node, not under your seed phrase.',
+    custody: 'full',
+  },
+];
+
+const CUSTODY_LABEL: Record<Custody, { text: string; className: string }> = {
+  none: {
+    text: 'We never hold it',
+    className: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30',
+  },
+  window: {
+    text: 'We hold it briefly',
+    className: 'bg-amber-500/10 text-amber-300 border-amber-500/30',
+  },
+  full: {
+    text: 'We hold it',
+    className: 'bg-rose-500/10 text-rose-300 border-rose-500/30',
+  },
+};
+
+export default function CustodyPage() {
+  return (
+    <div className="container mx-auto px-4 py-16 max-w-4xl">
+      <h1 className="text-4xl font-bold mb-4 text-white">Who holds your money</h1>
+      <p className="text-lg text-gray-300 mb-10">
+        CoinPay is not one custody model, so we do not describe it with one word. Some parts of
+        CoinPay never touch your funds. Some hold them for about a minute. Some hold them until
+        someone tells us to let go. Below is which is which, what happens to your money if this
+        company disappears, and who decides when two parties disagree.
+      </p>
+
+      {/* ── 1. Who holds it right now ─────────────────────────── */}
+      <section className="mb-14">
+        <h2 className="text-2xl font-bold mb-4 text-white">1. Who holds the money right now</h2>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="border-b border-white/20">
+                <th className="py-3 pr-4 text-white font-semibold align-bottom">Product</th>
+                <th className="py-3 pr-4 text-white font-semibold align-bottom">
+                  Who can move the funds
+                </th>
+                <th className="py-3 text-white font-semibold align-bottom whitespace-nowrap">
+                  Custody
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {CUSTODY_ROWS.map((row) => (
+                <tr key={row.product} className="border-b border-white/10 align-top">
+                  <td className="py-4 pr-4 text-white font-medium">{row.product}</td>
+                  <td className="py-4 pr-4 text-gray-300">{row.who}</td>
+                  <td className="py-4">
+                    <span
+                      className={`inline-block whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium ${
+                        CUSTODY_LABEL[row.custody].className
+                      }`}
+                    >
+                      {CUSTODY_LABEL[row.custody].text}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="rounded-xl border border-white/15 bg-white/5 p-5 mt-6">
+          <p className="text-gray-300">
+            <strong className="text-white">Which of these apply to you.</strong> Escrow, Lightning,
+            and the web wallet are opt-in — most merchants never enable them, and if you don&apos;t,
+            the custodial rows above are not part of your setup. The payment forwarding window is
+            not opt-in. It applies to every on-chain payment CoinPay processes, so it is the one row
+            that describes you no matter how you use the product.
+          </p>
+        </div>
+
+        <p className="text-gray-300 mt-6">
+          That window is worth being precise about, because &ldquo;funds go directly to your
+          wallet&rdquo; is the kind of phrase that sounds like nothing touches them. Something does.
+          Every payment is received at an address we derive from our own seed, and our monitor —
+          which runs every minute — forwards the balance on to you minus the fee. There is no mode
+          where a customer pays your wallet directly. In the normal case you are holding the funds
+          well under a minute after confirmation. If a forward fails — a bad RPC, a gas shortfall —
+          it retries, and the money stays at our address until it succeeds. During that time we
+          could move it. We do not, but you are trusting us, not math.
+        </p>
+
+        <p className="text-gray-300 mt-4">
+          Default escrow is the same trust, held for longer and on purpose. Money sits at our
+          address for the length of the job. If that is not a trade you want to make, create the
+          escrow as{' '}
+          <span className="text-white font-medium">2-of-3 multisig</span> instead: we hold one key
+          of three, which is enough to break a tie and not enough to take anything.
+        </p>
+      </section>
+
+      {/* ── 2. If we disappear ────────────────────────────────── */}
+      <section className="mb-14">
+        <h2 className="text-2xl font-bold mb-4 text-white">
+          2. What happens if CoinPay disappears tomorrow
+        </h2>
+
+        <p className="text-gray-300 mb-4">
+          Split by whether your funds depend on us being alive.
+        </p>
+
+        <h3 className="text-lg font-semibold text-white mt-6 mb-2">You are fine without us</h3>
+        <ul className="list-disc list-inside text-gray-300 space-y-2 mb-6">
+          <li>
+            <strong className="text-white">Web wallet.</strong> Your seed is in your browser and we
+            never had it. Export it, import it into any compatible wallet, and your funds are
+            unaffected by anything that happens to this company. Export it{' '}
+            <em>before</em> you need it — clearing site data destroys the only copy we cannot help
+            you replace.
+          </li>
+          <li>
+            <strong className="text-white">Money already forwarded.</strong> Once a payment reaches
+            your wallet it is yours, in your custody, with no ongoing dependency on CoinPay.
+          </li>
+          <li>
+            <strong className="text-white">2-of-3 multisig escrow.</strong> The depositor and the
+            beneficiary together are two of three signers. They can settle the escrow between
+            themselves without CoinPay ever signing. This is the only product here where a dispute
+            about our absence has a purely mechanical answer.
+          </li>
+        </ul>
+
+        <h3 className="text-lg font-semibold text-white mt-6 mb-2">You are depending on us</h3>
+        <ul className="list-disc list-inside text-gray-300 space-y-2 mb-6">
+          <li>
+            <strong className="text-white">Default custodial escrow</strong>, funds mid-forward, and{' '}
+            <strong className="text-white">Lightning balances</strong> are all held at addresses
+            derived from CoinPay&apos;s own seed. If our infrastructure and our keys are gone, there
+            is no third party holding a backup for you and no on-chain mechanism that releases the
+            funds without us. Recovery would depend entirely on Profullstack, Inc. being able and
+            willing to act.
+          </li>
+          <li>
+            We are not a bank. There is no deposit insurance, no segregated trust account, and no
+            regulator you can escalate to for these balances.
+          </li>
+        </ul>
+
+        <div className="rounded-xl border border-white/15 bg-white/5 p-5">
+          <p className="text-gray-300">
+            <strong className="text-white">Open source helps, but not the way people assume.</strong>{' '}
+            CoinPay is MIT-licensed and the full server is public, so you can audit exactly what we
+            do with keys and you could run the whole stack yourself. What that does{' '}
+            <em>not</em> do is give you our keys. Reading the code tells you the custodial escrow
+            model is honest about what it is; it does not make it non-custodial. Treat the licence
+            as a transparency guarantee, not a recovery plan.
+          </p>
+        </div>
+
+        <p className="text-gray-300 mt-6">
+          The practical advice, which is against our interest to give and true anyway: keep working
+          balances small, withdraw Lightning to on-chain for anything you would miss, and use
+          multisig escrow for amounts where our continued existence is not something you want to
+          bet on.
+        </p>
+      </section>
+
+      {/* ── 3. Disputes ───────────────────────────────────────── */}
+      <section className="mb-14">
+        <h2 className="text-2xl font-bold mb-4 text-white">
+          3. When there is a dispute, who decides and on what evidence
+        </h2>
+
+        <p className="text-gray-300 mb-4">
+          Either the depositor or the beneficiary can open a dispute on a funded escrow. What
+          happens next depends on who was named arbiter when the escrow was created.
+        </p>
+
+        <ul className="list-disc list-inside text-gray-300 space-y-2 mb-6">
+          <li>
+            <strong className="text-white">If you named an arbiter</strong> — a third party you both
+            chose — that party decides, and CoinPay executes what they decide.
+          </li>
+          <li>
+            <strong className="text-white">If you did not name one, CoinPay decides.</strong> That is
+            the default, it applies to most escrows, and it means the company operating the escrow
+            is also refereeing it.
+          </li>
+        </ul>
+
+        <p className="text-gray-300 mb-4">
+          The evidence is whatever is attached to the escrow: the job description, milestones and
+          deliverables written into its metadata at creation, the stated reason for the dispute, and
+          the escrow&apos;s event log — every state change, timestamped, including the on-chain
+          deposit and any settlement attempts. We can see when money arrived and what the two of you
+          said the work was. We cannot see whether the work was actually good.
+        </p>
+
+        <p className="text-gray-300 mb-4">
+          Two limits we would rather state than have you discover:
+        </p>
+        <ul className="list-disc list-inside text-gray-300 space-y-2 mb-6">
+          <li>
+            <strong className="text-white">There is no published response time</strong> and no
+            formal evidence standard. A CoinPay-arbitrated dispute is a human reading the metadata
+            and making a judgement call.
+          </li>
+          <li>
+            <strong className="text-white">There is no appeal.</strong> When CoinPay is the arbiter,
+            CoinPay&apos;s decision is final and there is no external body to escalate to.
+          </li>
+        </ul>
+
+        <p className="text-gray-300 mb-4">
+          Two things do work in your favour. On a{' '}
+          <strong className="text-white">2-of-3 multisig escrow the arbiter cannot simply take the
+          money</strong> — they can only propose an outcome, which still needs a second signature
+          from the depositor or the beneficiary. And a funded escrow cannot sit forever: at expiry
+          it settles automatically. By default it{' '}
+          <strong className="text-white">refunds the depositor</strong>; if the escrow was created
+          with auto-release enabled, it pays the beneficiary instead. Either way the funds move
+          without anyone needing us to intervene.
+        </p>
+
+        <p className="text-gray-300">
+          If a dispute is significant enough that &ldquo;the company decides, with no appeal&rdquo;
+          is not an acceptable answer, name a mutually trusted arbiter at creation time and use the
+          multisig model. Those options exist precisely because our default answer to this question
+          is weaker than it should be.
+        </p>
+      </section>
+
+      {/* ── Footer links ──────────────────────────────────────── */}
+      <section className="border-t border-white/10 pt-8">
+        <p className="text-gray-400">
+          Related:{' '}
+          <Link href="/terms" className="text-purple-400 hover:text-purple-300">
+            Terms of Service
+          </Link>
+          {' · '}
+          <Link href="/docs" className="text-purple-400 hover:text-purple-300">
+            Documentation
+          </Link>
+          {' · '}
+          <a
+            href="https://github.com/profullstack/coinpayportal"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-purple-400 hover:text-purple-300"
+          >
+            Source code
+          </a>
+        </p>
+        <p className="text-gray-500 text-sm mt-3">
+          Found something on this page that does not match how CoinPay actually behaves? That is a
+          bug we want reported — open an issue against the repository.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/app/escrow/create/page.tsx
+++ b/src/app/escrow/create/page.tsx
@@ -863,6 +863,29 @@ export default function CreateEscrowPage() {
               <option value="custodial">Custodial (token-based release/refund)</option>
               <option value="multisig_2of3">2-of-3 Multisig (depositor + beneficiary + arbiter)</option>
             </select>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              {formData.escrow_model === 'multisig_2of3' ? (
+                <>
+                  Funds are locked on-chain and need <strong>2 of 3</strong> signatures to move.
+                  CoinPay holds one key, so we can&apos;t move your funds alone — and if CoinPay
+                  goes away, the depositor and beneficiary can settle without us.
+                </>
+              ) : (
+                <>
+                  Funds are held at an address <strong>CoinPay controls</strong> for the length of
+                  the escrow. You&apos;re trusting us to release correctly and to still be here at
+                  the end. For amounts where that isn&apos;t acceptable, choose 2-of-3 multisig.
+                </>
+              )}{' '}
+              <a
+                href="/custody"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-500 dark:text-blue-400 underline"
+              >
+                Who holds your money
+              </a>
+            </p>
           </div>
 
           {/* Chain */}

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -28,13 +28,66 @@ export default function HelpPage() {
               <h3 className="font-semibold mb-2 text-white">What are the fees?</h3>
               <p className="text-gray-300">
                 CoinPay charges a simple 0.5% platform fee. You receive 99.5% of each payment
-                directly to your wallet, minus blockchain network fees. Network fees vary by
+                to your wallet, minus blockchain network fees. Network fees vary by
                 blockchain (e.g., ~$0.00025 for Solana, ~$0.50-5 for Ethereum) and are outside our control.
               </p>
             </div>
           </div>
         </section>
-        
+
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-white">Custody &amp; Trust</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="font-semibold mb-2 text-white">Who holds my money right now?</h3>
+              <p className="text-gray-300">
+                It depends which product you&apos;re using, so we don&apos;t answer this with a
+                single word. Your web wallet keys are generated in your browser and never sent to
+                us. Incoming payments land at an address we control and are forwarded to your
+                wallet — usually well under a minute after confirmation, but we hold that key until
+                the forward completes. Default escrow is held by us for the whole escrow window.
+                Lightning balances sit on our node until you withdraw.{' '}
+                <a href="/custody" className="text-purple-600 hover:text-purple-700 font-medium">
+                  Full breakdown by product
+                </a>
+                .
+              </p>
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2 text-white">
+                What happens to my funds if CoinPay shuts down?
+              </h3>
+              <p className="text-gray-300">
+                Anything already in your own wallet is unaffected — we never had those keys, and
+                your web wallet seed lives in your browser (export it before you need it). A 2-of-3
+                multisig escrow can be settled by the depositor and beneficiary together without us
+                signing at all. But funds in default custodial escrow, in Lightning, or mid-forward
+                are held at addresses derived from our seed: there is no third-party backup and no
+                on-chain mechanism that releases them without us. Keep working balances small and
+                use multisig escrow for amounts you can&apos;t afford to have depend on us.
+              </p>
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2 text-white">
+                If there&apos;s a dispute, who decides and on what evidence?
+              </h3>
+              <p className="text-gray-300">
+                Either party can dispute a funded escrow. If you named an arbiter when creating it,
+                that party decides. If you didn&apos;t, <strong className="text-white">CoinPay
+                decides</strong> — the same company operating the escrow. The evidence is what&apos;s
+                attached to the escrow: the job description and deliverables in its metadata, the
+                stated dispute reason, and the timestamped event log. There&apos;s no published
+                response time and no appeal. On a multisig escrow the arbiter can only propose an
+                outcome — it still needs a second signature. A funded escrow also can&apos;t hang
+                forever: at expiry it auto-refunds the depositor, or auto-releases to the
+                beneficiary if that was enabled at creation.
+              </p>
+            </div>
+          </div>
+        </section>
+
         <section>
           <h2 className="text-2xl font-bold mb-4 text-white">Technical Support</h2>
           <p className="text-gray-300 mb-4">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,9 @@ import './globals.css';
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'https://coinpayportal.com'),
-  title: 'CoinPay - Non-Custodial Crypto Payment Gateway',
+  title: 'CoinPay - Crypto Payment Gateway, Escrow & Wallets',
   description: 'Accept cryptocurrency payments in your e-commerce store with automatic fee handling and real-time processing',
-  keywords: ['cryptocurrency', 'payment gateway', 'crypto payments', 'non-custodial', 'blockchain', 'bitcoin', 'ethereum'],
+  keywords: ['cryptocurrency', 'payment gateway', 'crypto payments', 'escrow', 'multisig', 'blockchain', 'bitcoin', 'ethereum'],
   authors: [{ name: 'CoinPay' }],
   creator: 'CoinPay',
   publisher: 'CoinPay',
@@ -73,7 +73,7 @@ const organizationJsonLd = {
   url: SITE_URL,
   logo: `${SITE_URL}/logo.png`,
   description:
-    'Non-custodial cryptocurrency payment gateway with multi-chain support, Lightning, and built-in escrow. Accept BTC, ETH, stablecoins; funds settle directly to merchant wallets.',
+    'Cryptocurrency payment gateway with multi-chain support, Lightning, escrow, and a non-custodial browser wallet. Accept BTC, ETH, and stablecoins; payments forward to merchant wallets after confirmation.',
   email: 'hello@coinpayportal.com',
   sameAs: [
     'https://github.com/profullstack/coinpay',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,8 +74,19 @@ export default function Home() {
             <p className="text-xl sm:text-2xl text-gray-300 mb-4 max-w-3xl mx-auto">
               Payments, Escrow &amp; Wallets for Humans and AI Agents
             </p>
-            <p className="text-lg text-gray-400 mb-12 max-w-2xl mx-auto">
-              Non-custodial crypto infrastructure — accept payments, hold funds in escrow, and manage wallets. API-first, no KYC, built for the agent economy.
+            <p className="text-lg text-gray-400 mb-8 max-w-2xl mx-auto">
+              Accept crypto payments, hold funds in escrow, and manage wallets. API-first, no KYC,
+              built for the agent economy.
+            </p>
+            <p className="text-base text-gray-400 mb-12 max-w-2xl mx-auto">
+              Wallet keys stay in your browser. Payments pass through an address we control for
+              about a minute before forwarding to you. Escrow and Lightning are opt-in, and we hold
+              those funds until they settle — unless you pick 2-of-3 multisig, where we can&apos;t
+              move them alone.{' '}
+              <Link href="/custody" className="text-purple-300 hover:text-purple-200 underline">
+                Who holds your money, product by product
+              </Link>
+              .
             </p>
           </div>
 
@@ -207,8 +218,9 @@ export default function Home() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                   </svg>
                 ),
-                title: 'Non-Custodial',
-                description: 'You control your private keys. Funds go directly to your wallet with no intermediaries.',
+                title: 'Clear About Custody',
+                description:
+                  'Web wallet keys never leave your browser. Payments sit at an address we control until forwarding completes. Escrow can be 2-of-3 multisig so we cannot move funds alone.',
               },
               {
                 icon: (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,6 +16,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/dashboard',
     '/terms',
     '/privacy',
+    '/custody',
     '/docs',
     '/about',
     '/contact',

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -15,8 +15,42 @@ export default function TermsPage() {
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-4 text-white">2. Service Description</h2>
           <p className="text-gray-300 mb-4">
-            CoinPay provides a non-custodial cryptocurrency payment gateway service. We facilitate 
-            the acceptance of cryptocurrency payments but do not hold, custody, or control your funds.
+            CoinPay provides a cryptocurrency payment gateway, escrow, and wallet service. Custody
+            differs by product, and we do not describe the service as non-custodial as a whole:
+          </p>
+          <ul className="list-disc list-inside text-gray-300 space-y-2 mb-4">
+            <li>
+              <strong className="text-white">Web wallet — non-custodial.</strong> Keys are generated
+              and held in your browser and are never transmitted to us.
+            </li>
+            <li>
+              <strong className="text-white">On-chain payments — custodial for a short window.</strong>{' '}
+              Payments are received at an address CoinPay derives and are then forwarded to your
+              wallet less applicable fees. CoinPay controls the key to that address until forwarding
+              completes.
+            </li>
+            <li>
+              <strong className="text-white">Escrow (default) — custodial.</strong> Funds are held at
+              a CoinPay-derived address for the duration of the escrow and are moved by CoinPay on
+              release, refund, expiry, or dispute resolution.
+            </li>
+            <li>
+              <strong className="text-white">Escrow (2-of-3 multisig) — non-custodial.</strong>{' '}
+              CoinPay holds one of three keys and cannot move funds unilaterally.
+            </li>
+            <li>
+              <strong className="text-white">Lightning wallet — custodial.</strong> See section 3.
+            </li>
+          </ul>
+          <p className="text-gray-300 mb-4">
+            Where CoinPay holds funds, it does so as a service provider and not as a bank, trustee,
+            or fiduciary. Such balances are not insured, not held in segregated trust accounts, and
+            not protected by any deposit guarantee scheme. A full plain-language breakdown — including
+            what happens to funds if CoinPay ceases operating and how disputes are decided — is at{' '}
+            <a href="/custody" className="text-purple-400 hover:text-purple-300">
+              coinpayportal.com/custody
+            </a>
+            .
           </p>
         </section>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -236,7 +236,12 @@ export default function Footer() {
                 </a>
               )}
               <p className="text-xs text-gray-400">
-                Non-custodial crypto payment gateway • 0.5% transaction fee
+                Crypto payments, escrow &amp; wallets • 0.5% transaction fee
+              </p>
+              <p className="text-xs text-gray-400">
+                <Link href="/custody" className="hover:text-gray-300 underline">
+                  Who holds your money
+                </Link>
               </p>
               <Link href="/escrow">
                 <img

--- a/src/lib/escrow/service.ts
+++ b/src/lib/escrow/service.ts
@@ -1,8 +1,15 @@
 /**
  * Escrow Service
  *
- * Anonymous, non-custodial escrow using platform HD wallet addresses.
+ * Anonymous CUSTODIAL escrow using platform HD wallet addresses.
  * Both humans and AI agents can create/fund/release/dispute escrows.
+ *
+ * Custody note: the escrow address is derived from the platform's own seed
+ * (`SYSTEM_MNEMONIC_*` via generatePaymentAddress), so for the whole escrow
+ * window CoinPay holds the key and could move the funds. That is custodial —
+ * this file used to call itself "non-custodial", which was wrong. The
+ * non-custodial path is `src/lib/multisig/engine.ts` (2-of-3, CoinPay holds
+ * one key). Keep `/custody` and `docs/ESCROW.md` in sync with any change here.
  *
  * Flow:
  * 1. Create escrow → generates HD wallet address for deposit


### PR DESCRIPTION
## Why

"Non-custodial" was used as a blanket claim across the site while the **default escrow model holds funds at a platform-derived address**. That tension is the first thing anyone evaluating a payment product pokes at, and the fuzzy version costs exactly the readers who read carefully.

CoinPay has four different custody profiles. This PR says which is which.

## Ground truth (verified against the code, not assumed)

| Surface | Who can move funds | Custody |
|---|---|---|
| Web wallet | User's browser only | Non-custodial |
| **On-chain payments** | Platform HD address → forwarded | **Custodial, brief window** |
| Escrow — `custodial` (**default**) | CoinPay, whole window | **Custodial** |
| Escrow — `multisig_2of3` | Any 2 of 3; CoinPay holds 1 | Non-custodial |
| Lightning | CoinPay's node | **Custodial until withdrawal** |

The payment row is the important one: `createPayment` always calls `generatePaymentAddress` (`src/lib/payments/service.ts:221`), deriving from `SYSTEM_MNEMONIC_*`, then forwards to the merchant. **There is no direct-to-merchant mode.** So "funds go directly to your wallet with no intermediaries" was inaccurate for the core product, independent of escrow. Escrow and Lightning are opt-in; the forwarding window is not.

## What changed

**New `/custody` page** answering the three questions people actually have, in plain words:
1. Who holds the money right now — per-product table
2. What happens if CoinPay disappears tomorrow — split into "fine without us" vs "depending on us"
3. When there's a dispute, who decides and on what evidence

It states the weak answers rather than hiding them: CoinPay is the **default arbiter**, there is **no published response time and no appeal**, and custodial balances have **no third-party recovery**. It also notes that MIT licensing is a transparency guarantee, not a recovery plan.

**`/terms`** — removed the legal representation that we "do not hold, custody, or control your funds," replaced with a per-product custody breakdown plus an explicit not-a-bank/not-insured/not-segregated statement. Terms already disclosed Lightning custody honestly; escrow now gets the same treatment.

**`public/skill.md`** — added a custody table. Agents act on this file programmatically. Its "keys never touch our servers" line was true of the web-wallet API it documents, but the frontmatter generalized it to escrow.

**Escrow creation form** — shows the custody consequence at the point of choice, not just the words "Custodial" / "2-of-3 Multisig."

**README** — had "Non-custodial: no intermediaries" directly above "deducted during forwarding." Forwarding *is* the intermediary.

Also: landing hero + feature card, About, Footer, blog CTA, page metadata, help FAQ, sitemap, and the self-contradictory `docs/ESCROW.md` ("non-custodial-style" escrow at platform addresses) and `src/lib/escrow/service.ts` header comment.

## Deliberately not changed

The custodial escrow **default** is untouched — flipping it to multisig is a product decision with migration consequences, not a copy fix. It's the one change that would let you make a materially stronger claim.

## Verification

- `tsc --noEmit` clean
- `eslint` 0 errors (2 pre-existing warnings untouched)
- 272 tests pass across escrow, payments, and escrow UI
- Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)