### PR TITLE
fix(escrow): authorize recurring series access

### DIFF
--- a/src/app/api/escrow/series/[id]/route.test.ts
+++ b/src/app/api/escrow/series/[id]/route.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockSupabase = vi.hoisted(() => ({ from: vi.fn() }));
+const mockAuthResult = vi.hoisted(() => ({
+  current: { success: true, context: { type: 'merchant', merchantId: 'merch_1' } } as any,
+}));
+const mockAuthorizeBusiness = vi.hoisted(() => vi.fn());
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn().mockReturnValue(mockSupabase),
+}));
+
+vi.mock('@/lib/auth/middleware', () => ({
+  authenticateRequest: vi.fn().mockImplementation(() => Promise.resolve(mockAuthResult.current)),
+  isMerchantAuth: vi.fn().mockImplementation((context: any) => context?.type === 'merchant'),
+}));
+
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: mockAuthorizeBusiness,
+}));
+
+import { DELETE, GET, PATCH } from './route';
+
+const params = { params: Promise.resolve({ id: 'series_1' }) };
+
+function makeSelectResult(series: any) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: series, error: null }),
+      }),
+    }),
+  };
+}
+
+function makeUpdateResult(data: any) {
+  return {
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+function setupSeriesQueries() {
+  const series = { id: 'series_1', merchant_id: 'biz_1', status: 'active' };
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'escrow_series') return makeSelectResult(series);
+    if (table === 'escrows') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  });
+  return series;
+}
+
+describe('/api/escrow/series/[id] authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockAuthResult.current = {
+      success: true,
+      context: { type: 'merchant', merchantId: 'merch_1' },
+    };
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'owner' });
+  });
+
+  it('authorizes reads against the series business', async () => {
+    const series = setupSeriesQueries();
+    const request = new NextRequest('http://localhost/api/escrow/series/series_1', {
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const response = await GET(request, params);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).series).toEqual(series);
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      mockSupabase,
+      'merch_1',
+      'biz_1',
+      'business.read',
+    );
+  });
+
+  it('does not expose another business series', async () => {
+    setupSeriesQueries();
+    mockAuthorizeBusiness.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Business not found',
+    });
+    const request = new NextRequest('http://localhost/api/escrow/series/series_1', {
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const response = await GET(request, params);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Business not found' });
+  });
+
+  it.each([
+    ['PATCH', PATCH],
+    ['DELETE', DELETE],
+  ])('blocks %s before mutating another business series', async (method, handler) => {
+    const series = { id: 'series_1', merchant_id: 'other_business', status: 'active' };
+    const table = makeSelectResult(series);
+    const update = vi.fn();
+    (table as any).update = update;
+    mockSupabase.from.mockReturnValue(table);
+    mockAuthorizeBusiness.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Business not found',
+    });
+    const request = new NextRequest('http://localhost/api/escrow/series/series_1', {
+      method,
+      headers: { authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: method === 'PATCH' ? JSON.stringify({ status: 'cancelled' }) : undefined,
+    });
+
+    const response = await handler(request, params);
+
+    expect(response.status).toBe(404);
+    expect(update).not.toHaveBeenCalled();
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      mockSupabase,
+      'merch_1',
+      'other_business',
+      'invoice.write',
+    );
+  });
+
+  it('updates an authorized series', async () => {
+    const series = { id: 'series_1', merchant_id: 'biz_1', status: 'active' };
+    const updated = { ...series, status: 'paused' };
+    let call = 0;
+    mockSupabase.from.mockImplementation(() => {
+      call += 1;
+      return call === 1 ? makeSelectResult(series) : makeUpdateResult(updated);
+    });
+    const request = new NextRequest('http://localhost/api/escrow/series/series_1', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'paused' }),
+    });
+
+    const response = await PATCH(request, params);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(updated);
+  });
+});

--- a/src/app/api/escrow/series/[id]/route.ts
+++ b/src/app/api/escrow/series/[id]/route.ts
@@ -7,12 +7,47 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authenticateRequest, isMerchantAuth } from '@/lib/auth/middleware';
+import { authorizeBusiness } from '@/lib/auth/authz';
+import type { Capability } from '@/lib/auth/permissions';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) throw new Error('Supabase not configured');
   return createClient(url, key);
