### PR TITLE
Add invoice commands to the CoinPay CLI

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -593,6 +593,40 @@ coinpay tokens list --business-id biz_123 --active-only
 coinpay payment qr pay_abc123
 ```
 
+### Invoices
+
+Invoice creation is draft-only. It does not send the invoice or move funds.
+When using a business-scoped API key, --business-id may be omitted.
+
+```bash
+# Create a draft invoice
+coinpay invoice create \
+  --amount 250 \
+  --currency USD \
+  --client-id cli_001 \
+  --crypto-currency USDC \
+  --due-date 2026-09-01 \
+  --notes "August development"
+
+# Route eventual settlement through a saved wallet or a direct address
+coinpay invoice create --amount 250 --wallet-id wal_001
+coinpay invoice create --amount 250 --merchant-wallet-address 0xabc123
+
+# Get invoice details
+coinpay invoice get inv_abc123
+
+# List invoices. Date filters apply to created_at and --date-to includes that day.
+coinpay invoice list \
+  --business-id biz_123 \
+  --status sent \
+  --client-id cli_001 \
+  --date-from 2026-08-01 \
+  --date-to 2026-08-31
+
+# Use --json with any invoice command for machine-readable output
+coinpay invoice list --status paid --json
+```
+
 ### Businesses
 
 ```bash

--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -15,6 +15,7 @@ import {
   DEFAULT_CHAINS,
 } from '../src/wallet.js';
 import { SwapClient, SwapCoins } from '../src/swap.js';
