### PR TITLE
fix(admin): neutralize formulas in CSV exports

### DIFF
--- a/src/app/admin/users/UsersContent.test.tsx
+++ b/src/app/admin/users/UsersContent.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCsv } from './UsersContent';
+
+function user(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'user-1',
+    email: 'person@example.com',
+    name: 'Person',
+    isAdmin: false,
+    authProvider: 'email',
+    subscriptionPlanId: null,
+    subscriptionStatus: null,
+    createdAt: '2026-08-12T00:00:00Z',
+    lastLoginAt: null,
+    lastActivityAt: null,
+    businessesCount: 0,
+    activeBusinessesCount: 0,
+    paymentsTotal: 0,
+    paymentsSettled: 0,
+    settledVolumeUsd: 0,
+    invoicesTotal: 0,
+    invoicesPaid: 0,
+    invoicesPaidUsd: 0,
+    invoiceFeesUsd: 0,
+    escrowsTotal: 0,
+    escrowsSettled: 0,
+    escrowVolumeUsd: 0,
+    stripeTotal: 0,
+    stripeCompleted: 0,
+    stripeVolumeUsd: 0,
+    totalVolumeUsd: 0,
+    ...overrides,
+  };
+}
+
+describe('toCsv', () => {
+  it('neutralizes formula prefixes in user-controlled cells', () => {
+    const csv = toCsv([
+      user({ email: '+SUM(1)@example.com', name: '=1+1' }),
+      user({ email: 'safe@example.com', name: '\t@SUM(1)' }),
+    ] as never);
+
+    expect(csv).toContain("'+SUM(1)@example.com,'=1+1");
+    expect(csv).toContain("safe@example.com,'\t@SUM(1)");
+    expect(csv).not.toContain('\n+SUM(1)@example.com,=1+1');
+  });
+
+  it('still quotes commas and doubles embedded quotes', () => {
+    const csv = toCsv([user({ name: 'Doe, "Jane"' })] as never);
+
+    expect(csv).toContain('"Doe, ""Jane"""');
+  });
+});

--- a/src/app/admin/users/UsersContent.tsx
+++ b/src/app/admin/users/UsersContent.tsx
@@ -142,7 +142,7 @@ const CSV_COLUMNS: { header: string; value: (u: UserRow) => string | number }[] 
   { header: 'total_volume_usd', value: (u) => u.totalVolumeUsd },
 ];
 
-function toCsv(rows: UserRow[]): string {
+export function toCsv(rows: UserRow[]): string {
   const escape = (v: string | number): string => {
     const s = String(v);
     return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;

--- a/src/app/admin/users/UsersContent.tsx
+++ b/src/app/admin/users/UsersContent.tsx
@@ -144,8 +144,9 @@ const CSV_COLUMNS: { header: string; value: (u: UserRow) => string | number }[] 
 
 export function toCsv(rows: UserRow[]): string {
   const escape = (v: string | number): string => {
-    const s = String(v);
-    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    const raw = String(v);
+    const safe = typeof v === 'string' && /^[\u0000-\u0020]*[=+\-@]/.test(raw) ? `'${raw}` : raw;
+    return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
   };
   const lines = [CSV_COLUMNS.map((c) => c.header).join(',')];
   for (const row of rows) {


### PR DESCRIPTION
## Summary

- neutralize formula-like user strings before CSV serialization
- preserve numeric cells as numeric values
- retain correct escaping for commas, quotes, CR, and LF
- add regression coverage for direct and whitespace-prefixed formula markers

Closes #246

## Validation

- itest run src/app/admin/users/UsersContent.test.tsx src/app/api/admin/users/route.test.ts src/lib/stats/admin-user-stats.test.ts - 23 passed
- full itest run - 3,775 passed, 12 skipped
- focused ESLint - passed
- 	sc --noEmit - passed
- git diff --check - passed