### PR TITLE
fix(swap): authorize deposit hash updates

### DIFF
--- a/src/app/api/swap/[id]/deposit/route.test.ts
+++ b/src/app/api/swap/[id]/deposit/route.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => {
+  const single = vi.fn();
+  const selectWalletEq = vi.fn(() => ({ single }));
+  const selectIdEq = vi.fn(() => ({ eq: selectWalletEq }));
+  const select = vi.fn(() => ({ eq: selectIdEq }));
+  const updateWalletEq = vi.fn();
+  const updateIdEq = vi.fn(() => ({ eq: updateWalletEq }));
+  const update = vi.fn(() => ({ eq: updateIdEq }));
+  const from = vi.fn(() => ({ select, update }));
+  const authenticate = vi.fn();
+
+  return {
+    single,
+    selectWalletEq,
+    selectIdEq,
+    select,
+    updateWalletEq,
+    updateIdEq,
+    update,
+    from,
+    authenticate,
+  };
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mocks.from })),
+}));
+
+vi.mock('@/lib/web-wallet/auth', () => ({
+  authenticateWalletRequest: (...args: unknown[]) => mocks.authenticate(...args),
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/swap/swap-123/deposit', {
+    method: 'POST',
+    headers: {
+      authorization: 'Wallet wallet-123:signature:1234567890:nonce',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/swap/[id]/deposit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.single.mockResolvedValue({
+      data: { provider_data: { depositCoin: 'btc' } },
+      error: null,
+    });
+    mocks.authenticate.mockResolvedValue({ success: true, walletId: 'wallet-123' });
+    mocks.updateWalletEq.mockResolvedValue({ error: null });
+  });
+
+  it('authenticates the request against the swap owner and scopes the update', async () => {
+    const request = makeRequest({ txHash: 'tx-123' });
+    const response = await POST(request, { params: Promise.resolve({ id: 'swap-123' }) });
+
+    expect(response.status).toBe(200);
+    expect(mocks.authenticate).toHaveBeenCalledWith(
+      expect.anything(),
+      request.headers.get('authorization'),
+      'POST',
+      '/api/swap/swap-123/deposit',
+      JSON.stringify({ txHash: 'tx-123' })
+    );
+    expect(mocks.selectIdEq).toHaveBeenCalledWith('id', 'swap-123');
+    expect(mocks.selectWalletEq).toHaveBeenCalledWith('wallet_id', 'wallet-123');
+    expect(mocks.update).toHaveBeenCalledWith({
+      provider_data: { depositCoin: 'btc', deposit_tx_hash: 'tx-123' },
+    });
+    expect(mocks.updateIdEq).toHaveBeenCalledWith('id', 'swap-123');
+    expect(mocks.updateWalletEq).toHaveBeenCalledWith('wallet_id', 'wallet-123');
+  });
+
+  it('rejects unauthenticated requests without reading or updating the swap', async () => {
+    mocks.authenticate.mockResolvedValue({ success: false, error: 'Invalid signature' });
+
+    const response = await POST(makeRequest({ txHash: 'tx-123' }), {
+      params: Promise.resolve({ id: 'swap-123' }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the swap does not exist', async () => {
+    mocks.single.mockResolvedValue({ data: null, error: { message: 'not found' } });
+
+    const response = await POST(makeRequest({ txHash: 'tx-123' }), {
+      params: Promise.resolve({ id: 'missing' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(mocks.authenticate).toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing transaction hash before authentication', async () => {
+    const response = await POST(makeRequest({}), {
+      params: Promise.resolve({ id: 'swap-123' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing swap ID before authentication', async () => {
+    const response = await POST(makeRequest({ txHash: 'tx-123' }), {
+      params: Promise.resolve({ id: '' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.authenticate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/swap/[id]/deposit/route.ts
+++ b/src/app/api/swap/[id]/deposit/route.ts
@@ -5,6 +5,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateWalletRequest } from '@/lib/web-wallet/auth';
+import { WalletErrors } from '@/lib/web-wallet/response';
 
 function getSupabase() {
   return createClient(
@@ -20,7 +22,8 @@ export async function POST(
   const supabase = getSupabase();
   try {
     const { id } = await params;
-    const body = await request.json();
+    const rawBody = await request.text();
+    const body = JSON.parse(rawBody);
     const { txHash } = body;
 
     if (!id || !txHash) {
@@ -30,12 +33,31 @@ export async function POST(
       );
     }
 
+    const auth = await authenticateWalletRequest(
+      supabase,
+      request.headers.get('authorization'),
+      request.method,
+      request.nextUrl.pathname,
+      rawBody
+    );
+    if (!auth.success || !auth.walletId) {
+      return WalletErrors.unauthorized(auth.error);
+    }
+
     // Get current provider_data
-    const { data: swap } = await supabase
+    const { data: swap, error: lookupError } = await supabase
       .from('swaps')
       .select('provider_data')
       .eq('id', id)
+      .eq('wallet_id', auth.walletId)
       .single();
+
+    if (lookupError || !swap) {
+      return NextResponse.json(
+        { error: 'Swap not found' },
+        { status: 404 }
+      );
+    }
 
     // Update provider_data with the tx hash
     const newProviderData = { ...(swap?.provider_data || {}), deposit_tx_hash: txHash };
@@ -43,7 +65,8 @@ export async function POST(
     const { error } = await supabase
       .from('swaps')
       .update({ provider_data: newProviderData })
-      .eq('id', id);
+      .eq('id', id)
+      .eq('wallet_id', auth.walletId);
 
     if (error) {
       console.error(`[Swap Deposit] DB update failed for ${id}:`, error);

--- a/src/app/api/swap/swap-routes.test.ts
+++ b/src/app/api/swap/swap-routes.test.ts
@@ -4,7 +4,6 @@ import { GET as getQuote } from './quote/route';
 import { POST as createSwap } from './create/route';
 import { GET as getStatus } from './[id]/route';
 import { GET as getCoins } from './coins/route';
-import { POST as saveDeposit } from './[id]/deposit/route';
 
 // Mock Supabase
 vi.mock('@supabase/supabase-js', () => ({
@@ -304,47 +303,6 @@ describe('Swap API Routes', () => {
       const btc = data.coins.find((c: { symbol: string }) => c.symbol === 'BTC');
       expect(btc).toBeDefined();
       expect(btc.ticker).toBe('btc');
-    });
-  });
-
-  describe('POST /api/swap/[id]/deposit', () => {
-    it('should save deposit tx hash', async () => {
-      const request = new NextRequest('http://localhost/api/swap/test123/deposit', {
-        method: 'POST',
-        body: JSON.stringify({ txHash: '0xabc123def456' }),
-      });
-
-      const response = await saveDeposit(request, { params: Promise.resolve({ id: 'test123' }) });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.success).toBe(true);
-    });
-
-    it('should reject missing swap ID', async () => {
-      const request = new NextRequest('http://localhost/api/swap//deposit', {
-        method: 'POST',
-        body: JSON.stringify({ txHash: '0xabc123def456' }),
-      });
-
-      const response = await saveDeposit(request, { params: Promise.resolve({ id: '' }) });
-      const data = await response.json();
-
-      expect(response.status).toBe(400);
-      expect(data.error).toBe('Missing swap ID or transaction hash');
-    });
-
-    it('should reject missing tx hash', async () => {
-      const request = new NextRequest('http://localhost/api/swap/test123/deposit', {
-        method: 'POST',
-        body: JSON.stringify({}),
-      });
-
-      const response = await saveDeposit(request, { params: Promise.resolve({ id: 'test123' }) });
-      const data = await response.json();
-
-      expect(response.status).toBe(400);
-      expect(data.error).toBe('Missing swap ID or transaction hash');
     });
   });
 });

--- a/src/components/web-wallet/SwapForm.tsx
+++ b/src/components/web-wallet/SwapForm.tsx
@@ -254,11 +254,8 @@ export function SwapForm({ walletId, addresses, balances, displayCurrency = 'USD
       }
       
       // Save the tx hash to the database
-      fetch(`/api/swap/${createdSwap.id}/deposit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ txHash: result.txHash }),
-      }).catch(err => console.error('Failed to save deposit tx hash:', err));
+      wallet.saveSwapDeposit(createdSwap.id, result.txHash)
+        .catch(err => console.error('Failed to save deposit tx hash:', err));
       
       setDepositTxHash(result.txHash);
       setPassword('');

--- a/src/lib/wallet-sdk/swap.test.ts
+++ b/src/lib/wallet-sdk/swap.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSwapMethods } from './swap';
+import type { WalletAPIClient } from './client';
+
+describe('wallet SDK swap methods', () => {
+  it('saves a deposit hash with wallet authentication', async () => {
+    const request = vi.fn().mockResolvedValue(undefined);
+    const methods = createSwapMethods({ request } as unknown as WalletAPIClient, 'wallet-123');
+
+    await methods.saveSwapDeposit('swap-123', 'tx-123');
+
+    expect(request).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/api/swap/swap-123/deposit',
+      body: { txHash: 'tx-123' },
+      authenticated: true,
+    });
+  });
+});

--- a/src/lib/wallet-sdk/swap.ts
+++ b/src/lib/wallet-sdk/swap.ts
@@ -83,6 +83,15 @@ export function createSwapMethods(client: WalletAPIClient, walletId: string) {
       return (data.swaps || []).map(mapSwap);
     },
 
+    async saveSwapDeposit(swapId: string, txHash: string): Promise<void> {
+      await client.request<void>({
+        method: 'POST',
+        path: `/api/swap/${swapId}/deposit`,
+        body: { txHash },
+        authenticated: true,
+      });
+    },
+
     async getSwapCoins(): Promise<SwapCoin[]> {
       const data = await client.request<any>({
         method: 'GET',

--- a/src/lib/wallet-sdk/wallet.ts
+++ b/src/lib/wallet-sdk/wallet.ts
@@ -728,6 +728,7 @@ export class Wallet {
   createSwap(params: SwapCreateParams) { return this.swap.createSwap(params); }
   getSwapStatus(swapId: string) { return this.swap.getSwapStatus(swapId); }
   getSwapHistory(options?: SwapHistoryOptions) { return this.swap.getSwapHistory(options); }
+  saveSwapDeposit(swapId: string, txHash: string) { return this.swap.saveSwapDeposit(swapId, txHash); }
   getSwapCoins() { return this.swap.getSwapCoins(); }
 
   // ── Events ──


### PR DESCRIPTION
## Summary
- require wallet signature or wallet JWT authentication before reading a swap
- scope deposit hash reads and writes to the authenticated wallet
- route the web-wallet UI through the authenticated SDK method

## Security impact
Previously, anyone with a swap ID could overwrite its stored deposit transaction hash because the service-role route did not authenticate the caller or verify wallet ownership.

## Tests
- `pnpm exec vitest run 'src/app/api/swap/[id]/deposit/route.test.ts' 'src/lib/wallet-sdk/swap.test.ts' 'src/app/api/swap/swap-routes.test.ts'`
- `pnpm type-check`
- `pnpm test` (269 files, 3,730 passed, 12 skipped)
- targeted ESLint (0 errors; 4 pre-existing warnings in touched legacy files)