### PR TITLE
fix(home): drop the custody line from the hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,18 +74,10 @@ export default function Home() {
             <p className="text-xl sm:text-2xl text-gray-300 mb-4 max-w-3xl mx-auto">
               Payments, Escrow &amp; Wallets for Humans and AI Agents
             </p>
-            <p className="text-lg text-gray-400 mb-6 max-w-2xl mx-auto">
+            {/* Custody is disclosed per product on /custody, linked from the
+                footer, Terms, and the help FAQ — not from the hero. */}
+            <p className="text-lg text-gray-400 mb-10 max-w-2xl mx-auto">
               Get paid in crypto. Escrow, wallets, and one API — no KYC.
-            </p>
-            {/* Custody in one line, not a paragraph. The detail belongs on
-                /custody; the hero only owes a visitor an honest summary and a
-                door to walk through. */}
-            <p className="text-sm text-gray-500 mb-10 max-w-2xl mx-auto">
-              Non-custodial wallet, custodial escrow —{' '}
-              <Link href="/custody" className="text-purple-400 hover:text-purple-300 underline">
-                we say exactly which is which
-              </Link>
-              .
             </p>
           </div>
 


### PR DESCRIPTION
Removes one line from the hero.

**Before:**
> Payments, Escrow & Wallets for Humans and AI Agents
> Get paid in crypto. Escrow, wallets, and one API — no KYC.
> ~~Non-custodial wallet, custodial escrow — we say exactly which is which~~

**After:**
> Payments, Escrow & Wallets for Humans and AI Agents
> Get paid in crypto. Escrow, wallets, and one API — no KYC.

That line was accurate, but it put the weakest fact about the product in its most valuable space. That was a positioning decision I made on the way past rather than one anyone asked for.

## What is *not* changed

Custody disclosure is exactly as thorough as it was. `/custody` is untouched and still linked from the **footer, Terms, the help FAQ, and About** (5 links). The hero just stops leading with it.

Also kept from #234:
- the `▶ Try the live demo` hero CTA
- the corrected stat strip

That stat replaced **"Funds never touch us / Non-custodial"**, which was *false* rather than merely awkward — every payment lands at a CoinPay-derived address before forwarding. That one isn't a matter of taste, so it stays fixed.

Verified: `tsc` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)