### PR TITLE
fix(clients): authorize team detail access

### DIFF
--- a/src/app/api/clients/[id]/route.test.ts
+++ b/src/app/api/clients/[id]/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockFrom = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const mockVerifyToken = vi.fn();
+vi.mock('@/lib/auth/jwt', () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+}));
+
+const mockAuthorizeBusiness = vi.fn();
+vi.mock('@/lib/auth/authz', () => ({
+  authorizeBusiness: (...args: unknown[]) => mockAuthorizeBusiness(...args),
+}));
+
+vi.mock('@/lib/secrets', () => ({
+  getJwtSecret: vi.fn(() => 'test-secret'),
+}));
+
+import { DELETE, GET, PUT } from './route';
+
+const params = { params: Promise.resolve({ id: 'client-1' }) };
+
+function request(method: string, body?: unknown) {
+  return new NextRequest('http://localhost/api/clients/client-1', {
+    method,
+    headers: {
+      authorization: 'Bearer test-token',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function clientLookup(client: Record<string, unknown>) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: client, error: null }),
+      }),
+    }),
+  };
+}
+
+describe('/api/clients/[id] team access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockVerifyToken.mockReturnValue({ userId: 'team-member-1' });
+    mockAuthorizeBusiness.mockResolvedValue({ ok: true, role: 'writer' });
+  });
+
+  it('lets an authorized team member read a client owned by the business owner', async () => {
+    const client = {
+      id: 'client-1',
+      business_id: 'business-1',
+      user_id: 'business-owner-1',
+      email: 'client@example.com',
+    };
+    mockFrom.mockReturnValue(clientLookup(client));
+
+    const response = await GET(request('GET'), params);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true, client });
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      expect.anything(),
+      'team-member-1',
+      'business-1',
+      'business.read'
+    );
+  });
+
+  it('lets a writer update a client after business authorization', async () => {
+    const existingClient = { id: 'client-1', business_id: 'business-1' };
+    const updatedClient = { ...existingClient, name: 'Updated Client' };
+    const updateSingle = vi.fn().mockResolvedValue({ data: updatedClient, error: null });
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateBusinessEq = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateIdEq = vi.fn().mockReturnValue({ eq: updateBusinessEq });
+    const table = {
+      ...clientLookup(existingClient),
+      update: vi.fn().mockReturnValue({ eq: updateIdEq }),
+    };
+    mockFrom.mockReturnValue(table);
+
+    const response = await PUT(request('PUT', { name: 'Updated Client' }), params);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true, client: updatedClient });
+    expect(mockAuthorizeBusiness).toHaveBeenCalledWith(
+      expect.anything(),
+      'team-member-1',
+      'business-1',
+      'customer.write'
+    );
+    expect(updateBusinessEq).toHaveBeenCalledWith('business_id', 'business-1');
+  });
+
+  it('blocks a readonly member from deleting a client', async () => {
+    const deleteTable = {
+      ...clientLookup({ id: 'client-1', business_id: 'business-1' }),
+      delete: vi.fn(),
+    };
+    mockFrom.mockReturnValue(deleteTable);
+    mockAuthorizeBusiness.mockResolvedValue({
+      ok: false,
+      status: 403,
+      error: 'Insufficient permissions',
+    });
+
+    const response = await DELETE(request('DELETE'), params);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'Insufficient permissions',
+    });
+    expect(deleteTable.delete).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 instead of 500 for an invalid token', async () => {
+    mockVerifyToken.mockImplementation(() => {
+      throw new Error('invalid token');
+    });
+
+    const response = await GET(request('GET'), params);
+
+    expect(response.status).toBe(401);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/clients/[id]/route.ts
+++ b/src/app/api/clients/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
+import { authorizeBusiness, type AuthzResult } from '@/lib/auth/authz';
 import { getJwtSecret } from '@/lib/secrets';
 
 function getAuth(request: NextRequest) {
@@ -9,7 +10,22 @@ function getAuth(request: NextRequest) {
   const token = authHeader.substring(7);
   const jwtSecret = getJwtSecret();
   if (!jwtSecret) return null;
-  return verifyToken(token, jwtSecret);
+  try {
+    return verifyToken(token, jwtSecret);
+  } catch {
+    return null;
+  }
+}
+
+function clientAuthzError(authz: AuthzResult) {
+  if (authz.ok) return null;
+  return NextResponse.json(
+    {
+      success: false,
+      error: authz.status === 404 ? 'Client not found' : authz.error,
+    },
+    { status: authz.status }
+  );
 }
 
 /**
@@ -29,15 +45,18 @@ export async function GET(
       .from('clients')
       .select('*')
       .eq('id', id)
-      .eq('user_id', decoded.userId)
       .single();
 
     if (error || !client) {
       return NextResponse.json({ success: false, error: 'Client not found' }, { status: 404 });
     }
 
+    const authz = await authorizeBusiness(supabase, decoded.userId, client.business_id, 'business.read');
+    const authzError = clientAuthzError(authz);
+    if (authzError) return authzError;
+
     return NextResponse.json({ success: true, client });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -55,6 +74,25 @@ export async function PUT(
     if (!decoded) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const { data: existingClient, error: lookupError } = await supabase
+      .from('clients')
+      .select('id, business_id')
+      .eq('id', id)
+      .single();
+
+    if (lookupError || !existingClient) {
+      return NextResponse.json({ success: false, error: 'Client not found' }, { status: 404 });
+    }
+
+    const authz = await authorizeBusiness(
+      supabase,
+      decoded.userId,
+      existingClient.business_id,
+      'customer.write'
+    );
+    const authzError = clientAuthzError(authz);
+    if (authzError) return authzError;
+
     const body = await request.json();
     const { name, email, phone, address, website, company_name } = body;
 
@@ -62,7 +100,7 @@ export async function PUT(
       .from('clients')
       .update({ name, email, phone, address, website, company_name, updated_at: new Date().toISOString() })
       .eq('id', id)
-      .eq('user_id', decoded.userId)
+      .eq('business_id', existingClient.business_id)
       .select()
       .single();
 
@@ -71,7 +109,7 @@ export async function PUT(
     }
 
     return NextResponse.json({ success: true, client });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -89,18 +127,37 @@ export async function DELETE(
     if (!decoded) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const { data: existingClient, error: lookupError } = await supabase
+      .from('clients')
+      .select('id, business_id')
+      .eq('id', id)
+      .single();
+
+    if (lookupError || !existingClient) {
+      return NextResponse.json({ success: false, error: 'Client not found' }, { status: 404 });
+    }
+
+    const authz = await authorizeBusiness(
+      supabase,
+      decoded.userId,
+      existingClient.business_id,
+      'customer.write'
+    );
+    const authzError = clientAuthzError(authz);
+    if (authzError) return authzError;
+
     const { error } = await supabase
       .from('clients')
       .delete()
       .eq('id', id)
-      .eq('user_id', decoded.userId);
+      .eq('business_id', existingClient.business_id);
 
     if (error) {
       return NextResponse.json({ success: false, error: 'Failed to delete client' }, { status: 500 });
     }
 
     return NextResponse.json({ success: true });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- authorize client detail reads through the client's business with `business.read`
- authorize updates and deletes with `customer.write`
- keep mutations scoped to the authorized business and return 401 for invalid JWTs
- add focused regression coverage for team reads, writer updates, readonly deletes, and invalid tokens

Closes #238

## Testing
- `vitest run src/app/api/clients/[id]/route.test.ts` — 4 passed
- `tsc --noEmit`
- targeted ESLint on the changed route and test
- `git diff --check`