+}
+
+async function loadAuthorizedSeries(
+  supabase: ReturnType<typeof getSupabase>,
+  id: string,
+  merchantId: string,
+  capability: Capability
+) {
+  const { data: series, error } = await supabase
+    .from('escrow_series')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error || !series) {
+    return {
+      response: NextResponse.json({ error: 'Series not found' }, { status: 404 }),
+    };
+  }
+
+  const authz = await authorizeBusiness(
+    supabase,
+    merchantId,
+    series.merchant_id,
+    capability
+  );
+  if (!authz.ok) {
+    return {
+      response: NextResponse.json({ error: authz.error }, { status: authz.status }),
+    };
+  }
+
+  return { series };
 }
 
 export async function GET(
@@ -30,15 +65,14 @@ export async function GET(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { data: series, error } = await supabase
-      .from('escrow_series')
-      .select('*')
-      .eq('id', id)
-      .single();
-
-    if (error || !series) {
-      return NextResponse.json({ error: 'Series not found' }, { status: 404 });
-    }
+    const authorized = await loadAuthorizedSeries(
+      supabase,
+      id,
+      authResult.context.merchantId,
+      'business.read'
+    );
+    if ('response' in authorized) return authorized.response;
+    const { series } = authorized;
 
     // Fetch linked crypto escrows
     const { data: cryptoEscrows } = await supabase
@@ -72,6 +106,14 @@ export async function PATCH(
     if (!authResult.success || !authResult.context || !isMerchantAuth(authResult.context)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const authorized = await loadAuthorizedSeries(
+      supabase,
+      id,
+      authResult.context.merchantId,
+      'invoice.write'
+    );
+    if ('response' in authorized) return authorized.response;
 
     const updates: Record<string, any> = { updated_at: new Date().toISOString() };
 
@@ -122,6 +164,14 @@ export async function DELETE(
     if (!authResult.success || !authResult.context || !isMerchantAuth(authResult.context)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const authorized = await loadAuthorizedSeries(
+      supabase,
+      id,
+      authResult.context.merchantId,
+      'invoice.write'
+    );
+    if ('response' in authorized) return authorized.response;
 
     const { data, error } = await supabase
       .from('escrow_series')

--- a/src/app/api/escrow/series/route.test.ts
+++ b/src/app/api/escrow/series/route.test.ts
@@ -12,6 +12,9 @@ const mockAuthResult = vi.hoisted(() => ({
   current: { success: true, context: { type: 'merchant', merchantId: 'merch_1' } } as any,
 }));
 
+const mockAuthorizeBusiness = vi.hoisted(() => vi.fn());
+const mockListAccessibleBusinessIds = vi.hoisted(() => vi.fn());
+
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn().mockReturnValue(mockSupabase),
 }));
@@ -19,6 +22,11 @@ vi.mock('@supabase/supabase-js', () => ({
 vi.mock('@/lib/auth/middleware', () => ({
   authenticateRequest: vi.fn().mockImplementation(() => Promise.resolve(mockAuthResult.current)),
   isMerchantAuth: vi.fn().mockImplementation((ctx: any) => ctx?.type === 'merchant'),
+}));
+
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: mockAuthorizeBusiness,
+  listAccessibleBusinessIds: mockListAccessibleBusinessIds,
 }));
 
 // Mock createEscrow + isBusinessPaidTier (used in POST)
@@ -57,7 +65,9 @@ function setupSelectChained(data: any[] = [], error: any = null) {
     };
     return q;
   };
-  mockSupabase.from.mockReturnValue(makeQuery(data, error));
+  const query = makeQuery(data, error);
+  mockSupabase.from.mockReturnValue(query);
+  return query;
 }
 
 describe('POST /api/escrow/series', () => {
@@ -66,6 +76,8 @@ describe('POST /api/escrow/series', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
     mockAuthResult.current = { success: true, context: { type: 'merchant', merchantId: 'merch_1' } };
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'owner' });
+    mockListAccessibleBusinessIds.mockResolvedValue(['biz_1']);
     setupInsert();
   });
 
@@ -120,6 +132,25 @@ describe('POST /api/escrow/series', () => {
     expect(res.status).toBe(401);
   });
 
