### PR TITLE
feat(admin): see every user's activity and volume in one place

### DIFF
--- a/src/app/admin/AdminContent.tsx
+++ b/src/app/admin/AdminContent.tsx
@@ -165,6 +165,12 @@ export default function AdminContent() {
         <h2 className="text-lg font-semibold text-white mb-3">Tools</h2>
         <div className="flex flex-wrap gap-3">
           <Link
+            href="/admin/users"
+            className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
+          >
+            User stats →
+          </Link>
+          <Link
             href="/admin/email-broadcast"
             className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
           >

--- a/src/app/admin/users/UsersContent.tsx
+++ b/src/app/admin/users/UsersContent.tsx
@@ -1,0 +1,475 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+
+type SortKey =
+  | 'email'
+  | 'created_at'
+  | 'last_login_at'
+  | 'last_activity_at'
+  | 'businesses_count'
+  | 'payments_total'
+  | 'payments_settled'
+  | 'settled_volume_usd'
+  | 'invoices_total'
+  | 'invoices_paid_usd'
+  | 'escrows_total'
+  | 'stripe_volume_usd'
+  | 'total_volume_usd';
+
+type UserRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  isAdmin: boolean;
+  authProvider: string | null;
+  subscriptionPlanId: string | null;
+  subscriptionStatus: string | null;
+  createdAt: string;
+  lastLoginAt: string | null;
+  lastActivityAt: string | null;
+  businessesCount: number;
+  activeBusinessesCount: number;
+  paymentsTotal: number;
+  paymentsSettled: number;
+  settledVolumeUsd: number;
+  invoicesTotal: number;
+  invoicesPaid: number;
+  invoicesPaidUsd: number;
+  invoiceFeesUsd: number;
+  escrowsTotal: number;
+  escrowsSettled: number;
+  escrowVolumeUsd: number;
+  stripeTotal: number;
+  stripeCompleted: number;
+  stripeVolumeUsd: number;
+  totalVolumeUsd: number;
+};
+
+type Summary = {
+  usersTotal: number;
+  usersNew7d: number;
+  usersNew30d: number;
+  usersActive30d: number;
+  businessesTotal: number;
+  businessesActive: number;
+  paymentsTotal: number;
+  paymentsSettled: number;
+  paymentsVolumeUsd: number;
+  invoicesTotal: number;
+  invoicesPaid: number;
+  invoicesPaidUsd: number;
+  escrowsTotal: number;
+  escrowsSettled: number;
+  escrowVolumeUsd: number;
+  stripeCompleted: number;
+  stripeVolumeUsd: number;
+};
+
+const PAGE_SIZE = 50;
+
+function authHeaders(extra?: HeadersInit): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+  const headers: Record<string, string> = { ...(extra as Record<string, string>) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+function usd(value: number): string {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function count(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function shortDate(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** "3d ago" reads faster than a timestamp when scanning a column for staleness. */
+function relative(value: string | null): string {
+  if (!value) return 'never';
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return 'never';
+  const days = Math.floor((Date.now() - then) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+const COLUMNS: { key: SortKey; label: string; numeric: boolean; title?: string }[] = [
+  { key: 'email', label: 'User', numeric: false },
+  { key: 'created_at', label: 'Signed up', numeric: false },
+  { key: 'last_activity_at', label: 'Last active', numeric: false, title: 'Most recent login, payment, invoice, escrow or Stripe charge' },
+  { key: 'businesses_count', label: 'Biz', numeric: true, title: 'Businesses' },
+  { key: 'payments_settled', label: 'Payments', numeric: true, title: 'Settled / total crypto payments' },
+  { key: 'settled_volume_usd', label: 'Crypto', numeric: true, title: 'USD volume of settled crypto payments' },
+  { key: 'invoices_total', label: 'Invoices', numeric: true, title: 'Paid / total invoices' },
+  { key: 'stripe_volume_usd', label: 'Stripe', numeric: true, title: 'USD volume of completed Stripe charges' },
+  { key: 'total_volume_usd', label: 'Total USD', numeric: true, title: 'Crypto + invoices + escrows + Stripe' },
+];
+
+const CSV_COLUMNS: { header: string; value: (u: UserRow) => string | number }[] = [
+  { header: 'email', value: (u) => u.email },
+  { header: 'name', value: (u) => u.name ?? '' },
+  { header: 'is_admin', value: (u) => String(u.isAdmin) },
+  { header: 'auth_provider', value: (u) => u.authProvider ?? '' },
+  { header: 'plan', value: (u) => u.subscriptionPlanId ?? '' },
+  { header: 'subscription_status', value: (u) => u.subscriptionStatus ?? '' },
+  { header: 'signed_up', value: (u) => u.createdAt },
+  { header: 'last_login_at', value: (u) => u.lastLoginAt ?? '' },
+  { header: 'last_activity_at', value: (u) => u.lastActivityAt ?? '' },
+  { header: 'businesses', value: (u) => u.businessesCount },
+  { header: 'active_businesses', value: (u) => u.activeBusinessesCount },
+  { header: 'payments_total', value: (u) => u.paymentsTotal },
+  { header: 'payments_settled', value: (u) => u.paymentsSettled },
+  { header: 'settled_volume_usd', value: (u) => u.settledVolumeUsd },
+  { header: 'invoices_total', value: (u) => u.invoicesTotal },
+  { header: 'invoices_paid', value: (u) => u.invoicesPaid },
+  { header: 'invoices_paid_usd', value: (u) => u.invoicesPaidUsd },
+  { header: 'invoice_fees_usd', value: (u) => u.invoiceFeesUsd },
+  { header: 'escrows_total', value: (u) => u.escrowsTotal },
+  { header: 'escrows_settled', value: (u) => u.escrowsSettled },
+  { header: 'escrow_volume_usd', value: (u) => u.escrowVolumeUsd },
+  { header: 'stripe_total', value: (u) => u.stripeTotal },
+  { header: 'stripe_completed', value: (u) => u.stripeCompleted },
+  { header: 'stripe_volume_usd', value: (u) => u.stripeVolumeUsd },
+  { header: 'total_volume_usd', value: (u) => u.totalVolumeUsd },
+];
+
+function toCsv(rows: UserRow[]): string {
+  const escape = (v: string | number): string => {
+    const s = String(v);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const lines = [CSV_COLUMNS.map((c) => c.header).join(',')];
+  for (const row of rows) {
+    lines.push(CSV_COLUMNS.map((c) => escape(c.value(row))).join(','));
+  }
+  return lines.join('\n');
+}
+
+function StatTile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-400">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-white">{value}</div>
+      {sub && <div className="mt-1 text-xs text-gray-500">{sub}</div>}
+    </div>
+  );
+}
+
+export default function UsersContent() {
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [sort, setSort] = useState<SortKey>('last_activity_at');
+  const [dir, setDir] = useState<'asc' | 'desc'>('desc');
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [authState, setAuthState] = useState<'unknown' | 'unauthenticated' | 'forbidden' | 'ok'>('unknown');
+  const [error, setError] = useState<string | null>(null);
+
+  // Debounce the search box so typing an email is one request, not eight.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearch(searchInput);
+      setOffset(0);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  const queryString = useCallback(
+    (over: Partial<{ limit: number; offset: number; summary: string }> = {}) => {
+      const params = new URLSearchParams({
+        sort,
+        dir,
+        limit: String(over.limit ?? PAGE_SIZE),
+        offset: String(over.offset ?? offset),
+      });
+      if (search.trim()) params.set('search', search.trim());
+      if (over.summary) params.set('summary', over.summary);
+      return params.toString();
+    },
+    [sort, dir, offset, search],
+  );
+
+  // A slow request for an earlier sort must not overwrite a newer one.
+  const requestId = useRef(0);
+
+  const fetchUsers = useCallback(async () => {
+    const id = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/users?${queryString()}`, { headers: authHeaders() });
+      if (id !== requestId.current) return;
+      if (res.status === 401) {
+        setAuthState('unauthenticated');
+        return;
+      }
+      if (res.status === 403) {
+        setAuthState('forbidden');
+        return;
+      }
+      if (!res.ok) {
+        setError('Failed to load users');
+        return;
+      }
+      const data = await res.json();
+      if (id !== requestId.current) return;
+      setUsers(data.users ?? []);
+      setTotal(data.total ?? 0);
+      if (data.summary) setSummary(data.summary);
+      setAuthState('ok');
+    } catch {
+      if (id === requestId.current) setError('Network error');
+    } finally {
+      if (id === requestId.current) setLoading(false);
+    }
+  }, [queryString]);
+
+  useEffect(() => {
+    void fetchUsers();
+  }, [fetchUsers]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sort) {
+      setDir((d) => (d === 'desc' ? 'asc' : 'desc'));
+    } else {
+      setSort(key);
+      // Names read best A-Z; every metric reads best biggest-first.
+      setDir(key === 'email' ? 'asc' : 'desc');
+    }
+    setOffset(0);
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    setError(null);
+    try {
+      // Exports everything matching the current search, not just this page —
+      // 500 is the server's ceiling.
+      const res = await fetch(`/api/admin/users?${queryString({ limit: 500, offset: 0, summary: '0' })}`, {
+        headers: authHeaders(),
+      });
+      if (!res.ok) {
+        setError('Export failed');
+        return;
+      }
+      const data = await res.json();
+      const rows: UserRow[] = data.users ?? [];
+      const blob = new Blob([toCsv(rows)], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `coinpay-users-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      if (data.total > rows.length) {
+        setError(`Exported the first ${rows.length} of ${data.total} users — narrow the search for the rest.`);
+      }
+    } catch {
+      setError('Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const pageEnd = useMemo(() => Math.min(offset + users.length, total), [offset, users.length, total]);
+
+  if (authState === 'unauthenticated') {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-gray-300 mb-4">You need to log in.</p>
+        <Link href="/login" className="text-purple-400 hover:underline">Log in →</Link>
+      </div>
+    );
+  }
+
+  if (authState === 'forbidden') {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-red-400 mb-2">403 — Forbidden</p>
+        <p className="text-gray-400 mb-4">This area is restricted to administrators.</p>
+        <Link href="/dashboard" className="text-purple-400 hover:underline">Back to dashboard →</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="mb-2 flex items-baseline gap-3">
+        <Link href="/admin" className="text-sm text-gray-400 hover:text-purple-300">← Admin</Link>
+      </div>
+      <h1 className="text-3xl font-bold text-white mb-2">Users</h1>
+      <p className="text-gray-400 mb-8">
+        Every merchant account, with their activity and USD volume across crypto payments, invoices, escrows and Stripe.
+      </p>
+
+      {summary && (
+        <section className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
+          <StatTile label="Users" value={count(summary.usersTotal)} sub={`+${count(summary.usersNew7d)} in 7d · +${count(summary.usersNew30d)} in 30d`} />
+          <StatTile label="Logged in 30d" value={count(summary.usersActive30d)} sub={`of ${count(summary.usersTotal)}`} />
+          <StatTile label="Businesses" value={count(summary.businessesTotal)} sub={`${count(summary.businessesActive)} active`} />
+          <StatTile label="Crypto volume" value={usd(summary.paymentsVolumeUsd)} sub={`${count(summary.paymentsSettled)} of ${count(summary.paymentsTotal)} settled`} />
+          <StatTile label="Stripe volume" value={usd(summary.stripeVolumeUsd)} sub={`${count(summary.stripeCompleted)} completed`} />
+          <StatTile label="Invoiced" value={usd(summary.invoicesPaidUsd)} sub={`${count(summary.invoicesPaid)} of ${count(summary.invoicesTotal)} paid`} />
+        </section>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded border border-red-500/50 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <input
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search email or name…"
+          className="min-w-[16rem] flex-1 rounded bg-slate-950 px-3 py-2 text-sm text-white border border-slate-700 focus:border-purple-500 focus:outline-none"
+        />
+        <button
+          onClick={handleExport}
+          disabled={exporting}
+          className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20 disabled:opacity-50"
+        >
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
+        <button
+          onClick={() => void fetchUsers()}
+          disabled={loading}
+          className="text-sm text-gray-400 hover:text-purple-300 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900/50">
+        <table className="w-full min-w-[56rem] text-sm">
+          <thead>
+            <tr className="border-b border-slate-700 text-xs uppercase tracking-wide text-gray-400">
+              {COLUMNS.map((col) => (
+                <th
+                  key={col.key}
+                  title={col.title}
+                  className={`px-3 py-3 font-medium ${col.numeric ? 'text-right' : 'text-left'}`}
+                >
+                  <button
+                    onClick={() => toggleSort(col.key)}
+                    className={`hover:text-purple-300 ${sort === col.key ? 'text-purple-300' : ''}`}
+                  >
+                    {col.label}
+                    {sort === col.key && <span className="ml-1">{dir === 'desc' ? '↓' : '↑'}</span>}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {users.length === 0 && !loading && (
+              <tr>
+                <td colSpan={COLUMNS.length} className="px-3 py-8 text-center text-gray-400">
+                  {search.trim() ? `No users match “${search.trim()}”.` : 'No users yet.'}
+                </td>
+              </tr>
+            )}
+            {users.map((u) => {
+              const isOpen = expanded === u.id;
+              return (
+                <tr
+                  key={u.id}
+                  onClick={() => setExpanded(isOpen ? null : u.id)}
+                  className="cursor-pointer border-b border-slate-800 last:border-0 hover:bg-slate-800/40"
+                >
+                  <td className="px-3 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-white">{u.name || u.email.split('@')[0]}</span>
+                      {u.isAdmin && (
+                        <span className="rounded bg-purple-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-purple-300">
+                          admin
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-400">{u.email}</div>
+                    {isOpen && (
+                      <div className="mt-2 space-y-0.5 text-xs text-gray-400">
+                        <div>Plan: {u.subscriptionPlanId ?? '—'} ({u.subscriptionStatus ?? '—'})</div>
+                        <div>Auth: {u.authProvider ?? '—'}</div>
+                        <div>Businesses: {count(u.activeBusinessesCount)} active of {count(u.businessesCount)}</div>
+                        <div>Escrows: {count(u.escrowsSettled)} settled of {count(u.escrowsTotal)} · {usd(u.escrowVolumeUsd)}</div>
+                        <div>Invoices: {usd(u.invoicesPaidUsd)} paid · {usd(u.invoiceFeesUsd)} fees</div>
+                        <div>Stripe: {count(u.stripeCompleted)} of {count(u.stripeTotal)} completed</div>
+                        <div>Last login: {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleString() : 'never'}</div>
+                        <div className="font-mono text-[10px] text-gray-600">{u.id}</div>
+                      </div>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-gray-300">{shortDate(u.createdAt)}</td>
+                  <td className="whitespace-nowrap px-3 py-3 text-gray-300" title={u.lastActivityAt ?? ''}>
+                    {relative(u.lastActivityAt)}
+                  </td>
+                  <td className="px-3 py-3 text-right text-gray-300">{count(u.businessesCount)}</td>
+                  <td className="px-3 py-3 text-right text-gray-300">
+                    {count(u.paymentsSettled)}
+                    <span className="text-gray-500"> / {count(u.paymentsTotal)}</span>
+                  </td>
+                  <td className="px-3 py-3 text-right text-gray-300">{usd(u.settledVolumeUsd)}</td>
+                  <td className="px-3 py-3 text-right text-gray-300">
+                    {count(u.invoicesPaid)}
+                    <span className="text-gray-500"> / {count(u.invoicesTotal)}</span>
+                  </td>
+                  <td className="px-3 py-3 text-right text-gray-300">{usd(u.stripeVolumeUsd)}</td>
+                  <td className="px-3 py-3 text-right font-medium text-white">{usd(u.totalVolumeUsd)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-gray-400">
+        <span>
+          {total === 0 ? 'No users' : `${count(offset + 1)}–${count(pageEnd)} of ${count(total)}`}
+          {search.trim() && ' (filtered)'}
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setOffset((o) => Math.max(o - PAGE_SIZE, 0))}
+            disabled={offset === 0 || loading}
+            className="rounded border border-slate-700 px-3 py-1 hover:text-purple-300 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            onClick={() => setOffset((o) => o + PAGE_SIZE)}
+            disabled={pageEnd >= total || loading}
+            className="rounded border border-slate-700 px-3 py-1 hover:text-purple-300 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-6 text-xs text-gray-500">
+        USD columns cover settled crypto payments, paid USD-denominated invoices, settled escrows and completed Stripe
+        charges. Invoices priced in crypto are counted but not added to USD totals, and platform fees on crypto payments
+        are held in chain units, so they are not summed here.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,14 @@
+import { requireAdminPage } from '@/lib/auth/admin-guard';
+import UsersContent from './UsersContent';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Users · Admin · CoinPay',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminUsersPage() {
+  await requireAdminPage('/admin/users');
+  return <UsersContent />;
+}

--- a/src/app/api/admin/users/route.test.ts
+++ b/src/app/api/admin/users/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth/admin-guard', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/stats/admin-user-stats', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/stats/admin-user-stats')>(
+    '@/lib/stats/admin-user-stats',
+  );
+  return {
+    ...actual,
+    getAdminUserStats: vi.fn(),
+    getAdminPlatformStats: vi.fn(),
+  };
+});
+
+import { GET } from './route';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getAdminUserStats, getAdminPlatformStats } from '@/lib/stats/admin-user-stats';
+
+const admin = { id: 'admin-1', email: 'admin@example.com', is_admin: true as const };
+
+const emptyPage = { rows: [], total: 0, limit: 50, offset: 0 };
+
+function req(query = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/admin/users${query}`);
+}
+
+describe('GET /api/admin/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue(admin);
+    vi.mocked(getAdminUserStats).mockResolvedValue(emptyPage);
+    vi.mocked(getAdminPlatformStats).mockResolvedValue({ usersTotal: 3 } as never);
+  });
+
+  describe('authorization', () => {
+    it('propagates the guard response for a non-admin and never reads any stats', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue(
+        NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+      );
+
+      const res = await GET(req());
+
+      expect(res.status).toBe(403);
+      expect(getAdminUserStats).not.toHaveBeenCalled();
+      expect(getAdminPlatformStats).not.toHaveBeenCalled();
+    });
+
+    it('propagates a 401 for an unauthenticated caller', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue(
+        NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+      );
+
+      const res = await GET(req());
+
+      expect(res.status).toBe(401);
+      expect(getAdminUserStats).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('query parameters', () => {
+    it('defaults to last activity, descending, first page', async () => {
+      await GET(req());
+
+      expect(getAdminUserStats).toHaveBeenCalledWith({
+        search: null,
+        sort: 'last_activity_at',
+        direction: 'desc',
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    it('passes through a recognised sort key and direction', async () => {
+      await GET(req('?sort=total_volume_usd&dir=asc&search=acme&limit=10&offset=20'));
+
+      expect(getAdminUserStats).toHaveBeenCalledWith({
+        search: 'acme',
+        sort: 'total_volume_usd',
+        direction: 'asc',
+        limit: 10,
+        offset: 20,
+      });
+    });
+
+    it('falls back to the default sort when the key is not recognised', async () => {
+      await GET(req('?sort=password_hash&dir=sideways'));
+
+      expect(getAdminUserStats).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'last_activity_at', direction: 'desc' }),
+      );
+    });
+
+    it('clamps an oversized limit and a negative offset', async () => {
+      await GET(req('?limit=100000&offset=-5'));
+
+      expect(getAdminUserStats).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 500, offset: 0 }),
+      );
+    });
+
+    it('uses defaults when limit and offset are not numbers', async () => {
+      await GET(req('?limit=abc&offset=xyz'));
+
+      expect(getAdminUserStats).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, offset: 0 }),
+      );
+    });
+  });
+
+  describe('summary', () => {
+    it('includes platform totals by default', async () => {
+      const res = await GET(req());
+      const body = await res.json();
+
+      expect(getAdminPlatformStats).toHaveBeenCalled();
+      expect(body.summary).toEqual({ usersTotal: 3 });
+    });
+
+    it('skips the platform totals when summary=0', async () => {
+      const res = await GET(req('?summary=0'));
+      const body = await res.json();
+
+      expect(getAdminPlatformStats).not.toHaveBeenCalled();
+      expect(body.summary).toBeNull();
+    });
+  });
+
+  it('never caches — the response is every user on the platform', async () => {
+    const res = await GET(req());
+
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns 500 rather than an empty page when the query fails', async () => {
+    vi.mocked(getAdminUserStats).mockRejectedValue(new Error('boom'));
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await GET(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.users).toBeUndefined();
+    spy.mockRestore();
+  });
+});

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import {
+  getAdminPlatformStats,
+  getAdminUserStats,
+  parseSortDirection,
+  parseSortKey,
+} from '@/lib/stats/admin-user-stats';
+
+/**
+ * GET /api/admin/users — per-user statistics for the admin console.
+ *
+ * Every row here is another merchant's business data, so the admin check is
+ * the whole security boundary: the underlying Postgres functions are granted
+ * to `service_role` only and are unreachable from a browser session.
+ *
+ * `?summary=0` skips the platform totals. The table refetches on every sort,
+ * page and search change, and the totals do not vary with any of them.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const params = req.nextUrl.searchParams;
+  const search = params.get('search');
+  const sort = parseSortKey(params.get('sort'));
+  const direction = parseSortDirection(params.get('dir'));
+
+  // Clamped again in SQL; parsed here so a non-numeric ?limit=abc becomes the
+  // default rather than NaN.
+  const parsedLimit = Number.parseInt(params.get('limit') ?? '', 10);
+  const parsedOffset = Number.parseInt(params.get('offset') ?? '', 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), 500) : 50;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  const wantsSummary = params.get('summary') !== '0';
+
+  try {
+    const [page, summary] = await Promise.all([
+      getAdminUserStats({ search, sort, direction, limit, offset }),
+      wantsSummary ? getAdminPlatformStats() : Promise.resolve(null),
+    ]);
+
+    return NextResponse.json(
+      { users: page.rows, total: page.total, limit: page.limit, offset: page.offset, sort, dir: direction, summary },
+      // Never cache: this is per-admin data about every user on the platform.
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (err) {
+    console.error('[admin/users] failed to load stats', err);
+    return NextResponse.json({ error: 'Failed to load user stats' }, { status: 500 });
+  }
+}

--- a/src/lib/stats/admin-user-stats.test.ts
+++ b/src/lib/stats/admin-user-stats.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rpc = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: () => ({ rpc }),
+}));
+
+import {
+  getAdminUserStats,
+  getAdminPlatformStats,
+  parseSortKey,
+  parseSortDirection,
+} from './admin-user-stats';
+
+describe('parseSortKey', () => {
+  it('accepts every documented sort key', () => {
+    expect(parseSortKey('total_volume_usd')).toBe('total_volume_usd');
+    expect(parseSortKey('email')).toBe('email');
+  });
+
+  it('rejects anything else so a column name cannot be smuggled through', () => {
+    expect(parseSortKey('password_hash')).toBe('last_activity_at');
+    expect(parseSortKey('')).toBe('last_activity_at');
+    expect(parseSortKey(null)).toBe('last_activity_at');
+    expect(parseSortKey(undefined)).toBe('last_activity_at');
+  });
+});
+
+describe('parseSortDirection', () => {
+  it('only asc turns the sort around', () => {
+    expect(parseSortDirection('asc')).toBe('asc');
+    expect(parseSortDirection('ASC')).toBe('asc');
+    expect(parseSortDirection('desc')).toBe('desc');
+    expect(parseSortDirection('nonsense')).toBe('desc');
+    expect(parseSortDirection(null)).toBe('desc');
+  });
+});
+
+describe('getAdminUserStats', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps snake_case columns and coerces numeric strings', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        total: '285',
+        limit: 50,
+        offset: '0',
+        rows: [
+          {
+            id: 'user-1',
+            email: 'a@example.com',
+            name: 'Acme',
+            is_admin: false,
+            auth_provider: 'self',
+            subscription_plan_id: 'starter',
+            subscription_status: 'active',
+            created_at: '2026-07-05T00:00:00Z',
+            last_login_at: null,
+            last_activity_at: '2026-08-10T00:00:00Z',
+            businesses_count: 2,
+            active_businesses_count: 2,
+            payments_total: 479,
+            payments_settled: 240,
+            // Postgres sends numeric over the wire as a string.
+            settled_volume_usd: '14644.50',
+            invoices_total: 47,
+            invoices_paid: 25,
+            invoices_paid_usd: '2908.08',
+            invoice_fees_usd: '29.08080000',
+            escrows_total: 0,
+            escrows_settled: 0,
+            escrow_volume_usd: 0,
+            stripe_total: 793,
+            stripe_completed: 493,
+            stripe_volume_usd: '29024.580000000000',
+            total_volume_usd: '46577.160000000000',
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const page = await getAdminUserStats({ search: '  acme  ', sort: 'email', direction: 'asc' });
+
+    expect(page.total).toBe(285);
+    const [row] = page.rows;
+    expect(row.settledVolumeUsd).toBe(14644.5);
+    expect(row.stripeVolumeUsd).toBeCloseTo(29024.58, 2);
+    expect(row.totalVolumeUsd).toBeCloseTo(46577.16, 2);
+    expect(row.isAdmin).toBe(false);
+    expect(row.lastLoginAt).toBeNull();
+    expect(row.subscriptionPlanId).toBe('starter');
+  });
+
+  it('trims the search term and sends null for a blank one', async () => {
+    rpc.mockResolvedValue({ data: { total: 0, rows: [] }, error: null });
+
+    await getAdminUserStats({ search: '   ' });
+
+    expect(rpc).toHaveBeenCalledWith('admin_user_stats', expect.objectContaining({ p_search: null }));
+  });
+
+  it('forwards paging and sort arguments to the function', async () => {
+    rpc.mockResolvedValue({ data: { total: 0, rows: [] }, error: null });
+
+    await getAdminUserStats({ sort: 'created_at', direction: 'asc', limit: 25, offset: 75 });
+
+    expect(rpc).toHaveBeenCalledWith('admin_user_stats', {
+      p_search: null,
+      p_sort: 'created_at',
+      p_dir: 'asc',
+      p_limit: 25,
+      p_offset: 75,
+    });
+  });
+
+  it('tolerates a response with no rows array', async () => {
+    rpc.mockResolvedValue({ data: { total: 0 }, error: null });
+
+    await expect(getAdminUserStats()).resolves.toEqual({ rows: [], total: 0, limit: 0, offset: 0 });
+  });
+
+  it('throws instead of reporting zero users when the query fails', async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: 'permission denied' } });
+
+    await expect(getAdminUserStats()).rejects.toThrow(/permission denied/);
+  });
+});
+
+describe('getAdminPlatformStats', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps the platform totals', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        users_total: 285,
+        users_new_7d: 19,
+        users_new_30d: 81,
+        users_active_30d: 13,
+        businesses_total: 108,
+        businesses_active: 108,
+        payments_total: 2212,
+        payments_settled: 752,
+        payments_volume_usd: '24163.83',
+        invoices_total: 105,
+        invoices_paid: 27,
+        invoices_paid_usd: '3036.78',
+        escrows_total: 39,
+        escrows_settled: 5,
+        escrow_volume_usd: '102.98',
+        stripe_completed: 646,
+        stripe_volume_usd: '37493.280000000000',
+      },
+      error: null,
+    });
+
+    const stats = await getAdminPlatformStats();
+
+    expect(stats.usersTotal).toBe(285);
+    expect(stats.usersNew7d).toBe(19);
+    expect(stats.paymentsVolumeUsd).toBe(24163.83);
+    expect(stats.stripeVolumeUsd).toBeCloseTo(37493.28, 2);
+  });
+
+  it('throws when the function is unreachable', async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: 'function does not exist' } });
+
+    await expect(getAdminPlatformStats()).rejects.toThrow(/function does not exist/);
+  });
+});

--- a/src/lib/stats/admin-user-stats.ts
+++ b/src/lib/stats/admin-user-stats.ts
@@ -1,0 +1,222 @@
+/**
+ * Per-user statistics for the admin console.
+ *
+ * Thin typed wrapper over the `admin_user_stats()` and `admin_platform_stats()`
+ * Postgres functions. Both are granted to `service_role` only and are reached
+ * through `/api/admin/users`, behind `requireAdmin()` — this module does no
+ * authorization of its own, so nothing outside an admin-guarded route should
+ * import it.
+ *
+ * Postgres returns `numeric` as a string over the wire (it does not fit a JS
+ * number safely in general), so every figure is normalised through `toNumber`
+ * here rather than in the component. A `NaN` in a currency column would render
+ * as "$NaN" in the table, which is worse than a zero.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+
+/** Sort keys the Postgres function accepts. Anything else falls back server-side. */
+export const USER_SORT_KEYS = [
+  'email',
+  'name',
+  'created_at',
+  'last_login_at',
+  'last_activity_at',
+  'businesses_count',
+  'payments_total',
+  'payments_settled',
+  'settled_volume_usd',
+  'invoices_total',
+  'invoices_paid_usd',
+  'escrows_total',
+  'stripe_volume_usd',
+  'total_volume_usd',
+] as const;
+
+export type UserSortKey = (typeof USER_SORT_KEYS)[number];
+export type SortDirection = 'asc' | 'desc';
+
+export interface AdminUserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  isAdmin: boolean;
+  authProvider: string | null;
+  subscriptionPlanId: string | null;
+  subscriptionStatus: string | null;
+  createdAt: string;
+  lastLoginAt: string | null;
+  /** Most recent of: login, business, payment, invoice, escrow, Stripe charge. */
+  lastActivityAt: string | null;
+  businessesCount: number;
+  activeBusinessesCount: number;
+  paymentsTotal: number;
+  paymentsSettled: number;
+  settledVolumeUsd: number;
+  invoicesTotal: number;
+  invoicesPaid: number;
+  /** USD-denominated paid invoices only — crypto-denominated ones are counted, not summed. */
+  invoicesPaidUsd: number;
+  invoiceFeesUsd: number;
+  escrowsTotal: number;
+  escrowsSettled: number;
+  escrowVolumeUsd: number;
+  stripeTotal: number;
+  stripeCompleted: number;
+  stripeVolumeUsd: number;
+  /** Settled crypto + paid invoices + settled escrows + completed Stripe. */
+  totalVolumeUsd: number;
+}
+
+export interface AdminUserPage {
+  rows: AdminUserRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AdminPlatformStats {
+  usersTotal: number;
+  usersNew7d: number;
+  usersNew30d: number;
+  usersActive30d: number;
+  businessesTotal: number;
+  businessesActive: number;
+  paymentsTotal: number;
+  paymentsSettled: number;
+  paymentsVolumeUsd: number;
+  invoicesTotal: number;
+  invoicesPaid: number;
+  invoicesPaidUsd: number;
+  escrowsTotal: number;
+  escrowsSettled: number;
+  escrowVolumeUsd: number;
+  stripeCompleted: number;
+  stripeVolumeUsd: number;
+}
+
+type Numeric = number | string | null | undefined;
+
+function toNumber(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Narrow an arbitrary string to a sort key, falling back to last activity. */
+export function parseSortKey(value: string | null | undefined): UserSortKey {
+  return (USER_SORT_KEYS as readonly string[]).includes(value ?? '')
+    ? (value as UserSortKey)
+    : 'last_activity_at';
+}
+
+export function parseSortDirection(value: string | null | undefined): SortDirection {
+  return value?.toLowerCase() === 'asc' ? 'asc' : 'desc';
+}
+
+/** One row as it comes back from `admin_user_stats()`, before normalisation. */
+type RawUserRow = Record<string, string | number | boolean | null | undefined>;
+
+function mapRow(raw: unknown): AdminUserRow {
+  const row = (raw ?? {}) as RawUserRow;
+  const str = (v: unknown): string | null => (typeof v === 'string' && v ? v : null);
+  return {
+    id: String(row.id ?? ''),
+    email: String(row.email ?? ''),
+    name: str(row.name),
+    isAdmin: Boolean(row.is_admin),
+    authProvider: str(row.auth_provider),
+    subscriptionPlanId: str(row.subscription_plan_id),
+    subscriptionStatus: str(row.subscription_status),
+    createdAt: String(row.created_at ?? ''),
+    lastLoginAt: str(row.last_login_at),
+    lastActivityAt: str(row.last_activity_at),
+    businessesCount: toNumber(row.businesses_count),
+    activeBusinessesCount: toNumber(row.active_businesses_count),
+    paymentsTotal: toNumber(row.payments_total),
+    paymentsSettled: toNumber(row.payments_settled),
+    settledVolumeUsd: toNumber(row.settled_volume_usd),
+    invoicesTotal: toNumber(row.invoices_total),
+    invoicesPaid: toNumber(row.invoices_paid),
+    invoicesPaidUsd: toNumber(row.invoices_paid_usd),
+    invoiceFeesUsd: toNumber(row.invoice_fees_usd),
+    escrowsTotal: toNumber(row.escrows_total),
+    escrowsSettled: toNumber(row.escrows_settled),
+    escrowVolumeUsd: toNumber(row.escrow_volume_usd),
+    stripeTotal: toNumber(row.stripe_total),
+    stripeCompleted: toNumber(row.stripe_completed),
+    stripeVolumeUsd: toNumber(row.stripe_volume_usd),
+    totalVolumeUsd: toNumber(row.total_volume_usd),
+  };
+}
+
+export interface GetAdminUserStatsOptions {
+  search?: string | null;
+  sort?: UserSortKey;
+  direction?: SortDirection;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * One page of per-user statistics.
+ *
+ * Throws on failure rather than returning an empty page: unlike the public
+ * landing counters, a silent zero here would be indistinguishable from "you
+ * have no users", and the caller needs to surface the difference.
+ */
+export async function getAdminUserStats(
+  options: GetAdminUserStatsOptions = {},
+): Promise<AdminUserPage> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase.rpc('admin_user_stats', {
+    p_search: options.search?.trim() || null,
+    p_sort: options.sort ?? 'last_activity_at',
+    p_dir: options.direction ?? 'desc',
+    p_limit: options.limit ?? 50,
+    p_offset: options.offset ?? 0,
+  });
+
+  if (error || !data) {
+    throw new Error(`admin_user_stats failed: ${error?.message ?? 'no data'}`);
+  }
+
+  const payload = data as { rows?: unknown[]; total?: Numeric; limit?: Numeric; offset?: Numeric };
+  return {
+    rows: (payload.rows ?? []).map(mapRow),
+    total: toNumber(payload.total),
+    limit: toNumber(payload.limit),
+    offset: toNumber(payload.offset),
+  };
+}
+
+/** Platform-wide totals for the page header. Unaffected by the search filter. */
+export async function getAdminPlatformStats(): Promise<AdminPlatformStats> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase.rpc('admin_platform_stats');
+
+  if (error || !data) {
+    throw new Error(`admin_platform_stats failed: ${error?.message ?? 'no data'}`);
+  }
+
+  const raw = data as Record<string, Numeric>;
+  return {
+    usersTotal: toNumber(raw.users_total),
+    usersNew7d: toNumber(raw.users_new_7d),
+    usersNew30d: toNumber(raw.users_new_30d),
+    usersActive30d: toNumber(raw.users_active_30d),
+    businessesTotal: toNumber(raw.businesses_total),
+    businessesActive: toNumber(raw.businesses_active),
+    paymentsTotal: toNumber(raw.payments_total),
+    paymentsSettled: toNumber(raw.payments_settled),
+    paymentsVolumeUsd: toNumber(raw.payments_volume_usd),
+    invoicesTotal: toNumber(raw.invoices_total),
+    invoicesPaid: toNumber(raw.invoices_paid),
+    invoicesPaidUsd: toNumber(raw.invoices_paid_usd),
+    escrowsTotal: toNumber(raw.escrows_total),
+    escrowsSettled: toNumber(raw.escrows_settled),
+    escrowVolumeUsd: toNumber(raw.escrow_volume_usd),
+    stripeCompleted: toNumber(raw.stripe_completed),
+    stripeVolumeUsd: toNumber(raw.stripe_volume_usd),
+  };
+}

--- a/supabase/migrations/20260813120000_admin_user_stats.sql
+++ b/supabase/migrations/20260813120000_admin_user_stats.sql
@@ -1,0 +1,240 @@
+-- Per-user statistics for the admin console.
+--
+-- Answers "what is every user actually doing on this platform" in one query:
+-- signup, last activity, and their counts and USD volume across the four
+-- things a merchant can transact with (crypto payments, invoices, escrows,
+-- Stripe).
+--
+-- Two deliberate choices about money:
+--
+-- 1. `payments.fee_amount` and `escrows.fee_amount` are denominated in the
+--    chain's own units, not USD. Summing them across BTC, ETH, SOL and USDC
+--    would produce a number with no meaning, so platform fee revenue is not
+--    reported here. `invoices.fee_amount` *is* USD and is reported.
+-- 2. `invoices.amount` is mostly USD but a handful of rows are denominated in
+--    ETH/USDC_BASE. The USD column filters to `currency = 'USD'` so a 0.05 ETH
+--    invoice cannot be added to a $50 one; `invoices_total` still counts every
+--    invoice, so the count and the total will legitimately disagree.
+--
+-- "Settled" matches `public_landing_stats()`: confirmed, or confirmed and
+-- forwarded. Expired payment windows are excluded from volume but still
+-- counted in `payments_total`, which is what makes the settle rate readable.
+--
+-- Aggregation is per-merchant in separate CTEs rather than one wide join:
+-- joining businesses to payments *and* invoices *and* escrows in a single
+-- query fans out the row set and multiplies every count by the cardinality of
+-- the other branches.
+
+create or replace function public.admin_user_stats(
+  p_search text default null,
+  p_sort text default 'last_activity_at',
+  p_dir text default 'desc',
+  p_limit int default 50,
+  p_offset int default 0
+)
+returns json
+language plpgsql
+stable
+security invoker
+set search_path = public
+as $fn$
+declare
+  -- The aggregate is inlined into the dynamic statement below rather than
+  -- living in a view, so this function is the single object to grant, revoke
+  -- and reason about.
+  c_base constant text := $base$
+    with biz as (
+      select merchant_id,
+             count(*) as businesses_count,
+             count(*) filter (where active) as active_businesses_count,
+             max(created_at) as last_at
+      from businesses
+      group by merchant_id
+    ),
+    pay as (
+      select b.merchant_id,
+             count(*) as payments_total,
+             count(*) filter (where p.status in ('confirmed', 'forwarded')) as payments_settled,
+             coalesce(sum(p.amount) filter (where p.status in ('confirmed', 'forwarded')), 0) as settled_volume_usd,
+             max(p.created_at) as last_at
+      from payments p
+      join businesses b on b.id = p.business_id
+      group by b.merchant_id
+    ),
+    inv as (
+      select user_id as merchant_id,
+             count(*) as invoices_total,
+             count(*) filter (where status = 'paid') as invoices_paid,
+             coalesce(sum(amount) filter (where status = 'paid' and currency = 'USD'), 0) as invoices_paid_usd,
+             coalesce(sum(fee_amount) filter (where status = 'paid' and currency = 'USD'), 0) as invoice_fees_usd,
+             max(created_at) as last_at
+      from invoices
+      where user_id is not null
+      group by user_id
+    ),
+    esc as (
+      select b.merchant_id,
+             count(*) as escrows_total,
+             count(*) filter (where e.status = 'settled') as escrows_settled,
+             coalesce(sum(e.amount_usd) filter (where e.status = 'settled'), 0) as escrow_volume_usd,
+             max(e.created_at) as last_at
+      from escrows e
+      join businesses b on b.id = e.business_id
+      group by b.merchant_id
+    ),
+    stripe as (
+      select merchant_id,
+             count(*) as stripe_total,
+             count(*) filter (where status = 'completed') as stripe_completed,
+             -- stripe_transactions.amount is an integer count of minor units.
+             coalesce(sum(amount) filter (where status = 'completed'), 0) / 100.0 as stripe_volume_usd,
+             max(created_at at time zone 'UTC') as last_at
+      from stripe_transactions
+      where merchant_id is not null
+      group by merchant_id
+    )
+    select
+      m.id,
+      m.email,
+      m.name,
+      m.is_admin,
+      m.auth_provider,
+      m.subscription_plan_id,
+      m.subscription_status,
+      m.created_at,
+      m.last_login_at,
+      coalesce(biz.businesses_count, 0)         as businesses_count,
+      coalesce(biz.active_businesses_count, 0)  as active_businesses_count,
+      coalesce(pay.payments_total, 0)           as payments_total,
+      coalesce(pay.payments_settled, 0)         as payments_settled,
+      coalesce(pay.settled_volume_usd, 0)       as settled_volume_usd,
+      coalesce(inv.invoices_total, 0)           as invoices_total,
+      coalesce(inv.invoices_paid, 0)            as invoices_paid,
+      coalesce(inv.invoices_paid_usd, 0)        as invoices_paid_usd,
+      coalesce(inv.invoice_fees_usd, 0)         as invoice_fees_usd,
+      coalesce(esc.escrows_total, 0)            as escrows_total,
+      coalesce(esc.escrows_settled, 0)          as escrows_settled,
+      coalesce(esc.escrow_volume_usd, 0)        as escrow_volume_usd,
+      coalesce(stripe.stripe_total, 0)          as stripe_total,
+      coalesce(stripe.stripe_completed, 0)      as stripe_completed,
+      coalesce(stripe.stripe_volume_usd, 0)     as stripe_volume_usd,
+      coalesce(pay.settled_volume_usd, 0)
+        + coalesce(inv.invoices_paid_usd, 0)
+        + coalesce(esc.escrow_volume_usd, 0)
+        + coalesce(stripe.stripe_volume_usd, 0) as total_volume_usd,
+      -- greatest() ignores NULLs in Postgres, so a user who has never logged
+      -- in still reports their most recent transaction.
+      greatest(m.last_login_at, biz.last_at, pay.last_at, inv.last_at, esc.last_at, stripe.last_at)
+        as last_activity_at
+    from merchants m
+    left join biz    on biz.merchant_id    = m.id
+    left join pay    on pay.merchant_id    = m.id
+    left join inv    on inv.merchant_id    = m.id
+    left join esc    on esc.merchant_id    = m.id
+    left join stripe on stripe.merchant_id = m.id
+  $base$;
+
+  v_sort_col text;
+  v_dir text;
+  v_limit int;
+  v_offset int;
+  v_search text;
+  v_where text;
+  v_total bigint;
+  v_rows json;
+begin
+  -- Whitelist, not quote_ident: the caller supplies a sort *key*, never a
+  -- column name, so an unrecognised value falls back rather than reaching the
+  -- statement text.
+  v_sort_col := case p_sort
+    when 'email'              then 'email'
+    when 'name'               then 'name'
+    when 'created_at'         then 'created_at'
+    when 'last_login_at'      then 'last_login_at'
+    when 'last_activity_at'   then 'last_activity_at'
+    when 'businesses_count'   then 'businesses_count'
+    when 'payments_total'     then 'payments_total'
+    when 'payments_settled'   then 'payments_settled'
+    when 'settled_volume_usd' then 'settled_volume_usd'
+    when 'invoices_total'     then 'invoices_total'
+    when 'invoices_paid_usd'  then 'invoices_paid_usd'
+    when 'escrows_total'      then 'escrows_total'
+    when 'stripe_volume_usd'  then 'stripe_volume_usd'
+    when 'total_volume_usd'   then 'total_volume_usd'
+    else 'last_activity_at'
+  end;
+
+  v_dir    := case when lower(coalesce(p_dir, '')) = 'asc' then 'asc' else 'desc' end;
+  v_limit  := least(greatest(coalesce(p_limit, 50), 1), 500);
+  v_offset := greatest(coalesce(p_offset, 0), 0);
+  v_search := nullif(btrim(coalesce(p_search, '')), '');
+
+  v_where := case when v_search is null then '' else
+    ' where s.email ilike ''%'' || $1 || ''%'' or coalesce(s.name, '''') ilike ''%'' || $1 || ''%'' '
+  end;
+
+  execute format('select count(*) from (%s) s %s', c_base, v_where)
+    into v_total
+    using v_search;
+
+  -- The id tiebreak keeps pagination stable when the sort column ties, which
+  -- it does constantly: most users have zero of everything.
+  execute format(
+    'select coalesce(json_agg(row_to_json(t)), ''[]''::json) from ('
+      || 'select * from (%s) s %s order by s.%I %s nulls last, s.id asc limit %s offset %s'
+    || ') t',
+    c_base, v_where, v_sort_col, v_dir, v_limit, v_offset
+  )
+    into v_rows
+    using v_search;
+
+  return json_build_object('total', v_total, 'limit', v_limit, 'offset', v_offset, 'rows', v_rows);
+end;
+$fn$;
+
+comment on function public.admin_user_stats(text, text, text, int, int) is
+  'Per-user activity and USD volume for the admin console. Admin-gated in the '
+  'application layer (src/lib/auth/admin-guard.ts); service_role only here. '
+  'Excludes crypto-denominated fees, which are not summable as USD.';
+
+-- Platform-wide totals for the header of the same page. Deliberately a
+-- separate function: these are unaffected by the search filter, so folding
+-- them into the paged query would recompute a constant on every keystroke.
+create or replace function public.admin_platform_stats()
+returns json
+language sql
+stable
+security invoker
+set search_path = public
+as $fn$
+  select json_build_object(
+    'users_total',        (select count(*) from merchants),
+    'users_new_7d',       (select count(*) from merchants where created_at >= now() - interval '7 days'),
+    'users_new_30d',      (select count(*) from merchants where created_at >= now() - interval '30 days'),
+    'users_active_30d',   (select count(*) from merchants where last_login_at >= now() - interval '30 days'),
+    'businesses_total',   (select count(*) from businesses),
+    'businesses_active',  (select count(*) from businesses where active),
+    'payments_total',     (select count(*) from payments),
+    'payments_settled',   (select count(*) from payments where status in ('confirmed', 'forwarded')),
+    'payments_volume_usd',(select coalesce(sum(amount), 0) from payments where status in ('confirmed', 'forwarded')),
+    'invoices_total',     (select count(*) from invoices),
+    'invoices_paid',      (select count(*) from invoices where status = 'paid'),
+    'invoices_paid_usd',  (select coalesce(sum(amount), 0) from invoices where status = 'paid' and currency = 'USD'),
+    'escrows_total',      (select count(*) from escrows),
+    'escrows_settled',    (select count(*) from escrows where status = 'settled'),
+    'escrow_volume_usd',  (select coalesce(sum(amount_usd), 0) from escrows where status = 'settled'),
+    'stripe_completed',   (select count(*) from stripe_transactions where status = 'completed'),
+    'stripe_volume_usd',  (select coalesce(sum(amount), 0) / 100.0 from stripe_transactions where status = 'completed')
+  );
+$fn$;
+
+comment on function public.admin_platform_stats() is
+  'Platform-wide totals for the admin console header. service_role only.';
+
+-- Both functions read every merchant row on the platform, so neither is
+-- reachable by a browser: no grant to anon or authenticated. They are called
+-- server-side with the service role, behind requireAdmin().
+revoke all on function public.admin_user_stats(text, text, text, int, int) from public;
+revoke all on function public.admin_platform_stats() from public;
+grant execute on function public.admin_user_stats(text, text, text, int, int) to service_role;
+grant execute on function public.admin_platform_stats() to service_role;


### PR DESCRIPTION
Adds `/admin/users` — a sortable, searchable table of every merchant account with their activity and USD volume, plus platform-wide totals and a CSV export.

## What you get

**Header tiles** — users (with 7d/30d signups), logged-in-in-30d, businesses, crypto volume, Stripe volume, invoiced.

**Per-user row** — signed up, last active (most recent of login/payment/invoice/escrow/Stripe), businesses, settled/total payments, crypto USD, paid/total invoices, Stripe USD, and a combined total. Click a row to expand plan, auth provider, escrow and invoice-fee detail, and the merchant id.

Sort by any column, search by email or name, page through 50 at a time, export up to 500 matching rows as CSV.

## How it's built

| Piece | Where |
|---|---|
| Aggregation | `supabase/migrations/20260813120000_admin_user_stats.sql` — `admin_user_stats()` + `admin_platform_stats()` |
| Typed wrapper | `src/lib/stats/admin-user-stats.ts` |
| API | `src/app/api/admin/users/route.ts`, behind the existing `requireAdmin()` |
| UI | `src/app/admin/users/` |

Aggregation is in Postgres rather than the route, so a page of stats is one round trip instead of five queries per user. Both functions are granted to `service_role` only — no `anon`/`authenticated` grant, so a browser cannot reach them through PostgREST. Per-merchant CTEs are kept separate on purpose: joining businesses to payments *and* invoices *and* escrows in one query fans out the row set and multiplies every count by the cardinality of the other branches.

## Two things deliberately not reported

- **Crypto-denominated fees.** `payments.fee_amount` and `escrows.fee_amount` are in chain units. Summing 0.14 across BTC, ETH, SOL and USDC yields a meaningless number, so only invoice fees (which are USD) appear.
- **Crypto-priced invoices.** Four invoices are denominated in ETH/USDC_BASE. They're counted but excluded from the USD column, so the count and total legitimately disagree — the page footnote says so rather than silently adding 0.05 ETH to a dollar figure.

"Settled" matches `public_landing_stats()`: `confirmed` or `forwarded`. Expired payment windows stay in `payments_total`, which is what makes the settle rate readable.

## Migration is already applied

The two functions are live on `mlywdeoogwsebabohskk` (coinpayportal.com) — applied via the Supabase MCP, since no CI applies migrations for this repo. They're additive and read-only, so this branch is safe to merge whenever. Verified against prod: 285 users, 752 of 2,212 payments settled, \$24,163.83 crypto volume, \$37,493.28 Stripe.

## Checks

- `vitest run` — 272 files, 3781 passed, 3 skipped (21 of those are new)
- `tsc --noEmit` — clean
- `eslint` on touched paths — clean
- `next build --webpack` — compiles; `/admin/users` and `/api/admin/users` register as dynamic routes
- Search binding verified against prod: `' or 1=1--` returns 0 rows; unknown sort keys fall back; limit/offset clamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)