+import { createInvoice, getInvoice, listInvoices, InvoiceStatus } from '../src/invoices.js';
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
@@ -190,6 +191,43 @@ function parsePositiveInteger(value) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+function parsePositiveAmount(value) {
+  if (typeof value !== 'string') return null;
+
+  const normalized = value.trim();
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(normalized);
+  if (!match) return null;
+
+  const cents = BigInt(match[1]) * 100n + BigInt((match[2] || '').padEnd(2, '0'));
+  if (cents <= 0n || cents > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+
+  return Number(cents) / 100;
+}
+
+function isValidDate(value) {
+  if (typeof value !== 'string') return false;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+
+  const [, year, month, day] = match.map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function requireFlagValues(flags, names) {
+  for (const name of names) {
+    if (flags[name] === true) {
+      print.error('--' + name + ' requires a value');
+      process.exit(1);
+    }
+  }
+}
+
 /**
  * Show help
  */
@@ -216,6 +254,14 @@ ${colors.cyan}Commands:${colors.reset}
     get <id>              Get payment details
     list                  List payments
     qr <id>               Get payment QR code
+
+  ${colors.bright}invoice${colors.reset}
+    create                Create a draft invoice (--amount required)
+      --wallet-id <id>    Route settlement through a saved wallet
+      --merchant-wallet-address <address>
+                            Route settlement to a direct address
+    get <id>              Get invoice details
+    list                  List invoices with optional filters
 
   ${colors.bright}tokens${colors.reset}
     list                  List checkout tokens (--business-id, --active-only)
@@ -678,6 +724,165 @@ async function handlePayment(subcommand, args, flags) {
     default:
       print.error(`Unknown payment command: ${subcommand}`);
       showHelp();
+  }
+}
+
+function printInvoiceDetails(invoice) {
+  const label = invoice.invoiceNumber || invoice.id;
+  console.log('\n' + colors.bright + label + colors.reset);
+  print.info('ID: ' + invoice.id);
+  print.info('Status: ' + (invoice.status || 'unknown'));
+  print.info('Amount: ' + invoice.amount + ' ' + (invoice.currency || ''));
+  if (invoice.businessId) print.info('Business: ' + invoice.businessId);
+  if (invoice.clientId) print.info('Client: ' + invoice.clientId);
+  if (invoice.cryptoCurrency) print.info('Crypto: ' + invoice.cryptoCurrency);
+  if (invoice.dueDate) print.info('Due: ' + invoice.dueDate);
+  if (invoice.notes) print.info('Notes: ' + invoice.notes);
+  console.log();
+}
+
+/**
+ * Invoice commands
+ */
+async function handleInvoice(subcommand, args, flags) {
+  const client = createClient();
+
+  switch (subcommand) {
+    case 'create': {
+      requireFlagValues(flags, [
+        'amount',
+        'business-id',
+        'client-id',
+        'currency',
+        'crypto-currency',
+        'due-date',
+        'notes',
+        'wallet-id',
+        'merchant-wallet-address',
+      ]);
+
+      const amount = parsePositiveAmount(flags.amount);
+      if (amount === null) {
+        print.error('--amount must be a positive decimal with at most two decimal places');
+        print.info('Example: coinpay invoice create --amount 125 --currency USD --notes "Consulting"');
+        process.exit(1);
+      }
+
+      const currency = flags.currency || 'USD';
+      if (!/^[A-Za-z]{3}$/.test(currency)) {
+        print.error('--currency must be a three-letter currency code');
+        process.exit(1);
+      }
+
+      const dueDate = flags['due-date'];
+      if (dueDate !== undefined && !isValidDate(dueDate)) {
+        print.error('--due-date must be a valid date in YYYY-MM-DD format');
+        process.exit(1);
+      }
+
+      const cryptoCurrency = flags['crypto-currency'];
+      const invoice = await createInvoice(client, {
+        businessId: flags['business-id'],
+        clientId: flags['client-id'],
+        currency: currency.toUpperCase(),
+        amount,
+        cryptoCurrency: cryptoCurrency?.toUpperCase(),
+        dueDate,
+        notes: flags.notes,
+        walletId: flags['wallet-id'],
+        merchantWalletAddress: flags['merchant-wallet-address'],
+      });
+
+      if (flags.json) {
+        print.json(invoice);
+        break;
+      }
+
+      print.success('Draft invoice created');
+      printInvoiceDetails(invoice);
+      break;
+    }
+
+    case 'list': {
+      requireFlagValues(flags, ['business-id', 'status', 'client-id', 'date-from', 'date-to']);
+
+      const status = flags.status?.toLowerCase();
+      const validStatuses = new Set(Object.values(InvoiceStatus));
+      if (status !== undefined && !validStatuses.has(status)) {
+        print.error('--status must be one of: ' + [...validStatuses].join(', '));
+        process.exit(1);
+      }
+
+      const dateFrom = flags['date-from'];
+      const dateTo = flags['date-to'];
+      if (dateFrom !== undefined && !isValidDate(dateFrom)) {
+        print.error('--date-from must be a valid date in YYYY-MM-DD format');
+        process.exit(1);
+      }
+      if (dateTo !== undefined && !isValidDate(dateTo)) {
+        print.error('--date-to must be a valid date in YYYY-MM-DD format');
+        process.exit(1);
+      }
+      if (dateFrom && dateTo && dateFrom > dateTo) {
+        print.error('--date-from must not be later than --date-to');
+        process.exit(1);
+      }
+
+      const result = await listInvoices(client, {
+        businessId: flags['business-id'],
+        status,
+        clientId: flags['client-id'],
+        dateFrom,
+        dateTo,
+      });
+
+      if (flags.json) {
+        print.json(result);
+        break;
+      }
+
+      if (result.invoices.length === 0) {
+        print.info('No invoices found');
+        break;
+      }
+
+      console.log('\n' + colors.bright + 'Invoices' + colors.reset + ' (' + (result.total ?? result.invoices.length) + ')\n');
+      for (const invoice of result.invoices) {
+        const label = invoice.invoiceNumber || invoice.id;
+        const created = invoice.createdAt ? invoice.createdAt.slice(0, 10) : '-';
+        console.log(
+          '  ' + colors.bright + label + colors.reset +
+          '  ' + (invoice.status || 'unknown') +
+          '  ' + invoice.amount + ' ' + (invoice.currency || '') +
+          '  ' + created
+        );
+        if (invoice.invoiceNumber && invoice.id) console.log('    ' + invoice.id);
+      }
+      console.log();
+      break;
+    }
+
+    case 'get': {
+      const id = args[0];
+      if (!id) {
+        print.error('Usage: coinpay invoice get <id>');
+        process.exit(1);
+      }
+
+      const invoice = await getInvoice(client, id);
+      if (flags.json) {
+        print.json(invoice);
+        break;
+      }
+
+      printInvoiceDetails(invoice);
+      break;
+    }
+
+    default:
+      print.error('Unknown invoice command: ' + subcommand);
+      print.info('Available: create, list, get');
+      process.exit(1);
   }
 }
 
@@ -3225,6 +3430,10 @@ async function handleLightning(subcommand, args, flags) {
         
       case 'payment':
         await handlePayment(subcommand, args, flags);
+        break;
+
+      case 'invoice':
+        await handleInvoice(subcommand, args, flags);
         break;
 
       case 'tokens':

--- a/packages/sdk/src/invoices.js
+++ b/packages/sdk/src/invoices.js
@@ -32,7 +32,7 @@
  * Create a new invoice
  * @param {CoinPayClient} client - API client instance
  * @param {Object} options - Invoice parameters
- * @param {string} options.businessId - Business ID
+ * @param {string} [options.businessId] - Business ID (optional for business-scoped API keys)
  * @param {string} [options.clientId] - Client ID (optional)
  * @param {string} options.currency - Fiat currency code (USD, EUR, etc.)
  * @param {number} options.amount - Invoice amount
@@ -115,7 +115,7 @@ export async function listInvoices(client, filters = {}) {
  * @returns {Promise<Object>} Invoice details
  */
 export async function getInvoice(client, id) {
-  const data = await client.request(`/invoices/${id}`);
+  const data = await client.request(`/invoices/${encodeURIComponent(id)}`);
   return normalizeInvoice(data);
 }
 
@@ -145,7 +145,7 @@ export async function updateInvoice(client, id, updates) {
   if (updates.walletId !== undefined) body.wallet_id = updates.walletId;
   if (updates.merchantWalletAddress !== undefined) body.merchant_wallet_address = updates.merchantWalletAddress;
 
-  const data = await client.request(`/invoices/${id}`, {
+  const data = await client.request(`/invoices/${encodeURIComponent(id)}`, {
     method: 'PUT',
     body: JSON.stringify(body),
   });
@@ -160,7 +160,7 @@ export async function updateInvoice(client, id, updates) {
  * @returns {Promise<Object>} Deletion confirmation
  */
 export async function deleteInvoice(client, id) {
-  return client.request(`/invoices/${id}`, {
+  return client.request(`/invoices/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
 }
@@ -173,7 +173,7 @@ export async function deleteInvoice(client, id) {
  * @returns {Promise<Object>} Send result with payment details
  */
 export async function sendInvoice(client, id) {
-  const data = await client.request(`/invoices/${id}/send`, {
+  const data = await client.request(`/invoices/${encodeURIComponent(id)}/send`, {
     method: 'POST',
   });
   return data;
@@ -187,7 +187,7 @@ export async function sendInvoice(client, id) {
  * @returns {Promise<Object>} Payment data (address, amount, status, etc.)
  */
 export async function getInvoicePaymentData(client, id) {
-  const data = await client.requestUnauthenticated(`/invoices/${id}/pay`);
+  const data = await client.requestUnauthenticated(`/invoices/${encodeURIComponent(id)}/pay`);
   return data;
 }
 
@@ -208,24 +208,30 @@ export const InvoiceStatus = {
 
 function normalizeInvoice(data) {
   if (!data) return data;
+
+  // Single-invoice API responses are wrapped, while older SDK callers and
+  // tests may still supply the invoice object directly.
+  const invoice = data.invoice ?? data;
+
   return {
-    id: data.id,
-    businessId: data.business_id,
-    clientId: data.client_id,
-    currency: data.currency,
-    amount: data.amount,
-    cryptoCurrency: data.crypto_currency,
-    cryptoAmount: data.crypto_amount,
-    status: data.status,
-    dueDate: data.due_date,
-    notes: data.notes,
-    walletId: data.wallet_id,
-    merchantWalletAddress: data.merchant_wallet_address,
-    paymentAddress: data.payment_address,
-    stripeCheckoutUrl: data.stripe_checkout_url,
-    paidAt: data.paid_at,
-    sentAt: data.sent_at,
-    createdAt: data.created_at,
-    updatedAt: data.updated_at,
+    id: invoice.id,
+    invoiceNumber: invoice.invoice_number,
+    businessId: invoice.business_id,
+    clientId: invoice.client_id,
+    currency: invoice.currency,
+    amount: invoice.amount,
+    cryptoCurrency: invoice.crypto_currency,
+    cryptoAmount: invoice.crypto_amount,
+    status: invoice.status,
+    dueDate: invoice.due_date,
+    notes: invoice.notes,
+    walletId: invoice.wallet_id,
+    merchantWalletAddress: invoice.merchant_wallet_address,
+    paymentAddress: invoice.payment_address,
+    stripeCheckoutUrl: invoice.stripe_checkout_url,
+    paidAt: invoice.paid_at,
+    sentAt: invoice.sent_at,
+    createdAt: invoice.created_at,
+    updatedAt: invoice.updated_at,
   };
 }

--- a/packages/sdk/test/cli-invoice.test.js
+++ b/packages/sdk/test/cli-invoice.test.js
@@ -1,0 +1,379 @@
+/**
+ * CLI Invoice Command Tests
+ */
+
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+const CLI_PATH = join(import.meta.dirname, '..', 'bin', 'coinpay.js');
+
+function runCLI(args, baseUrl) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      env: {
+        ...process.env,
+        COINPAY_API_KEY: 'cp_test_invoice_key',
+        COINPAY_BASE_URL: baseUrl,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ status: code, stdout, stderr, output: stdout + stderr });
+    });
+  });
+}
+
+describe('CLI Invoice Commands', () => {
+  let server;
+  let baseUrl;
+  let requests;
+  let respond;
+
+  beforeAll(async () => {
+    server = createServer(async (request, response) => {
+      const chunks = [];
+      for await (const chunk of request) chunks.push(chunk);
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      const captured = {
+        method: request.method,
+        url: request.url,
+        headers: request.headers,
+        body: rawBody ? JSON.parse(rawBody) : undefined,
+      };
+      requests.push(captured);
+
+      const result = await respond(captured);
+      response.writeHead(result.status || 200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(result.body));
+    });
+
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const address = server.address();
+    baseUrl = 'http://127.0.0.1:' + address.port + '/api';
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    requests = [];
+    respond = () => ({ status: 404, body: { error: 'Unexpected request' } });
+  });
+
+  it('shows invoice commands in global help', async () => {
+    const result = await runCLI(['--help'], baseUrl);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('invoice');
+    expect(result.output).toContain('Create a draft invoice');
+    expect(result.output).toContain('Get invoice details');
+  });
+
+  it('creates a draft invoice and emits clean JSON', async () => {
+    respond = () => ({
+      status: 201,
+      body: {
+        success: true,
+        invoice: {
+          id: 'inv_123',
+          invoice_number: 'INV-001',
+          business_id: 'biz_123',
+          client_id: 'cli_123',
+          currency: 'USD',
+          amount: 125.5,
+          crypto_currency: 'USDC',
+          status: 'draft',
+          due_date: '2026-09-01',
+          notes: 'August work',
+          created_at: '2026-08-12T00:00:00.000Z',
+        },
+      },
+    });
+
+    const result = await runCLI(
+      [
+        'invoice',
+        'create',
+        '--business-id',
+        'biz_123',
+        '--client-id',
+        'cli_123',
+        '--amount',
+        '125.50',
+        '--currency',
+        'usd',
+        '--crypto-currency',
+        'usdc',
+        '--due-date',
+        '2026-09-01',
+        '--notes',
+        'August work',
+        '--json',
+      ],
+      baseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).not.toContain('\u001b[');
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      id: 'inv_123',
+      invoiceNumber: 'INV-001',
+      amount: 125.5,
+      currency: 'USD',
+      status: 'draft',
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      method: 'POST',
+      url: '/api/invoices',
+      body: {
+        business_id: 'biz_123',
+        client_id: 'cli_123',
+        currency: 'USD',
+        amount: 125.5,
+        crypto_currency: 'USDC',
+        due_date: '2026-09-01',
+        notes: 'August work',
+      },
+    });
+    expect(requests[0].body).not.toHaveProperty('schedule');
+    expect(requests[0].headers.authorization).toBe('Bearer cp_test_invoice_key');
+  });
+
+  it('allows API-key scoped creation without --business-id', async () => {
+    respond = () => ({
+      status: 201,
+      body: {
+        success: true,
+        invoice: {
+          id: 'inv_scoped',
+          invoice_number: 'INV-002',
+          business_id: 'biz_from_key',
+          currency: 'USD',
+          amount: 10,
+          status: 'draft',
+        },
+      },
+    });
+
+    const result = await runCLI(['invoice', 'create', '--amount', '10', '--json'], baseUrl);
+
+    expect(result.status).toBe(0);
+    expect(requests[0].body).not.toHaveProperty('business_id');
+    expect(requests[0].body).toMatchObject({ amount: 10, currency: 'USD' });
+  });
+
+  it.each(['0', '-1', 'NaN', 'Infinity', '12usd', '0x1A', '1e3', '10.005'])(
+    'rejects invalid create amount %s before making a request',
+    async (amount) => {
+      const result = await runCLI(['invoice', 'create', '--amount', amount], baseUrl);
+
+      expect(result.status).not.toBe(0);
+      expect(result.output).toMatch(/positive (?:number|decimal)|requires a value/i);
+      expect(requests).toHaveLength(0);
+    }
+  );
+
+  it('rejects missing flag values and invalid dates', async () => {
+    const missingValue = await runCLI(['invoice', 'create', '--amount'], baseUrl);
+    expect(missingValue.status).not.toBe(0);
+    expect(missingValue.output).toContain('--amount requires a value');
+
+    const invalidDate = await runCLI(
+      ['invoice', 'create', '--amount', '25', '--due-date', 'not-a-date'],
+      baseUrl
+    );
+    expect(invalidDate.status).not.toBe(0);
+    expect(invalidDate.output).toMatch(/due-date.*valid date/i);
+
+    const ambiguousDate = await runCLI(
+      ['invoice', 'create', '--amount', '25', '--due-date', '5'],
+      baseUrl
+    );
+    expect(ambiguousDate.status).not.toBe(0);
+    expect(ambiguousDate.output).toMatch(/due-date.*YYYY-MM-DD/i);
+
+    const impossibleDate = await runCLI(
+      ['invoice', 'create', '--amount', '25', '--due-date', '2026-02-30'],
+      baseUrl
+    );
+    expect(impossibleDate.status).not.toBe(0);
+    expect(impossibleDate.output).toMatch(/due-date.*YYYY-MM-DD/i);
+    expect(requests).toHaveLength(0);
+  });
+
+  it('forwards wallet routing fields when creating a draft', async () => {
+    respond = () => ({
+      status: 201,
+      body: {
+        success: true,
+        invoice: { id: 'inv_wallet', currency: 'USD', amount: 25, status: 'draft' },
+      },
+    });
+
+    const result = await runCLI(
+      [
+        'invoice',
+        'create',
+        '--amount',
+        '25',
+        '--wallet-id',
+        'wal_123',
+        '--merchant-wallet-address',
+        '0xabc123',
+        '--json',
+      ],
+      baseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(requests[0].body).toMatchObject({
+      wallet_id: 'wal_123',
+      merchant_wallet_address: '0xabc123',
+    });
+    expect(requests[0].body).not.toHaveProperty('schedule');
+  });
+
+  it('forwards every supported list filter and emits JSON', async () => {
+    respond = () => ({
+      body: {
+        success: true,
+        total: 1,
+        invoices: [
+          {
+            id: 'inv_list',
+            invoice_number: 'INV-010',
+            business_id: 'biz_123',
+            client_id: 'cli_123',
+            currency: 'USD',
+            amount: 50,
+            status: 'sent',
+            created_at: '2026-08-10T12:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    const result = await runCLI(
+      [
+        'invoice',
+        'list',
+        '--business-id',
+        'biz_123',
+        '--status',
+        'SENT',
+        '--client-id',
+        'cli_123',
+        '--date-from',
+        '2026-08-01',
+        '--date-to',
+        '2026-08-31',
+        '--json',
+      ],
+      baseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      total: 1,
+      invoices: [{ id: 'inv_list', invoiceNumber: 'INV-010', status: 'sent' }],
+    });
+    expect(requests[0].url).toBe(
+      '/api/invoices?business_id=biz_123&status=sent&client_id=cli_123&date_from=2026-08-01&date_to=2026-08-31'
+    );
+  });
+
+  it('rejects unsupported statuses and reversed date ranges', async () => {
+    const badStatus = await runCLI(['invoice', 'list', '--status', 'rejected'], baseUrl);
+    expect(badStatus.status).not.toBe(0);
+    expect(badStatus.output).toMatch(/status must be one of/i);
+
+    const badDate = await runCLI(['invoice', 'list', '--date-from', '5'], baseUrl);
+    expect(badDate.status).not.toBe(0);
+    expect(badDate.output).toMatch(/date-from.*YYYY-MM-DD/i);
+
+    const badRange = await runCLI(
+      ['invoice', 'list', '--date-from', '2026-09-01', '--date-to', '2026-08-01'],
+      baseUrl
+    );
+    expect(badRange.status).not.toBe(0);
+    expect(badRange.output).toMatch(/date-from must not be later/i);
+    expect(requests).toHaveLength(0);
+  });
+
+  it('prints readable invoice details for get', async () => {
+    respond = () => ({
+      body: {
+        success: true,
+        invoice: {
+          id: 'inv_get',
+          invoice_number: 'INV-011',
+          business_id: 'biz_123',
+          currency: 'EUR',
+          amount: 80,
+          status: 'sent',
+          notes: 'Design review',
+        },
+      },
+    });
+
+    const result = await runCLI(['invoice', 'get', 'inv_get'], baseUrl);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('INV-011');
+    expect(result.output).toContain('ID: inv_get');
+    expect(result.output).toContain('Status: sent');
+    expect(result.output).toContain('Amount: 80 EUR');
+    expect(requests[0].url).toBe('/api/invoices/inv_get');
+  });
+
+  it('encodes invoice ids before requesting them', async () => {
+    respond = () => ({
+      body: {
+        success: true,
+        invoice: { id: 'inv#1/../payments', status: 'draft' },
+      },
+    });
+
+    const result = await runCLI(['invoice', 'get', 'inv#1/../payments', '--json'], baseUrl);
+
+    expect(result.status).toBe(0);
+    expect(requests[0].url).toBe('/api/invoices/inv%231%2F..%2Fpayments');
+  });
+
+  it('requires an id for get', async () => {
+    const result = await runCLI(['invoice', 'get'], baseUrl);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('coinpay invoice get <id>');
+    expect(requests).toHaveLength(0);
+  });
+
+  it('returns a non-zero status and useful error for API failures', async () => {
+    respond = () => ({ status: 422, body: { error: 'Invoice could not be created' } });
+
+    const result = await runCLI(['invoice', 'create', '--amount', '25'], baseUrl);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Invoice could not be created');
+    expect(result.stderr).not.toContain('cp_test_invoice_key');
+  });
+});

--- a/packages/sdk/test/invoices.test.js
+++ b/packages/sdk/test/invoices.test.js
@@ -32,6 +32,7 @@ describe('Invoice SDK', () => {
     it('should create invoice with required fields', async () => {
       const mockResponse = {
         id: 'inv_123',
+        invoice_number: 'INV-001',
         business_id: 'biz_456',
         currency: 'USD',
         amount: 250,
@@ -40,7 +41,7 @@ describe('Invoice SDK', () => {
         updated_at: '2026-03-22T12:00:00Z',
       };
 
-      mockClient.request.mockResolvedValue(mockResponse);
+      mockClient.request.mockResolvedValue({ success: true, invoice: mockResponse });
 
       const result = await createInvoice(mockClient, {
         businessId: 'biz_456',
@@ -59,6 +60,7 @@ describe('Invoice SDK', () => {
 
       expect(result).toEqual({
         id: 'inv_123',
+        invoiceNumber: 'INV-001',
         businessId: 'biz_456',
         clientId: undefined,
         currency: 'USD',
@@ -96,7 +98,7 @@ describe('Invoice SDK', () => {
         updated_at: '2026-03-22T12:00:00Z',
       };
 
-      mockClient.request.mockResolvedValue(mockResponse);
+      mockClient.request.mockResolvedValue({ success: true, invoice: mockResponse });
 
       const result = await createInvoice(mockClient, {
         businessId: 'biz_456',
@@ -136,8 +138,22 @@ describe('Invoice SDK', () => {
     it('should list invoices without filters', async () => {
       const mockResponse = {
         invoices: [
-          { id: 'inv_1', business_id: 'biz_456', currency: 'USD', amount: 100, status: 'draft', created_at: '2026-03-20T12:00:00Z' },
-          { id: 'inv_2', business_id: 'biz_456', currency: 'USD', amount: 200, status: 'sent', created_at: '2026-03-21T12:00:00Z' },
+          {
+            id: 'inv_1',
+            business_id: 'biz_456',
+            currency: 'USD',
+            amount: 100,
+            status: 'draft',
+            created_at: '2026-03-20T12:00:00Z',
+          },
+          {
+            id: 'inv_2',
+            business_id: 'biz_456',
+            currency: 'USD',
+            amount: 200,
+            status: 'sent',
+            created_at: '2026-03-21T12:00:00Z',
+          },
         ],
         total: 2,
       };
@@ -156,7 +172,14 @@ describe('Invoice SDK', () => {
     it('should list invoices with filters', async () => {
       const mockResponse = {
         invoices: [
-          { id: 'inv_3', business_id: 'biz_456', currency: 'USD', amount: 300, status: 'paid', created_at: '2026-03-22T12:00:00Z' },
+          {
+            id: 'inv_3',
+            business_id: 'biz_456',
+            currency: 'USD',
+            amount: 300,
+            status: 'paid',
+            created_at: '2026-03-22T12:00:00Z',
+          },
         ],
         total: 1,
       };
@@ -193,6 +216,7 @@ describe('Invoice SDK', () => {
     it('should get invoice by ID', async () => {
       const mockResponse = {
         id: 'inv_123',
+        invoice_number: 'INV-009',
         business_id: 'biz_456',
         currency: 'USD',
         amount: 250,
@@ -203,14 +227,26 @@ describe('Invoice SDK', () => {
         updated_at: '2026-03-22T14:00:00Z',
       };
 
-      mockClient.request.mockResolvedValue(mockResponse);
+      mockClient.request.mockResolvedValue({ success: true, invoice: mockResponse });
 
       const result = await getInvoice(mockClient, 'inv_123');
 
       expect(mockClient.request).toHaveBeenCalledWith('/invoices/inv_123');
       expect(result.id).toBe('inv_123');
+      expect(result.invoiceNumber).toBe('INV-009');
       expect(result.status).toBe('sent');
       expect(result.paymentAddress).toBe('0xdef456');
+    });
+
+    it('should encode invoice IDs in request paths', async () => {
+      mockClient.request.mockResolvedValue({
+        success: true,
+        invoice: { id: 'inv#1/../payments', status: 'draft' },
+      });
+
+      await getInvoice(mockClient, 'inv#1/../payments');
+
+      expect(mockClient.request).toHaveBeenCalledWith('/invoices/inv%231%2F..%2Fpayments');
     });
   });
 
@@ -227,7 +263,7 @@ describe('Invoice SDK', () => {
         updated_at: '2026-03-22T15:00:00Z',
       };
 
-      mockClient.request.mockResolvedValue(mockResponse);
+      mockClient.request.mockResolvedValue({ success: true, invoice: mockResponse });
 
       const result = await updateInvoice(mockClient, 'inv_123', {
         amount: 300,


### PR DESCRIPTION
## Summary

- add `coinpay invoice create`, `list`, and `get` to the installed SDK CLI
- support the existing auth flow, invoice filters, wallet routing, readable output, and `--json`
- normalize invoice API envelopes and safely encode invoice IDs in SDK paths
- document the commands and add subprocess/API-mock coverage

`invoice create` only creates a draft. It does not send, schedule, mark paid, or move funds.

## Tests

- `pnpm exec vitest run test/cli-invoice.test.js test/invoices.test.js` (32 passed)
- full SDK suite (534 passed, 3 skipped)
- `node --check` and `git diff --check`

SDK lint is currently blocked by the existing ESLint 8/9 plugin mismatch in unchanged `src/auth.js`.