+  it('returns 404 when the merchant cannot access the business', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Business not found',
+    });
+
+    const res = await POST(makeReq(validBody));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Business not found' });
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      mockSupabase,
+      'merch_1',
+      'biz_1',
+      'invoice.write',
+    );
+  });
+
   it('returns 201 with series data on success', async () => {
     const seriesData = { id: 'series_1', amount: 100, coin: 'BTC', interval: 'monthly', status: 'active' };
     setupInsert(seriesData);
@@ -137,28 +168,12 @@ describe('GET /api/escrow/series', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
     mockAuthResult.current = { success: true, context: { type: 'merchant', merchantId: 'merch_1' } };
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'owner' });
+    mockListAccessibleBusinessIds.mockResolvedValue(['biz_1']);
   });
 
   it('returns series scoped to merchant businesses when no business_id', async () => {
-    mockSupabase.from.mockImplementation((table: string) => {
-      if (table === 'businesses') {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: [{ id: 'biz_1' }], error: null }),
-          }),
-        };
-      }
-      // escrow_series — needs thenable query object
-      const q: any = {};
-      q.select = vi.fn().mockReturnValue(q);
-      q.eq = vi.fn().mockReturnValue(q);
-      q.in = vi.fn().mockReturnValue(q);
-      q.order = vi.fn().mockReturnValue(q);
-      q.then = (resolve: any, reject?: any) => {
-        return Promise.resolve({ data: [{ id: 's1' }], error: null }).then(resolve, reject);
-      };
-      return q;
-    });
+    const query = setupSelectChained([{ id: 's1' }]);
 
     const req = new NextRequest('http://localhost:3000/api/escrow/series', {
       headers: { authorization: 'Bearer test' },
@@ -167,6 +182,8 @@ describe('GET /api/escrow/series', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.series).toEqual([{ id: 's1' }]);
+    expect(mockListAccessibleBusinessIds).toHaveBeenCalledWith(mockSupabase, 'merch_1');
+    expect(query.in).toHaveBeenCalledWith('merchant_id', ['biz_1']);
   });
 
   it('returns series list filtered by business_id', async () => {
@@ -178,5 +195,41 @@ describe('GET /api/escrow/series', () => {
     const res = await GET(req);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ series: seriesList });
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      mockSupabase,
+      'merch_1',
+      'biz_1',
+      'business.read',
+    );
+  });
+
+  it('returns 404 instead of listing another business series', async () => {
+    mockAuthorizeBusiness.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Business not found',
+    });
+    setupSelectChained([{ id: 'other-series' }]);
+    const req = new NextRequest('http://localhost:3000/api/escrow/series?business_id=other', {
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Business not found' });
+  });
+
+  it('returns an empty list when the merchant has no accessible businesses', async () => {
+    mockListAccessibleBusinessIds.mockResolvedValue([]);
+    setupSelectChained([{ id: 'should-not-leak' }]);
+    const req = new NextRequest('http://localhost:3000/api/escrow/series', {
+      headers: { authorization: 'Bearer test' },
+    });
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ series: [] });
   });
 });

--- a/src/app/api/escrow/series/route.ts
+++ b/src/app/api/escrow/series/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authenticateRequest, isMerchantAuth } from '@/lib/auth/middleware';
+import { authorizeBusiness, listAccessibleBusinessIds } from '@/lib/auth/authz';
 import { createEscrow } from '@/lib/escrow';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
 
@@ -64,6 +65,16 @@ export async function POST(request: NextRequest) {
     const authResult = await authenticateRequest(supabase, authHeader || apiKeyHeader);
     if (!authResult.success || !authResult.context || !isMerchantAuth(authResult.context)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const authz = await authorizeBusiness(
+      supabase,
+      authResult.context.merchantId,
+      business_id,
+      'invoice.write'
+    );
+    if (!authz.ok) {
+      return NextResponse.json({ error: authz.error }, { status: authz.status });
     }
 
     // Calculate next charge based on interval
@@ -175,19 +186,25 @@ export async function GET(request: NextRequest) {
     // If business_id specified (and not 'all'), filter by it
     // Otherwise list all series for the merchant's businesses
     if (businessId && businessId !== 'all') {
+      const authz = await authorizeBusiness(
+        supabase,
+        authResult.context.merchantId,
+        businessId,
+        'business.read'
+      );
+      if (!authz.ok) {
+        return NextResponse.json({ error: authz.error }, { status: authz.status });
+      }
       query = query.eq('merchant_id', businessId);
     } else {
-      // Get all businesses for this merchant
-      const merchantId = (authResult.context as any).merchantId;
-      if (merchantId) {
-        const { data: businesses } = await supabase
-          .from('businesses')
-          .select('id')
-          .eq('merchant_id', merchantId);
-        if (businesses && businesses.length > 0) {
-          query = query.in('merchant_id', businesses.map((b: { id: string }) => b.id));
-        }
+      const businessIds = await listAccessibleBusinessIds(
+        supabase,
+        authResult.context.merchantId
+      );
+      if (businessIds.length === 0) {
+        return NextResponse.json({ series: [] });
       }
+      query = query.in('merchant_id', businessIds);
     }
 
     const status = searchParams.get('status');


### PR DESCRIPTION
## Summary

- authorize recurring escrow series creation and filtered lists against the requested business
- scope unfiltered lists to every business accessible through owner, business-member, or organization-member access
- authorize detail reads and block updates or cancellation before mutating an inaccessible series
- add regression coverage for collection and per-series authorization

Closes #236

## Testing

- `vitest run src/app/api/escrow/series/route.test.ts src/app/api/escrow/series/[id]/route.test.ts` — 17 passed
- `tsc --noEmit`
- targeted ESLint on the four changed files
- `git diff --check`
