### PR TITLE
Fix TypeScript declarations for invoice SDK exports

### DIFF
--- a/packages/sdk/src/index.d.ts
+++ b/packages/sdk/src/index.d.ts
@@ -44,6 +44,26 @@ export type {
   ListPaymentsFnParams 
 } from './payments.js';
 
+// Invoice exports
+export {
+  createInvoice,
+  getInvoice,
+  listInvoices,
+  updateInvoice,
+  deleteInvoice,
+  sendInvoice,
+  getInvoicePaymentData,
+  InvoiceStatus,
+} from './invoices.js';
+export type {
+  Invoice,
+  InvoiceStatusType,
+  CreateInvoiceParams,
+  ListInvoicesParams,
+  UpdateInvoiceParams,
+  ListInvoicesResult,
+} from './invoices.js';
+
 // Webhook exports
 export {
   verifyWebhookSignature,

--- a/packages/sdk/src/invoices.d.ts
+++ b/packages/sdk/src/invoices.d.ts
@@ -1,0 +1,77 @@
+import type { CoinPayClient } from './client.js';
+
+export const InvoiceStatus: {
+  readonly DRAFT: 'draft';
+  readonly SENT: 'sent';
+  readonly PAID: 'paid';
+  readonly OVERDUE: 'overdue';
+  readonly CANCELLED: 'cancelled';
+};
+
+export type InvoiceStatusType = (typeof InvoiceStatus)[keyof typeof InvoiceStatus];
+
+export interface Invoice {
+  id: string;
+  invoiceNumber?: string;
+  businessId?: string;
+  clientId?: string;
+  currency?: string;
+  amount?: number;
+  cryptoCurrency?: string;
+  cryptoAmount?: string | number;
+  status?: InvoiceStatusType;
+  dueDate?: string;
+  notes?: string;
+  walletId?: string;
+  merchantWalletAddress?: string;
+  paymentAddress?: string;
+  stripeCheckoutUrl?: string;
+  paidAt?: string;
+  sentAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface CreateInvoiceParams {
+  businessId?: string;
+  clientId?: string;
+  currency: string;
+  amount: number;
+  cryptoCurrency?: string;
+  dueDate?: string;
+  notes?: string;
+  walletId?: string;
+  merchantWalletAddress?: string;
+}
+
+export interface ListInvoicesParams {
+  businessId?: string;
+  status?: InvoiceStatusType;
+  clientId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface UpdateInvoiceParams {
+  amount?: number;
+  currency?: string;
+  cryptoCurrency?: string;
+  dueDate?: string;
+  notes?: string;
+  clientId?: string;
+  walletId?: string;
+  merchantWalletAddress?: string;
+}
+
+export interface ListInvoicesResult {
+  invoices: Invoice[];
+  total?: number;
+}
+
+export function createInvoice(client: CoinPayClient, options: CreateInvoiceParams): Promise<Invoice>;
+export function listInvoices(client: CoinPayClient, filters?: ListInvoicesParams): Promise<ListInvoicesResult>;
+export function getInvoice(client: CoinPayClient, id: string): Promise<Invoice>;
+export function updateInvoice(client: CoinPayClient, id: string, updates: UpdateInvoiceParams): Promise<Invoice>;
+export function deleteInvoice(client: CoinPayClient, id: string): Promise<Record<string, unknown>>;
+export function sendInvoice(client: CoinPayClient, id: string): Promise<Record<string, unknown>>;
+export function getInvoicePaymentData(client: CoinPayClient, id: string): Promise<Record<string, unknown>>;

--- a/packages/sdk/test/fixtures/invoice-types.ts
+++ b/packages/sdk/test/fixtures/invoice-types.ts
@@ -1,0 +1,37 @@
+import {
+  CoinPayClient,
+  InvoiceStatus,
+  createInvoice,
+  deleteInvoice,
+  getInvoice,
+  getInvoicePaymentData,
+  listInvoices,
+  sendInvoice,
+  updateInvoice,
+  type CreateInvoiceParams,
+  type Invoice,
+  type ListInvoicesParams,
+  type UpdateInvoiceParams,
+} from '../../src/index.js';
+
+declare const client: CoinPayClient;
+
+const createParams: CreateInvoiceParams = {
+  amount: 25,
+  currency: 'USD',
+};
+const listParams: ListInvoicesParams = { status: InvoiceStatus.DRAFT };
+const updates: UpdateInvoiceParams = { notes: 'Updated terms' };
+
+const created: Promise<Invoice> = createInvoice(client, createParams);
+const fetched: Promise<Invoice> = getInvoice(client, 'inv_123');
+const listed: Promise<{ invoices: Invoice[]; total?: number }> = listInvoices(client, listParams);
+const updated: Promise<Invoice> = updateInvoice(client, 'inv_123', updates);
+
+void created;
+void fetched;
+void listed;
+void updated;
+void deleteInvoice(client, 'inv_123');
+void sendInvoice(client, 'inv_123');
+void getInvoicePaymentData(client, 'inv_123');

--- a/packages/sdk/test/typescript-declarations.test.js
+++ b/packages/sdk/test/typescript-declarations.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+import { join } from 'node:path';
+
+describe('TypeScript declarations', () => {
+  it('exposes the invoice API from the package entry point', () => {
+    const fixture = join(import.meta.dirname, 'fixtures', 'invoice-types.ts');
+    const program = ts.createProgram([fixture], {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2022,
+      noEmit: true,
+      strict: true,
+      skipLibCheck: true,
+    });
+
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+    const messages = diagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+    expect(messages).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #243.

## What changed
- add declarations for the invoice runtime module
- export invoice functions, constants, and parameter/result types from the package entry point
- add a TypeScript compilation regression test covering every public invoice export

## Validation
- itest run packages/sdk/test - 527 passed, 12 skipped