### PR TITLE
Show share links after creating invoices

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -596,6 +596,9 @@ coinpay payment qr pay_abc123
 ### Invoices
 
 Invoice creation is draft-only. It does not send the invoice or move funds.
+The create command prints the public `/now/{invoiceId}` payment link so it can be
+copied into chat. The payment page becomes available after the invoice is sent.
+Create's JSON output includes the same link as `shareUrl`.
 When using a business-scoped API key, --business-id may be omitted.
 
 ```bash

--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -125,6 +125,10 @@ function getBaseUrl() {
   return process.env.COINPAY_BASE_URL || config.baseUrl || 'https://coinpayportal.com/api';
 }
 
+function getInvoiceShareUrl(invoiceId) {
+  return new URL(`/now/${encodeURIComponent(invoiceId)}`, getBaseUrl()).toString();
+}
+
 /**
  * Create client instance
  */
@@ -727,7 +731,7 @@ async function handlePayment(subcommand, args, flags) {
   }
 }
 
-function printInvoiceDetails(invoice) {
+function printInvoiceDetails(invoice, { shareUrl } = {}) {
   const label = invoice.invoiceNumber || invoice.id;
   console.log('\n' + colors.bright + label + colors.reset);
   print.info('ID: ' + invoice.id);
@@ -738,6 +742,7 @@ function printInvoiceDetails(invoice) {
   if (invoice.cryptoCurrency) print.info('Crypto: ' + invoice.cryptoCurrency);
   if (invoice.dueDate) print.info('Due: ' + invoice.dueDate);
   if (invoice.notes) print.info('Notes: ' + invoice.notes);
+  if (shareUrl) print.info('Share link (opens after send): ' + shareUrl);
   console.log();
 }
 
@@ -792,14 +797,15 @@ async function handleInvoice(subcommand, args, flags) {
         walletId: flags['wallet-id'],
         merchantWalletAddress: flags['merchant-wallet-address'],
       });
+      const shareUrl = invoice.id ? getInvoiceShareUrl(invoice.id) : undefined;
 
       if (flags.json) {
-        print.json(invoice);
+        print.json(shareUrl ? { ...invoice, shareUrl } : invoice);
         break;
       }
 
       print.success('Draft invoice created');
-      printInvoiceDetails(invoice);
+      printInvoiceDetails(invoice, { shareUrl });
       break;
     }
 

--- a/packages/sdk/test/cli-invoice.test.js
+++ b/packages/sdk/test/cli-invoice.test.js
@@ -139,6 +139,7 @@ describe('CLI Invoice Commands', () => {
       amount: 125.5,
       currency: 'USD',
       status: 'draft',
+      shareUrl: new URL('/now/inv_123', baseUrl).toString(),
     });
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({
@@ -174,11 +175,40 @@ describe('CLI Invoice Commands', () => {
       },
     });
 
-    const result = await runCLI(['invoice', 'create', '--amount', '10', '--json'], baseUrl);
+    const result = await runCLI(['invoice', 'create', '--amount', '10'], baseUrl);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain(new URL('/now/inv_scoped', baseUrl).toString());
     expect(requests[0].body).not.toHaveProperty('business_id');
     expect(requests[0].body).toMatchObject({ amount: 10, currency: 'USD' });
+  });
+
+  it('builds the share link from the configured web origin', async () => {
+    respond = () => ({
+      status: 201,
+      body: {
+        success: true,
+        invoice: {
+          id: 'inv_custom',
+          invoice_number: 'INV-003',
+          currency: 'USD',
+          amount: 15,
+          status: 'draft',
+        },
+      },
+    });
+    const customBaseUrl = new URL('/coinpay/api/', baseUrl).toString();
+
+    const result = await runCLI(
+      ['invoice', 'create', '--amount', '15', '--json'],
+      customBaseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).shareUrl).toBe(
+      new URL('/now/inv_custom', customBaseUrl).toString()
+    );
+    expect(requests[0].url).toBe('/coinpay/api/invoices');
   });
 
   it.each(['0', '-1', 'NaN', 'Infinity', '12usd', '0x1A', '1e3', '10.005'])(


### PR DESCRIPTION
## Summary

- print the existing public `/now/{invoiceId}` link after `coinpay invoice create`
- include the same link as `shareUrl` in create JSON output
- clarify that draft links open after the invoice is sent and build links from the configured CoinPay origin

This follows up on the review feedback from #241 without adding invoice sending or chat integration.

## Tests

- `pnpm test` (535 passed, 3 skipped)