### PR TITLE
feat(web-bot-auth): verify who is calling, not just that they paid

### DIFF
--- a/docs/WEB_BOT_AUTH.md
+++ b/docs/WEB_BOT_AUTH.md
@@ -1,0 +1,199 @@
+# Web Bot Auth
+
+Cryptographic identity for automated traffic. A bot signs its request with an
+Ed25519 key and publishes the matching public key at a well-known URL; the
+origin verifies the signature and learns **which** agent is calling, instead of
+guessing from a `User-Agent` string that anyone can type.
+
+CoinPay implements both halves:
+
+- **Verifier** — check signatures on requests arriving at your origin, and
+  resolve the signing key to a CoinPay DID and trust tier.
+- **Directory** — publish keys for CoinPay-hosted agents at
+  `/.well-known/http-message-signatures-directory`, so those agents are
+  verifiable by anyone who speaks Web Bot Auth, Cloudflare included.
+
+The point of pairing this with x402: identity, permission and payment resolve at
+the same hop. Cloudflare does that at their edge for sites behind their CDN.
+CoinPay does it for any origin.
+
+## The wire format
+
+Three headers, per the IETF HTTP Message Signatures drafts (RFC 9421):
+
+```
+Signature-Agent: "https://signature-agent.test"
+Signature-Input: sig1=("@authority" "signature-agent");created=1735689600;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U";alg="ed25519";expires=1735689900;tag="web-bot-auth"
+Signature: sig1=:jdq0SqOwHdyHr9+r5jw3iYZH6aNGKijYp/EstF4RQTQdi5N5YYKrD+mCT1HA1nZDsi6nJKuHxUi/5Syp3rLWBA==:
+```
+
+- `tag` **must** be `web-bot-auth`. Signatures tagged anything else are ignored.
+- `keyid` is the RFC 7638 JWK thumbprint (base64url) of the signing key.
+- `alg` is `ed25519`. Nothing else is accepted.
+- `Signature-Agent` points at the key directory. It is a structured-field
+  String, so the quotes are part of the value.
+
+### What must be covered
+
+At minimum `@authority`. It is what stops a signature captured at one origin
+being replayed against another. Cover anything else whose integrity matters —
+if you send a budget or a price header, sign it, or a middlebox can rewrite it.
+
+Components must resolve to ASCII. A non-ASCII value cannot round-trip through
+the signature base and is rejected rather than signed over in mangled form.
+
+### Freshness
+
+`created` and `expires` are both honoured, with 300s of clock-skew tolerance.
+A signature valid for more than **one hour** is rejected outright: at that
+point it is a bearer token, and anyone who observes it can replay it for as
+long as it lives. Keep them short — minutes, not hours.
+
+## Verifying requests
+
+```javascript
+const res = await fetch('https://coinpayportal.com/api/web-bot-auth/verify', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', 'x-api-key': 'cp_live_xxxxx' },
+  body: JSON.stringify({
+    method: request.method,
+    url: request.url,
+    headers: {
+      'signature': request.headers.get('signature'),
+      'signature-input': request.headers.get('signature-input'),
+      'signature-agent': request.headers.get('signature-agent'),
+    },
+  }),
+});
+
+const result = await res.json();
+```
+
+A verified, registered agent comes back as:
+
+```json
+{
+  "verified": true,
+  "keyid": "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
+  "agent_origin": "https://bot.example",
+  "covered_components": ["@authority", "signature-agent"],
+  "identity": { "known": true, "did": "did:web:bot.example", "label": "Crawler v2" },
+  "trust": { "tier": "B", "score": 64, "label": "Good", "risk_level": "medium" }
+}
+```
+
+An unsigned or badly signed request returns **HTTP 200** with
+`verified: false` and a `reason`. That is not an error — on a public endpoint
+most callers are unsigned, and what to do about it is your decision, not the
+facilitator's.
+
+### Reading the result honestly
+
+Three distinct states, easy to conflate and expensive to get wrong:
+
+| State | Meaning |
+|---|---|
+| `verified: false` | No usable signature. You know nothing about the caller. |
+| `verified: true`, `identity.known: false` | The caller **is** who they say they are, cryptographically. They have simply never registered with CoinPay. |
+| `verified: true`, `identity.known: true` | Verified *and* bound to a DID, with a trust tier attached. |
+
+`known: false` means **unknown, not untrusted**. Every legitimate agent that has
+never registered here looks exactly like that. Blocking on it blocks the honest
+majority.
+
+`trust` is `null` unless the key is bound to a DID with enough history to score.
+
+### Failure reasons
+
+| `reason` | Meaning |
+|---|---|
+| `missing_headers` | No `Signature`/`Signature-Input`, or no `Signature-Agent` |
+| `no_web_bot_auth_signature` | Signatures present, none tagged `web-bot-auth` |
+| `missing_keyid` | No `keyid` parameter |
+| `unsupported_algorithm` | `alg` is not `ed25519` |
+| `expired` / `not_yet_valid` | Outside the `created`/`expires` window |
+| `lifetime_too_long` | Valid for more than an hour |
+| `unknown_key` | `keyid` is not in the agent's directory |
+| `directory_error` | The directory could not be fetched or parsed |
+| `bad_signature` | Signature did not verify over the reconstructed base |
+| `malformed` | Unparseable headers, or a covered component absent from the request |
+
+`directory_error` is deliberately distinct from `bad_signature`: an unreachable
+directory is an availability problem, not evidence of a forgery.
+
+## Registering a key
+
+Binding a key to a DID is what turns an anonymous-but-verified caller into one
+with a reputation.
+
+```bash
+curl -X POST https://coinpayportal.com/api/web-bot-auth/keys \
+  -H "authorization: Bearer $COINPAY_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "jwk": { "kty": "OKP", "crv": "Ed25519", "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" },
+    "signature_agent": "https://bot.example",
+    "agent_did": "did:web:bot.example",
+    "label": "Crawler v2"
+  }'
+```
+
+Returns `201` with the `keyid` your signer must put in `Signature-Input`.
+
+Notes:
+
+- The thumbprint is **always recomputed** from the JWK. It is the join key
+  between a signature and an identity, so it is never taken from input.
+- `agent_did` must already be registered to your account, or you get `403`.
+  Otherwise anyone could bind their key to someone else's reputation.
+- A registration is scoped to its `signature_agent`. Republishing another
+  operator's public key at your own directory does **not** inherit their
+  identity — the origin is checked at resolve time.
+- Only `kty`/`crv`/`x` are stored. A JWK containing a private `d` is rejected
+  outright rather than quietly stripped, because an operator who pastes one
+  needs to know it was exposed.
+
+## Publishing keys (the directory)
+
+Set `published: true` to have CoinPay serve a key from its own directory at
+`/.well-known/http-message-signatures-directory`, with content type
+`application/http-message-signatures-directory+json`.
+
+A published key cannot also declare an external `signature_agent` — two
+directories claiming the same key would disagree about who owns it.
+
+The directory is cached for 300s. Keep it short: verifiers re-read it to pick up
+rotations and revocations, and a long TTL keeps a revoked key alive downstream.
+
+## Fetching directories safely
+
+Verification fetches a URL supplied by the caller, which is a
+server-side-request-forgery primitive if left open. The fetch is therefore
+HTTPS-only, redirect-refusing, 5s-timeout, 128KB-capped, and rejects private and
+link-local address literals (`localhost`, `127.0.0.0/8`, `10/8`,
+`192.168/16`, `172.16/12`, `169.254/16`, IPv6 ULA/loopback).
+
+This blocks address literals. It is **not** complete DNS-rebinding protection —
+a hostname that resolves to an internal address at connect time will still be
+attempted. Run it somewhere without interesting internal services, or put an
+egress policy in front of it.
+
+## What this does not do
+
+- **No nonce replay cache.** `nonce` is parsed but not checked against a store,
+  so a signature can be replayed within its validity window. Short `expires`
+  values are what bound the exposure. Cloudflare does not validate nonces today
+  either.
+- **No allowlist of known operators.** CoinPay verifies signatures and resolves
+  registered keys; it does not maintain a curated list of "real" crawler
+  operators the way a CDN does.
+- **No purpose signal.** Distinguishing search from agent from training traffic,
+  and pricing those differently, is a separate piece of work.
+
+## References
+
+- [RFC 9421 — HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421.html)
+- [RFC 7638 — JWK Thumbprint](https://www.rfc-editor.org/rfc/rfc7638.html)
+- [RFC 8037 — Ed25519 for JOSE](https://www.rfc-editor.org/rfc/rfc8037.html)
+- [Cloudflare: Web Bot Auth](https://developers.cloudflare.com/bots/concepts/bot/verified-bots/web-bot-auth/)
+- [`docs/X402_INTEGRATION.md`](./X402_INTEGRATION.md) — the payment half

--- a/src/app/.well-known/http-message-signatures-directory/route.ts
+++ b/src/app/.well-known/http-message-signatures-directory/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /.well-known/http-message-signatures-directory
+ *
+ * CoinPay's Web Bot Auth key directory: the JWKS that verifiers fetch to check
+ * signatures from agents CoinPay hosts. Publishing it is what makes those
+ * agents verifiable by anyone who speaks Web Bot Auth — Cloudflare included —
+ * rather than only by CoinPay.
+ *
+ * Public and unauthenticated by design. It contains public keys only.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { DIRECTORY_CONTENT_TYPE, isEd25519Jwk } from '@/lib/web-bot-auth';
+
+export const dynamic = 'force-dynamic';
+
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase not configured');
+  return createClient(url, key);
+}
+
+export async function GET() {
+  try {
+    const supabase = getSupabase();
+    const nowIso = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from('web_bot_auth_keys')
+      .select('jwk, not_before, expires_at')
+      .eq('published', true)
+      .eq('active', true)
+      .is('revoked_at', null);
+
+    if (error) {
+      console.error('web-bot-auth directory query failed', error);
+      return NextResponse.json({ error: 'Directory unavailable' }, { status: 503 });
+    }
+
+    const keys = (data ?? [])
+      .filter((row) => {
+        // Serving a key outside its stated window would invite verifiers to
+        // accept signatures the operator considers retired.
+        if (row.not_before && row.not_before > nowIso) return false;
+        if (row.expires_at && row.expires_at <= nowIso) return false;
+        return true;
+      })
+      .map((row) => row.jwk)
+      .filter(isEd25519Jwk);
+
+    return new NextResponse(JSON.stringify({ keys }), {
+      status: 200,
+      headers: {
+        'content-type': DIRECTORY_CONTENT_TYPE,
+        // Short cache: verifiers re-read this to pick up rotations and
+        // revocations, and a long TTL keeps a revoked key alive downstream.
+        'cache-control': 'public, max-age=300, must-revalidate',
+      },
+    });
+  } catch (err) {
+    console.error('web-bot-auth directory error', err);
+    return NextResponse.json({ error: 'Directory unavailable' }, { status: 503 });
+  }
+}

--- a/src/app/api/web-bot-auth/keys/route.ts
+++ b/src/app/api/web-bot-auth/keys/route.ts
@@ -1,0 +1,165 @@
+/**
+ * Web Bot Auth key registry API
+ *
+ *   POST /api/web-bot-auth/keys  — register a public key against an identity
+ *   GET  /api/web-bot-auth/keys  — list the caller's registered keys
+ *
+ * Registering a key is what turns an anonymous-but-verified signature into a
+ * CoinPay identity with a DID and a reputation behind it.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { authenticateRequest } from '@/lib/auth/middleware';
+import { registerAgentKey } from '@/lib/web-bot-auth/identity';
+import { isEd25519Jwk, jwkThumbprint } from '@/lib/web-bot-auth';
+
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase not configured');
+  return createClient(url, key);
+}
+
+const jwkSchema = z.object({
+  kty: z.literal('OKP'),
+  crv: z.literal('Ed25519'),
+  x: z.string().min(1),
+  // Reject a private key outright rather than silently discarding `d`: an
+  // operator who pastes one needs to know it was exposed, not have it ignored.
+  d: z.never().optional(),
+});
+
+const registerSchema = z.object({
+  jwk: jwkSchema,
+  signature_agent: z.string().url().optional(),
+  agent_did: z.string().startsWith('did:').optional(),
+  label: z.string().max(200).optional(),
+  /** Serve this key from CoinPay's own directory. */
+  published: z.boolean().optional(),
+});
+
+/** Resolve the merchant behind either a JWT or an API key. */
+async function resolveMerchantId(
+  supabase: ReturnType<typeof getSupabase>,
+  request: NextRequest
+): Promise<string | null> {
+  const auth = await authenticateRequest(
+    supabase,
+    request.headers.get('authorization')
+  );
+  if (!auth.success || !auth.context) return null;
+  // Both contexts carry the owning merchant; a business key acts for its owner.
+  return auth.context.merchantId;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = getSupabase();
+
+    const merchantId = await resolveMerchantId(supabase, request);
+    if (!merchantId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = registerSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ') },
+        { status: 400 }
+      );
+    }
+
+    const { jwk, signature_agent, agent_did, label, published } = parsed.data;
+    if (!isEd25519Jwk(jwk)) {
+      return NextResponse.json({ error: 'Not a valid Ed25519 public JWK' }, { status: 400 });
+    }
+
+    // A key published from CoinPay's directory must not also claim to live at
+    // someone else's, or the two directories would disagree about who owns it.
+    if (published && signature_agent) {
+      return NextResponse.json(
+        { error: 'A published key cannot also declare an external signature_agent' },
+        { status: 400 }
+      );
+    }
+
+    // Only bind a DID the caller actually controls.
+    if (agent_did) {
+      const { data: owned } = await supabase
+        .from('merchant_dids')
+        .select('did')
+        .eq('did', agent_did)
+        .eq('merchant_id', merchantId)
+        .maybeSingle();
+
+      if (!owned) {
+        return NextResponse.json(
+          { error: 'agent_did is not registered to this account' },
+          { status: 403 }
+        );
+      }
+    }
+
+    const result = await registerAgentKey(supabase, {
+      jwk,
+      signatureAgent: signature_agent ?? null,
+      agentDid: agent_did ?? null,
+      merchantId,
+      label: label ?? null,
+      published: published ?? false,
+    });
+
+    if ('error' in result) {
+      const conflict = result.error === 'Key already registered';
+      return NextResponse.json({ error: result.error }, { status: conflict ? 409 : 500 });
+    }
+
+    return NextResponse.json(
+      {
+        keyid: result.keyid,
+        // Echo the thumbprint the signer must put in Signature-Input.
+        hint: 'Use this keyid in the Signature-Input keyid parameter',
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error('web-bot-auth key registration error', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = getSupabase();
+
+    const merchantId = await resolveMerchantId(supabase, request);
+    if (!merchantId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from('web_bot_auth_keys')
+      .select('keyid, jwk, signature_agent, agent_did, label, published, active, created_at, revoked_at')
+      .eq('merchant_id', merchantId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: 'Could not list keys' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      keys: (data ?? []).map((row) => ({
+        ...row,
+        // Recompute rather than trust the stored value, so a row edited out of
+        // band cannot misreport which key it is.
+        keyid_check: isEd25519Jwk(row.jwk) ? jwkThumbprint(row.jwk) : null,
+      })),
+    });
+  } catch (err) {
+    console.error('web-bot-auth key list error', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/web-bot-auth/verify/route.ts
+++ b/src/app/api/web-bot-auth/verify/route.ts
@@ -1,0 +1,115 @@
+/**
+ * POST /api/web-bot-auth/verify
+ *
+ * Verify a Web Bot Auth signature and, when the key is registered, return the
+ * CoinPay identity and trust tier behind it.
+ *
+ * This is the identity half of what Cloudflare resolves at its edge: who is
+ * calling, whether that claim is cryptographic, and what their track record
+ * is — answered for any origin, not only ones behind a particular CDN.
+ *
+ * Body: { method, url, headers: { signature, signature-input, signature-agent } }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { verifyWebBotAuth } from '@/lib/web-bot-auth';
+import { resolveAgentIdentity } from '@/lib/web-bot-auth/identity';
+import { computeTrustVector } from '@/lib/reputation/trust-engine';
+import { computeTrustTier } from '@/lib/reputation/trust-tiers';
+
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase not configured');
+  return createClient(url, key);
+}
+
+const verifySchema = z.object({
+  method: z.string().min(1),
+  url: z.string().url(),
+  headers: z.record(z.string()),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const apiKey = request.headers.get('x-api-key');
+    if (!apiKey) {
+      return NextResponse.json({ error: 'API key required' }, { status: 401 });
+    }
+
+    const supabase = getSupabase();
+
+    const { data: keyData, error: keyError } = await supabase
+      .from('api_keys')
+      .select('id, business_id, active')
+      .eq('key_hash', apiKey)
+      .single();
+
+    if (keyError || !keyData?.active) {
+      return NextResponse.json({ error: 'Invalid or inactive API key' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = verifySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ') },
+        { status: 400 }
+      );
+    }
+
+    const result = await verifyWebBotAuth(parsed.data);
+
+    if (!result.verified) {
+      // Not an error: most callers are unsigned, and the merchant decides what
+      // to do about that. 200 with verified:false keeps that distinction.
+      return NextResponse.json({
+        verified: false,
+        reason: result.reason,
+        detail: result.detail ?? null,
+      });
+    }
+
+    const identity = await resolveAgentIdentity(supabase, result);
+
+    // Trust is only meaningful for a key bound to a DID with a history.
+    let trust = null;
+    if (identity.did) {
+      try {
+        const profile = await computeTrustVector(supabase, identity.did);
+        const tier = computeTrustTier(profile.trust_vector);
+        trust = {
+          tier: tier.tier,
+          score: tier.score,
+          label: tier.label,
+          risk_level: tier.risk_level,
+        };
+      } catch (err) {
+        // A reputation failure must not turn a good signature into a bad one.
+        console.error('web-bot-auth trust lookup failed', err);
+      }
+    }
+
+    return NextResponse.json({
+      verified: true,
+      keyid: result.keyid,
+      signature_agent: result.signatureAgent,
+      agent_origin: result.agentOrigin,
+      covered_components: result.coveredComponents,
+      expires_at: result.expiresAt,
+      identity: {
+        // known:false means unregistered, which is not the same as untrusted —
+        // any agent that has never registered here looks exactly like this.
+        known: identity.known,
+        did: identity.did,
+        label: identity.label,
+      },
+      trust,
+    });
+  } catch (err) {
+    console.error('web-bot-auth verify error', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/lib/web-bot-auth/directory.ts
+++ b/src/lib/web-bot-auth/directory.ts
@@ -1,0 +1,209 @@
+/**
+ * Web Bot Auth — key directory handling
+ *
+ * A signer names its key directory in the `Signature-Agent` header. The
+ * directory is a JWKS served at a well-known path, and the `keyid` parameter
+ * is the RFC 7638 thumbprint of the key that signed the request.
+ *
+ * Fetching a URL supplied by the caller is a request-forgery primitive if left
+ * unguarded, so the fetch here is deliberately narrow: HTTPS only, no
+ * redirects, size-capped, timed out, and refused for private address literals.
+ */
+
+import {
+  createHash,
+  createPublicKey,
+  type KeyObject,
+  // Node's JWK type, not the DOM one — they are structurally different and
+  // createPublicKey only accepts Node's.
+  type JsonWebKey as NodeJsonWebKey,
+} from 'crypto';
+
+/** RFC 8037 Ed25519 public JWK. */
+export interface Ed25519Jwk {
+  kty: 'OKP';
+  crv: 'Ed25519';
+  x: string;
+  kid?: string;
+  nbf?: number;
+  exp?: number;
+}
+
+export const DIRECTORY_PATH = '/.well-known/http-message-signatures-directory';
+export const DIRECTORY_CONTENT_TYPE =
+  'application/http-message-signatures-directory+json';
+
+/** Cap on directory response size — a JWKS is small; anything large is abuse. */
+const MAX_DIRECTORY_BYTES = 128 * 1024;
+const FETCH_TIMEOUT_MS = 5_000;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface CacheEntry {
+  keys: Ed25519Jwk[];
+  expiresAt: number;
+}
+
+const directoryCache = new Map<string, CacheEntry>();
+
+/** Drop cached directories. Exposed for tests and key-rotation handling. */
+export function clearDirectoryCache(): void {
+  directoryCache.clear();
+}
+
+/**
+ * RFC 7638 JWK thumbprint for an Ed25519 key.
+ *
+ * The canonical form contains exactly the required members, lexicographically
+ * ordered, with no whitespace. Any deviation yields a different thumbprint and
+ * the key silently stops matching its keyid.
+ */
+export function jwkThumbprint(jwk: Ed25519Jwk): string {
+  const canonical = JSON.stringify({ crv: jwk.crv, kty: jwk.kty, x: jwk.x });
+  return createHash('sha256').update(canonical).digest('base64url');
+}
+
+/** Narrow an unknown JWKS member to a usable Ed25519 signing key. */
+export function isEd25519Jwk(value: unknown): value is Ed25519Jwk {
+  if (!value || typeof value !== 'object') return false;
+  const jwk = value as Record<string, unknown>;
+  return (
+    jwk.kty === 'OKP' &&
+    jwk.crv === 'Ed25519' &&
+    typeof jwk.x === 'string' &&
+    jwk.x.length > 0
+  );
+}
+
+/** Import an Ed25519 JWK as a verifying key. */
+export function toPublicKey(jwk: Ed25519Jwk): KeyObject {
+  return createPublicKey({ key: jwk as unknown as NodeJsonWebKey, format: 'jwk' });
+}
+
+/**
+ * Reject directory URLs that point somewhere a server-side fetch should not go.
+ *
+ * Hostnames still resolve at connect time, so this blocks the obvious literals
+ * rather than pretending to be complete DNS-rebinding protection.
+ */
+function assertSafeDirectoryUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Signature-Agent is not a valid URL: ${raw}`);
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new Error('Signature-Agent must be https');
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const isPrivate =
+    host === 'localhost' ||
+    host === '::1' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.internal') ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    /^f[cd][0-9a-f]{2}:/i.test(host);
+
+  if (isPrivate) {
+    throw new Error(`Refusing to fetch a key directory from ${url.hostname}`);
+  }
+
+  return url;
+}
+
+/**
+ * Resolve the directory URL for a `Signature-Agent` value.
+ *
+ * The header carries a structured-field String, so the quotes are part of the
+ * wire format and are stripped here. A bare origin gets the well-known path
+ * appended; an explicit path is honoured as given.
+ */
+export function directoryUrlFor(signatureAgent: string): URL {
+  const unquoted = signatureAgent.trim().replace(/^"|"$/g, '');
+  const url = assertSafeDirectoryUrl(unquoted);
+
+  if (url.pathname === '/' || url.pathname === '') {
+    url.pathname = DIRECTORY_PATH;
+  }
+  return url;
+}
+
+/**
+ * Fetch and cache the JWKS a signer publishes.
+ *
+ * @param signatureAgent - raw `Signature-Agent` header value
+ */
+export async function fetchDirectory(signatureAgent: string): Promise<Ed25519Jwk[]> {
+  const url = directoryUrlFor(signatureAgent);
+  const key = url.toString();
+
+  const cached = directoryCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.keys;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let body: string;
+  try {
+    const response = await fetch(key, {
+      // A redirect could bounce the fetch to an internal address that the
+      // checks above already rejected for the original URL.
+      redirect: 'error',
+      signal: controller.signal,
+      headers: { accept: `${DIRECTORY_CONTENT_TYPE}, application/json` },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Key directory returned HTTP ${response.status}`);
+    }
+
+    const length = Number(response.headers.get('content-length') ?? 0);
+    if (length > MAX_DIRECTORY_BYTES) {
+      throw new Error('Key directory is too large');
+    }
+
+    body = await response.text();
+    if (body.length > MAX_DIRECTORY_BYTES) {
+      throw new Error('Key directory is too large');
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error('Key directory is not valid JSON');
+  }
+
+  const rawKeys = (parsed as { keys?: unknown })?.keys;
+  if (!Array.isArray(rawKeys)) {
+    throw new Error('Key directory has no keys array');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const keys = rawKeys.filter(isEd25519Jwk).filter((jwk) => {
+    // Honour the directory's own validity window, when it states one.
+    if (typeof jwk.nbf === 'number' && now < jwk.nbf) return false;
+    if (typeof jwk.exp === 'number' && now >= jwk.exp) return false;
+    return true;
+  });
+
+  directoryCache.set(key, { keys, expiresAt: Date.now() + CACHE_TTL_MS });
+  return keys;
+}
+
+/** Find the key in a directory whose thumbprint matches `keyid`. */
+export function findKeyByThumbprint(
+  keys: Ed25519Jwk[],
+  keyid: string
+): Ed25519Jwk | undefined {
+  return keys.find((jwk) => jwkThumbprint(jwk) === keyid);
+}

--- a/src/lib/web-bot-auth/identity.test.ts
+++ b/src/lib/web-bot-auth/identity.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for resolving a verified Web Bot Auth key to a CoinPay identity.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveAgentIdentity, registerAgentKey } from './identity';
+import { jwkThumbprint, type Ed25519Jwk } from './directory';
+import type { VerifiedAgent } from './verify';
+
+const JWK: Ed25519Jwk = {
+  kty: 'OKP',
+  crv: 'Ed25519',
+  x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+};
+
+const AGENT: VerifiedAgent = {
+  verified: true,
+  keyid: jwkThumbprint(JWK),
+  signatureAgent: 'https://bot.example',
+  agentOrigin: 'https://bot.example',
+  coveredComponents: ['@authority'],
+  expiresAt: null,
+};
+
+/** Supabase stub whose maybeSingle() resolves to the supplied row. */
+function supabaseReturning(row: any, error: any = null) {
+  const chain: any = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () => Promise.resolve({ data: row, error }),
+  };
+  return { from: () => chain } as any;
+}
+
+describe('resolveAgentIdentity', () => {
+  it('returns the DID for a registered, active key', async () => {
+    const supabase = supabaseReturning({
+      agent_did: 'did:web:bot.example',
+      label: 'Crawler v2',
+      signature_agent: 'https://bot.example',
+      active: true,
+      revoked_at: null,
+    });
+
+    const identity = await resolveAgentIdentity(supabase, AGENT);
+
+    expect(identity).toMatchObject({
+      known: true,
+      did: 'did:web:bot.example',
+      label: 'Crawler v2',
+      keyid: AGENT.keyid,
+    });
+  });
+
+  it('treats an unregistered key as known:false rather than an error', async () => {
+    const identity = await resolveAgentIdentity(supabaseReturning(null), AGENT);
+
+    expect(identity.known).toBe(false);
+    expect(identity.did).toBeNull();
+    // The cryptographic facts survive even when the key is unknown here.
+    expect(identity.keyid).toBe(AGENT.keyid);
+    expect(identity.agentOrigin).toBe('https://bot.example');
+  });
+
+  it('ignores a revoked key', async () => {
+    const supabase = supabaseReturning({
+      agent_did: 'did:web:bot.example',
+      label: null,
+      signature_agent: 'https://bot.example',
+      active: true,
+      revoked_at: '2026-01-01T00:00:00Z',
+    });
+
+    expect((await resolveAgentIdentity(supabase, AGENT)).known).toBe(false);
+  });
+
+  it('ignores an inactive key', async () => {
+    const supabase = supabaseReturning({
+      agent_did: 'did:web:bot.example',
+      label: null,
+      signature_agent: 'https://bot.example',
+      active: false,
+      revoked_at: null,
+    });
+
+    expect((await resolveAgentIdentity(supabase, AGENT)).known).toBe(false);
+  });
+
+  it('refuses to hand over a DID when the key was registered for another directory', async () => {
+    // Republishing someone else's public key at your own directory must not
+    // let you inherit their identity and reputation.
+    const supabase = supabaseReturning({
+      agent_did: 'did:web:someone-else.example',
+      label: null,
+      signature_agent: 'https://someone-else.example',
+      active: true,
+      revoked_at: null,
+    });
+
+    const identity = await resolveAgentIdentity(supabase, AGENT);
+    expect(identity.known).toBe(false);
+    expect(identity.did).toBeNull();
+  });
+
+  it('does not fail closed into an exception on a query error', async () => {
+    const supabase = supabaseReturning(null, { message: 'boom' });
+    const identity = await resolveAgentIdentity(supabase, AGENT);
+    expect(identity.known).toBe(false);
+  });
+});
+
+describe('registerAgentKey', () => {
+  let inserted: any;
+  let supabase: any;
+
+  beforeEach(() => {
+    inserted = null;
+    supabase = {
+      from: () => ({
+        insert: (row: any) => {
+          inserted = row;
+          return Promise.resolve({ error: null });
+        },
+      }),
+    };
+  });
+
+  it('derives the keyid from the JWK rather than trusting input', async () => {
+    const result = await registerAgentKey(supabase, { jwk: JWK });
+
+    expect(result).toEqual({ keyid: jwkThumbprint(JWK) });
+    expect(inserted.keyid).toBe(jwkThumbprint(JWK));
+  });
+
+  it('stores only public JWK members', async () => {
+    // A caller pasting a private key must not get `d` persisted and then
+    // served from the public directory.
+    await registerAgentKey(supabase, {
+      jwk: { ...JWK, d: 'PRIVATE-KEY-MATERIAL' } as any,
+    });
+
+    expect(inserted.jwk).toEqual({ kty: 'OKP', crv: 'Ed25519', x: JWK.x });
+    expect(JSON.stringify(inserted)).not.toContain('PRIVATE-KEY-MATERIAL');
+  });
+
+  it('reports a duplicate registration distinctly', async () => {
+    supabase = {
+      from: () => ({
+        insert: () => Promise.resolve({ error: { code: '23505', message: 'dup' } }),
+      }),
+    };
+
+    const result = await registerAgentKey(supabase, { jwk: JWK });
+    expect(result).toEqual({ error: 'Key already registered' });
+  });
+});

--- a/src/lib/web-bot-auth/identity.ts
+++ b/src/lib/web-bot-auth/identity.ts
@@ -1,0 +1,123 @@
+/**
+ * Web Bot Auth — resolving a verified key to a CoinPay identity
+ *
+ * A verified signature proves control of a key published at some directory.
+ * That alone is anonymous: it says "the same caller as last time", not "an
+ * agent with a track record". This module joins the key to a registered DID so
+ * a caller arrives with a reputation attached.
+ *
+ * Identity and trust are kept separate on purpose. `verified` is a
+ * cryptographic fact. `did` and `trust` are claims CoinPay has recorded about
+ * that key, and their absence means unknown — never untrusted.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { VerifiedAgent } from './verify';
+import { jwkThumbprint, type Ed25519Jwk } from './directory';
+
+export interface AgentIdentity {
+  /** Thumbprint of the key that signed. Always present. */
+  keyid: string;
+  /** Directory origin the key was published at. Always present. */
+  agentOrigin: string;
+  /** Registered CoinPay DID, when this key has been mapped to one. */
+  did: string | null;
+  /** Operator-supplied label for the key. */
+  label: string | null;
+  /** True when the key is registered and active here. */
+  known: boolean;
+}
+
+/**
+ * Look up the CoinPay identity behind a verified signature.
+ *
+ * Returns an identity with `known: false` for a signature that verified
+ * against a directory CoinPay has no record of — a legitimate state for any
+ * agent that has not registered.
+ */
+export async function resolveAgentIdentity(
+  supabase: SupabaseClient,
+  agent: VerifiedAgent
+): Promise<AgentIdentity> {
+  const base: AgentIdentity = {
+    keyid: agent.keyid,
+    agentOrigin: agent.agentOrigin,
+    did: null,
+    label: null,
+    known: false,
+  };
+
+  const { data, error } = await supabase
+    .from('web_bot_auth_keys')
+    .select('agent_did, label, signature_agent, active, revoked_at')
+    .eq('keyid', agent.keyid)
+    .maybeSingle();
+
+  if (error || !data) return base;
+  if (!data.active || data.revoked_at) return base;
+
+  // A registration is scoped to the directory it was registered for. Without
+  // this check, publishing a copy of someone's public key at your own
+  // directory would let you inherit their DID and reputation.
+  if (
+    data.signature_agent &&
+    normalizeOrigin(data.signature_agent) !== agent.agentOrigin
+  ) {
+    return base;
+  }
+
+  return {
+    ...base,
+    did: data.agent_did ?? null,
+    label: data.label ?? null,
+    known: true,
+  };
+}
+
+function normalizeOrigin(value: string): string {
+  try {
+    return new URL(value.trim().replace(/^"|"$/g, '')).origin;
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Register a public key against an identity.
+ *
+ * The caller supplies the JWK; the thumbprint is always recomputed here rather
+ * than trusted from input, since it is the join key that decides which
+ * identity a signature resolves to.
+ */
+export async function registerAgentKey(
+  supabase: SupabaseClient,
+  input: {
+    jwk: Ed25519Jwk;
+    signatureAgent?: string | null;
+    agentDid?: string | null;
+    merchantId?: string | null;
+    label?: string | null;
+    published?: boolean;
+  }
+): Promise<{ keyid: string } | { error: string }> {
+  const keyid = jwkThumbprint(input.jwk);
+
+  const { error } = await supabase.from('web_bot_auth_keys').insert({
+    keyid,
+    // Store only the public members, so a caller cannot smuggle a private `d`
+    // into the row and have it served from the public directory.
+    jwk: { kty: input.jwk.kty, crv: input.jwk.crv, x: input.jwk.x },
+    signature_agent: input.signatureAgent ?? null,
+    agent_did: input.agentDid ?? null,
+    merchant_id: input.merchantId ?? null,
+    label: input.label ?? null,
+    published: input.published ?? false,
+  });
+
+  if (error) {
+    if (error.code === '23505') return { error: 'Key already registered' };
+    return { error: error.message };
+  }
+
+  return { keyid };
+}

--- a/src/lib/web-bot-auth/index.ts
+++ b/src/lib/web-bot-auth/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Web Bot Auth — cryptographic identity for automated traffic.
+ *
+ * Verifies RFC 9421 HTTP Message Signatures tagged `web-bot-auth`, so an
+ * origin can tell which agent is calling it instead of guessing from a
+ * User-Agent string that anyone can type.
+ */
+
+export {
+  verifyWebBotAuth,
+  WEB_BOT_AUTH_TAG,
+  MAX_SIGNATURE_LIFETIME_SECONDS,
+  CLOCK_SKEW_SECONDS,
+} from './verify';
+export type {
+  VerificationResult,
+  VerifiedAgent,
+  UnverifiedAgent,
+  VerifyFailureReason,
+} from './verify';
+
+export {
+  buildSignatureBase,
+  UnresolvableComponentError,
+} from './signature-base';
+export type { SignableRequest } from './signature-base';
+
+export {
+  parseSignatureInput,
+  parseSignatureHeader,
+} from './structured-fields';
+export type { SignatureInputEntry } from './structured-fields';
+
+export {
+  jwkThumbprint,
+  isEd25519Jwk,
+  toPublicKey,
+  fetchDirectory,
+  findKeyByThumbprint,
+  directoryUrlFor,
+  clearDirectoryCache,
+  DIRECTORY_PATH,
+  DIRECTORY_CONTENT_TYPE,
+} from './directory';
+export type { Ed25519Jwk } from './directory';

--- a/src/lib/web-bot-auth/signature-base.ts
+++ b/src/lib/web-bot-auth/signature-base.ts
@@ -1,0 +1,111 @@
+/**
+ * Web Bot Auth — RFC 9421 signature base construction
+ *
+ * The signature base is the exact byte string the signer signed. Every line is
+ * `"<component>": <value>`, and the final line is `"@signature-params"` set to
+ * the signer's own parameter text. Reproduce it wrong by a single space and
+ * verification fails in a way that looks like a bad key.
+ */
+
+import type { SignatureInputEntry } from './structured-fields';
+
+/** The request fields needed to rebuild a signature base. */
+export interface SignableRequest {
+  method: string;
+  /** Absolute request URL, e.g. https://api.example.com/premium?a=1 */
+  url: string;
+  /** Header lookup. Names are matched case-insensitively by the caller. */
+  headers: Headers | Record<string, string | string[] | undefined>;
+}
+
+/** Thrown when a covered component cannot be resolved from the request. */
+export class UnresolvableComponentError extends Error {
+  constructor(public readonly component: string) {
+    super(`Cannot resolve covered component: ${component}`);
+    this.name = 'UnresolvableComponentError';
+  }
+}
+
+function getHeader(
+  headers: SignableRequest['headers'],
+  name: string
+): string | undefined {
+  const lower = name.toLowerCase();
+
+  if (typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get(lower) ?? undefined;
+  }
+
+  const record = headers as Record<string, string | string[] | undefined>;
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() !== lower) continue;
+    const value = record[key];
+    // Repeated fields are combined with ", " per RFC 9421 §2.1.
+    return Array.isArray(value) ? value.join(', ') : value;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a single covered component to its signature-base value.
+ */
+function resolveComponent(component: string, request: SignableRequest): string {
+  if (!component.startsWith('@')) {
+    const value = getHeader(request.headers, component);
+    if (value === undefined) throw new UnresolvableComponentError(component);
+    // Field values are trimmed of leading/trailing whitespace, not internally.
+    return value.trim();
+  }
+
+  const url = new URL(request.url);
+
+  switch (component) {
+    case '@method':
+      return request.method.toUpperCase();
+    case '@authority':
+      // Host plus non-default port, lowercased. This is the component Web Bot
+      // Auth relies on to stop a signature being replayed at another origin.
+      return url.host.toLowerCase();
+    case '@scheme':
+      return url.protocol.replace(/:$/, '').toLowerCase();
+    case '@target-uri':
+      return url.toString();
+    case '@path':
+      return url.pathname;
+    case '@query':
+      // RFC 9421: the query including "?", or "?" when absent.
+      return url.search || '?';
+    case '@request-target':
+      return `${url.pathname}${url.search}`;
+    default:
+      throw new UnresolvableComponentError(component);
+  }
+}
+
+/**
+ * Build the signature base for one `Signature-Input` entry.
+ *
+ * @param entry - the parsed entry, whose `raw` text supplies @signature-params
+ * @param request - the request the signature is claimed to cover
+ */
+export function buildSignatureBase(
+  entry: SignatureInputEntry,
+  request: SignableRequest
+): string {
+  const lines: string[] = [];
+
+  for (const component of entry.components) {
+    // Signing a component whose value contains non-ASCII cannot round-trip
+    // through the signature base; reject rather than sign over a mangled value.
+    const value = resolveComponent(component, request);
+    if (/[^\x20-\x7e]/.test(value)) {
+      throw new UnresolvableComponentError(component);
+    }
+    lines.push(`"${component}": ${value}`);
+  }
+
+  // The signer's own parameter text, verbatim — never re-serialized.
+  lines.push(`"@signature-params": ${entry.raw}`);
+
+  return lines.join('\n');
+}

--- a/src/lib/web-bot-auth/structured-fields.ts
+++ b/src/lib/web-bot-auth/structured-fields.ts
@@ -1,0 +1,199 @@
+/**
+ * Web Bot Auth — RFC 8941 structured field parsing
+ *
+ * Only the shapes RFC 9421 actually puts on the wire are handled here:
+ * a Dictionary of Inner Lists with parameters (`Signature-Input`) and a
+ * Dictionary of Byte Sequences (`Signature`). This is deliberately not a
+ * general structured-fields implementation.
+ *
+ * The important detail is `raw`: for each dictionary member we keep the exact
+ * source text of its value. The signature base has to reproduce the signer's
+ * `@signature-params` byte for byte, and re-serializing a parsed value is a
+ * good way to differ from the signer over whitespace or parameter order and
+ * fail every signature for reasons that look like a crypto bug.
+ */
+
+export interface SignatureInputEntry {
+  /** Covered component identifiers, in signing order, unquoted. */
+  components: string[];
+  /** Signature parameters: created, expires, keyid, alg, nonce, tag. */
+  params: Record<string, string | number | boolean>;
+  /** Verbatim source text of this member's value, for the signature base. */
+  raw: string;
+}
+
+/**
+ * Split a structured-field Dictionary into `label -> raw value` pairs.
+ *
+ * Splitting happens only at top-level commas — those inside quoted strings,
+ * byte sequences or inner lists belong to the member, not between members.
+ */
+function splitDictionary(value: string): Array<{ label: string; raw: string }> {
+  const members: Array<{ label: string; raw: string }> = [];
+
+  let depth = 0;
+  let inString = false;
+  let inBytes = false;
+  let escaped = false;
+  let start = 0;
+
+  const push = (end: number) => {
+    const chunk = value.slice(start, end).trim();
+    if (!chunk) return;
+    const eq = chunk.indexOf('=');
+    // A dictionary member with no "=" is a boolean true; it carries no
+    // signature data, so record it with an empty value rather than dropping
+    // the label.
+    if (eq === -1) {
+      members.push({ label: chunk.trim(), raw: '' });
+      return;
+    }
+    members.push({ label: chunk.slice(0, eq).trim(), raw: chunk.slice(eq + 1).trim() });
+  };
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (inBytes) {
+      if (ch === ':') inBytes = false;
+      continue;
+    }
+
+    if (ch === '"') inString = true;
+    else if (ch === ':') inBytes = true;
+    else if (ch === '(') depth++;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+    else if (ch === ',' && depth === 0) {
+      push(i);
+      start = i + 1;
+    }
+  }
+  push(value.length);
+
+  return members;
+}
+
+/**
+ * Parse the parameter tail that follows a value, e.g. `;created=1;tag="x"`.
+ */
+function parseParams(text: string): Record<string, string | number | boolean> {
+  const params: Record<string, string | number | boolean> = {};
+
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== ';') {
+      i++;
+      continue;
+    }
+    i++; // consume ';'
+    while (text[i] === ' ') i++;
+
+    // Parameter name
+    let name = '';
+    while (i < text.length && /[a-zA-Z0-9_\-.*]/.test(text[i])) {
+      name += text[i];
+      i++;
+    }
+    if (!name) continue;
+
+    // Bare parameter -> boolean true
+    if (text[i] !== '=') {
+      params[name] = true;
+      continue;
+    }
+    i++; // consume '='
+
+    if (text[i] === '"') {
+      i++;
+      let out = '';
+      while (i < text.length && text[i] !== '"') {
+        if (text[i] === '\\') i++;
+        out += text[i];
+        i++;
+      }
+      i++; // closing quote
+      params[name] = out;
+      continue;
+    }
+
+    let token = '';
+    while (i < text.length && text[i] !== ';') {
+      token += text[i];
+      i++;
+    }
+    token = token.trim();
+    // Integers and decimals arrive as numbers; anything else stays a token.
+    params[name] = /^-?\d+(\.\d+)?$/.test(token) ? Number(token) : token;
+  }
+
+  return params;
+}
+
+/**
+ * Parse a `Signature-Input` header value.
+ *
+ * @example
+ *   sig1=("@authority" "signature-agent");created=1735689600;keyid="abc";alg="ed25519";tag="web-bot-auth"
+ */
+export function parseSignatureInput(value: string): Map<string, SignatureInputEntry> {
+  const out = new Map<string, SignatureInputEntry>();
+  if (!value) return out;
+
+  for (const { label, raw } of splitDictionary(value)) {
+    const open = raw.indexOf('(');
+    const close = raw.indexOf(')');
+    // Signature-Input members are always inner lists. Anything else is not a
+    // signature description and is skipped rather than half-parsed.
+    if (open === -1 || close === -1 || close < open) continue;
+
+    const inner = raw.slice(open + 1, close);
+    const components: string[] = [];
+    const itemPattern = /"((?:[^"\\]|\\.)*)"(?:;[^\s)]*)?/g;
+    let m: RegExpExecArray | null;
+    while ((m = itemPattern.exec(inner)) !== null) {
+      components.push(m[1]);
+    }
+
+    out.set(label, {
+      components,
+      params: parseParams(raw.slice(close + 1)),
+      raw,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Parse a `Signature` header value into raw signature bytes per label.
+ *
+ * Values are Byte Sequences: base64 delimited by colons, e.g. `sig1=:AAAA:`.
+ */
+export function parseSignatureHeader(value: string): Map<string, Buffer> {
+  const out = new Map<string, Buffer>();
+  if (!value) return out;
+
+  for (const { label, raw } of splitDictionary(value)) {
+    const first = raw.indexOf(':');
+    const last = raw.lastIndexOf(':');
+    if (first === -1 || last <= first) continue;
+
+    const b64 = raw.slice(first + 1, last);
+    try {
+      out.set(label, Buffer.from(b64, 'base64'));
+    } catch {
+      // A member whose bytes will not decode cannot verify; leave it out.
+    }
+  }
+
+  return out;
+}

--- a/src/lib/web-bot-auth/verify.ts
+++ b/src/lib/web-bot-auth/verify.ts
@@ -1,0 +1,217 @@
+/**
+ * Web Bot Auth — request signature verification
+ *
+ * Proves that a request was made by whoever controls the key published at the
+ * `Signature-Agent` directory. That is an identity claim, not an authorisation
+ * one: what a verified agent is then allowed to do, and at what price, is
+ * decided by the caller.
+ */
+
+import { verify as cryptoVerify } from 'crypto';
+import {
+  parseSignatureInput,
+  parseSignatureHeader,
+  type SignatureInputEntry,
+} from './structured-fields';
+import {
+  buildSignatureBase,
+  type SignableRequest,
+} from './signature-base';
+import {
+  fetchDirectory,
+  findKeyByThumbprint,
+  toPublicKey,
+  type Ed25519Jwk,
+} from './directory';
+
+/** The tag that marks a signature as Web Bot Auth rather than some other use. */
+export const WEB_BOT_AUTH_TAG = 'web-bot-auth';
+
+/** Longest signature validity we accept, regardless of what `expires` says. */
+export const MAX_SIGNATURE_LIFETIME_SECONDS = 3600;
+
+/** Tolerance for clock skew between signer and verifier. */
+export const CLOCK_SKEW_SECONDS = 300;
+
+export type VerifyFailureReason =
+  | 'missing_headers'
+  | 'no_web_bot_auth_signature'
+  | 'malformed'
+  | 'missing_keyid'
+  | 'unsupported_algorithm'
+  | 'expired'
+  | 'not_yet_valid'
+  | 'lifetime_too_long'
+  | 'unknown_key'
+  | 'directory_error'
+  | 'bad_signature';
+
+export interface VerifiedAgent {
+  verified: true;
+  /** RFC 7638 thumbprint of the signing key. */
+  keyid: string;
+  /** Directory URL the key was published at, unquoted. */
+  signatureAgent: string;
+  /** Origin of the directory — the identity actually proven. */
+  agentOrigin: string;
+  /** Covered components, useful for deciding how much the signature is worth. */
+  coveredComponents: string[];
+  expiresAt: number | null;
+}
+
+export interface UnverifiedAgent {
+  verified: false;
+  reason: VerifyFailureReason;
+  detail?: string;
+}
+
+export type VerificationResult = VerifiedAgent | UnverifiedAgent;
+
+/** Pick the `Signature-Input` member that is tagged as Web Bot Auth. */
+function selectWebBotAuthEntry(
+  entries: Map<string, SignatureInputEntry>
+): { label: string; entry: SignatureInputEntry } | null {
+  for (const [label, entry] of entries) {
+    if (entry.params.tag === WEB_BOT_AUTH_TAG) return { label, entry };
+  }
+  return null;
+}
+
+function headerOf(
+  headers: SignableRequest['headers'],
+  name: string
+): string | undefined {
+  if (typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get(name) ?? undefined;
+  }
+  const record = headers as Record<string, string | string[] | undefined>;
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() === name) {
+      const value = record[key];
+      return Array.isArray(value) ? value[0] : value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Verify a Web Bot Auth signature on a request.
+ *
+ * Returns a result rather than throwing: an unsigned or badly signed request
+ * is an ordinary event on a public endpoint, not an exceptional one.
+ *
+ * @param request - method, absolute URL, and headers as received
+ * @param options.now - override the clock, for tests
+ * @param options.resolveDirectory - override key lookup, for tests
+ */
+export async function verifyWebBotAuth(
+  request: SignableRequest,
+  options: {
+    now?: number;
+    resolveDirectory?: (signatureAgent: string) => Promise<Ed25519Jwk[]>;
+  } = {}
+): Promise<VerificationResult> {
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const resolveDirectory = options.resolveDirectory ?? fetchDirectory;
+
+  const signatureInput = headerOf(request.headers, 'signature-input');
+  const signature = headerOf(request.headers, 'signature');
+  const signatureAgent = headerOf(request.headers, 'signature-agent');
+
+  if (!signatureInput || !signature) {
+    return { verified: false, reason: 'missing_headers' };
+  }
+  if (!signatureAgent) {
+    // Without a directory pointer there is nothing to check the key against.
+    return { verified: false, reason: 'missing_headers', detail: 'no Signature-Agent' };
+  }
+
+  const entries = parseSignatureInput(signatureInput);
+  const selected = selectWebBotAuthEntry(entries);
+  if (!selected) {
+    return { verified: false, reason: 'no_web_bot_auth_signature' };
+  }
+
+  const { label, entry } = selected;
+  const { params } = entry;
+
+  const keyid = typeof params.keyid === 'string' ? params.keyid : null;
+  if (!keyid) return { verified: false, reason: 'missing_keyid' };
+
+  if (params.alg !== undefined && params.alg !== 'ed25519') {
+    return {
+      verified: false,
+      reason: 'unsupported_algorithm',
+      detail: String(params.alg),
+    };
+  }
+
+  const created = typeof params.created === 'number' ? params.created : null;
+  const expires = typeof params.expires === 'number' ? params.expires : null;
+
+  if (created !== null && created > now + CLOCK_SKEW_SECONDS) {
+    return { verified: false, reason: 'not_yet_valid' };
+  }
+  if (expires !== null && expires < now - CLOCK_SKEW_SECONDS) {
+    return { verified: false, reason: 'expired' };
+  }
+  // An unbounded or very long-lived signature is a bearer token in disguise:
+  // anyone who observes it can replay it for as long as it stays valid.
+  if (created !== null && expires !== null) {
+    if (expires - created > MAX_SIGNATURE_LIFETIME_SECONDS) {
+      return { verified: false, reason: 'lifetime_too_long' };
+    }
+  }
+
+  const signatures = parseSignatureHeader(signature);
+  const rawSignature = signatures.get(label);
+  if (!rawSignature || rawSignature.length === 0) {
+    return { verified: false, reason: 'malformed', detail: `no signature for ${label}` };
+  }
+
+  let base: string;
+  try {
+    base = buildSignatureBase(entry, request);
+  } catch (err) {
+    return {
+      verified: false,
+      reason: 'malformed',
+      detail: err instanceof Error ? err.message : 'bad signature base',
+    };
+  }
+
+  let keys: Ed25519Jwk[];
+  try {
+    keys = await resolveDirectory(signatureAgent);
+  } catch (err) {
+    return {
+      verified: false,
+      reason: 'directory_error',
+      detail: err instanceof Error ? err.message : 'directory fetch failed',
+    };
+  }
+
+  const jwk = findKeyByThumbprint(keys, keyid);
+  if (!jwk) return { verified: false, reason: 'unknown_key', detail: keyid };
+
+  let ok = false;
+  try {
+    // Ed25519 takes no separate digest algorithm, hence the null.
+    ok = cryptoVerify(null, Buffer.from(base, 'utf-8'), toPublicKey(jwk), rawSignature);
+  } catch {
+    ok = false;
+  }
+
+  if (!ok) return { verified: false, reason: 'bad_signature' };
+
+  const unquotedAgent = signatureAgent.trim().replace(/^"|"$/g, '');
+
+  return {
+    verified: true,
+    keyid,
+    signatureAgent: unquotedAgent,
+    agentOrigin: new URL(unquotedAgent).origin,
+    coveredComponents: entry.components,
+    expiresAt: expires,
+  };
+}

--- a/src/lib/web-bot-auth/web-bot-auth.test.ts
+++ b/src/lib/web-bot-auth/web-bot-auth.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Web Bot Auth verification tests
+ *
+ * Signatures are generated with real Ed25519 keys rather than mocked, because
+ * the thing most likely to be wrong is the signature base — and a mocked
+ * verifier would happily agree with a base that no real signer produces.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateKeyPairSync, sign as cryptoSign } from 'crypto';
+import {
+  verifyWebBotAuth,
+  buildSignatureBase,
+  parseSignatureInput,
+  parseSignatureHeader,
+  jwkThumbprint,
+  directoryUrlFor,
+  clearDirectoryCache,
+  type Ed25519Jwk,
+} from './index';
+
+const AGENT = 'https://signature-agent.test';
+const URL_UNDER_TEST = 'https://api.example.com/premium?tier=gold';
+
+function makeKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as unknown as Ed25519Jwk;
+  return { privateKey, jwk, keyid: jwkThumbprint(jwk) };
+}
+
+/**
+ * Sign a request the way a conforming bot would: build the base from the
+ * params we are about to put on the wire, then sign those exact bytes.
+ */
+function signRequest({
+  privateKey,
+  keyid,
+  components = ['@authority', 'signature-agent'],
+  created = 1735689600,
+  expires = 1735689600 + 300,
+  tag = 'web-bot-auth',
+  label = 'sig1',
+  agent = AGENT,
+  url = URL_UNDER_TEST,
+  method = 'GET',
+  extraHeaders = {} as Record<string, string>,
+}: any) {
+  const componentList = components.map((c: string) => `"${c}"`).join(' ');
+  const params =
+    `(${componentList});created=${created};keyid="${keyid}"` +
+    `;alg="ed25519";expires=${expires};tag="${tag}"`;
+
+  const headers: Record<string, string> = {
+    'signature-agent': `"${agent}"`,
+    'signature-input': `${label}=${params}`,
+    ...extraHeaders,
+  };
+
+  const entry = parseSignatureInput(headers['signature-input']).get(label)!;
+  const base = buildSignatureBase(entry, { method, url, headers });
+  const sig = cryptoSign(null, Buffer.from(base, 'utf-8'), privateKey);
+
+  headers.signature = `${label}=:${sig.toString('base64')}:`;
+  return { headers, base, method, url };
+}
+
+describe('signature base construction', () => {
+  it('produces exactly the RFC 9421 line format', () => {
+    const input =
+      'sig1=("@authority" "signature-agent");created=1735689600;keyid="abc";alg="ed25519";expires=1735693200;tag="web-bot-auth"';
+    const entry = parseSignatureInput(input).get('sig1')!;
+
+    const base = buildSignatureBase(entry, {
+      method: 'GET',
+      url: 'https://api.example.com/premium',
+      headers: { 'signature-agent': `"${AGENT}"` },
+    });
+
+    expect(base).toBe(
+      '"@authority": api.example.com\n' +
+        `"signature-agent": "${AGENT}"\n` +
+        '"@signature-params": ("@authority" "signature-agent");created=1735689600;keyid="abc";alg="ed25519";expires=1735693200;tag="web-bot-auth"'
+    );
+  });
+
+  it('reuses the signer\'s parameter text verbatim rather than re-serializing', () => {
+    // Unusual but legal ordering and spacing. Re-serializing would normalize
+    // it, change the bytes, and break every signature from this signer.
+    const input =
+      'sig1=("@authority");tag="web-bot-auth";keyid="abc";created=1;alg="ed25519"';
+    const entry = parseSignatureInput(input).get('sig1')!;
+
+    const base = buildSignatureBase(entry, {
+      method: 'GET',
+      url: 'https://api.example.com/x',
+      headers: {},
+    });
+
+    expect(base.endsWith(
+      '"@signature-params": ("@authority");tag="web-bot-auth";keyid="abc";created=1;alg="ed25519"'
+    )).toBe(true);
+  });
+
+  it('resolves derived components', () => {
+    const input = 'sig1=("@method" "@path" "@query" "@scheme");tag="web-bot-auth"';
+    const entry = parseSignatureInput(input).get('sig1')!;
+
+    const base = buildSignatureBase(entry, {
+      method: 'post',
+      url: 'https://api.example.com/a/b?x=1',
+      headers: {},
+    });
+
+    expect(base).toContain('"@method": POST');
+    expect(base).toContain('"@path": /a/b');
+    expect(base).toContain('"@query": ?x=1');
+    expect(base).toContain('"@scheme": https');
+  });
+
+  it('lowercases the authority and keeps a non-default port', () => {
+    const entry = parseSignatureInput('sig1=("@authority");tag="web-bot-auth"').get('sig1')!;
+    const base = buildSignatureBase(entry, {
+      method: 'GET',
+      url: 'https://API.Example.COM:8443/x',
+      headers: {},
+    });
+    expect(base).toContain('"@authority": api.example.com:8443');
+  });
+
+  it('throws when a covered component is absent from the request', () => {
+    const entry = parseSignatureInput('sig1=("x-not-sent");tag="web-bot-auth"').get('sig1')!;
+    expect(() =>
+      buildSignatureBase(entry, { method: 'GET', url: 'https://a.test/x', headers: {} })
+    ).toThrow(/Cannot resolve/);
+  });
+});
+
+describe('structured field parsing', () => {
+  it('does not split on commas inside quoted strings or inner lists', () => {
+    const input =
+      'sig1=("@authority" "signature-agent");keyid="a,b";tag="web-bot-auth", sig2=("@path");tag="other"';
+    const parsed = parseSignatureInput(input);
+
+    expect(parsed.size).toBe(2);
+    expect(parsed.get('sig1')!.params.keyid).toBe('a,b');
+    expect(parsed.get('sig1')!.components).toEqual(['@authority', 'signature-agent']);
+    expect(parsed.get('sig2')!.components).toEqual(['@path']);
+  });
+
+  it('parses byte sequences per label', () => {
+    const sigs = parseSignatureHeader('sig1=:AAEC:, sig2=:/w==:');
+    expect([...sigs.get('sig1')!]).toEqual([0, 1, 2]);
+    expect([...sigs.get('sig2')!]).toEqual([255]);
+  });
+
+  it('reads integer params as numbers and quoted params as strings', () => {
+    const entry = parseSignatureInput(
+      'sig1=("@authority");created=1735689600;keyid="abc";tag="web-bot-auth"'
+    ).get('sig1')!;
+    expect(entry.params.created).toBe(1735689600);
+    expect(entry.params.keyid).toBe('abc');
+  });
+});
+
+describe('jwkThumbprint', () => {
+  it('matches the RFC 7638 canonical form', () => {
+    // Canonical JSON is {"crv":...,"kty":...,"x":...} with no whitespace.
+    const jwk: Ed25519Jwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+    };
+    expect(jwkThumbprint(jwk)).toBe('kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k');
+  });
+
+  it('changes when the key changes', () => {
+    const a = makeKeypair();
+    const b = makeKeypair();
+    expect(a.keyid).not.toBe(b.keyid);
+  });
+});
+
+describe('directoryUrlFor', () => {
+  it('appends the well-known path to a bare origin', () => {
+    expect(directoryUrlFor('"https://bot.example"').toString()).toBe(
+      'https://bot.example/.well-known/http-message-signatures-directory'
+    );
+  });
+
+  it('keeps an explicit path', () => {
+    expect(directoryUrlFor('https://bot.example/keys.json').toString()).toBe(
+      'https://bot.example/keys.json'
+    );
+  });
+
+  it('refuses non-https', () => {
+    expect(() => directoryUrlFor('http://bot.example')).toThrow(/https/);
+  });
+
+  it.each([
+    'https://localhost/x',
+    'https://127.0.0.1/x',
+    'https://10.0.0.5/x',
+    'https://192.168.1.1/x',
+    'https://169.254.169.254/x',
+    'https://172.16.0.1/x',
+  ])('refuses to fetch from %s', (url) => {
+    expect(() => directoryUrlFor(url)).toThrow(/Refusing/);
+  });
+});
+
+describe('verifyWebBotAuth', () => {
+  let key: ReturnType<typeof makeKeypair>;
+  let directory: (agent: string) => Promise<Ed25519Jwk[]>;
+
+  beforeEach(() => {
+    clearDirectoryCache();
+    key = makeKeypair();
+    directory = async () => [key.jwk];
+  });
+
+  const now = 1735689600 + 10;
+
+  it('verifies a correctly signed request', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+
+    expect(result.verified).toBe(true);
+    if (!result.verified) throw new Error('expected verified');
+    expect(result.keyid).toBe(key.keyid);
+    expect(result.agentOrigin).toBe('https://signature-agent.test');
+    expect(result.coveredComponents).toContain('@authority');
+  });
+
+  it('rejects a signature made for a different authority', async () => {
+    // The whole point of covering @authority: a signature captured at one
+    // origin must not be replayable against another.
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      url: 'https://other.example.com/premium?tier=gold',
+    });
+
+    const result = await verifyWebBotAuth(
+      { ...req, url: URL_UNDER_TEST },
+      { now, resolveDirectory: directory }
+    );
+
+    expect(result).toMatchObject({ verified: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a tampered signature', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid });
+    const bytes = Buffer.from(req.headers.signature.split(':')[1], 'base64');
+    bytes[0] ^= 0xff;
+    req.headers.signature = `sig1=:${bytes.toString('base64')}:`;
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a signature from a key that is not in the directory', async () => {
+    const other = makeKeypair();
+    const req = signRequest({ privateKey: other.privateKey, keyid: other.keyid });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'unknown_key' });
+  });
+
+  it('rejects a keyid that does not match the key that signed', async () => {
+    // Claiming a directory key's id while signing with another key.
+    const other = makeKeypair();
+    const req = signRequest({ privateKey: other.privateKey, keyid: key.keyid });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'bad_signature' });
+  });
+
+  it('rejects an expired signature', async () => {
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      created: 1735689600,
+      expires: 1735689600 + 60,
+    });
+
+    const result = await verifyWebBotAuth(req, {
+      now: 1735689600 + 60 + 400,
+      resolveDirectory: directory,
+    });
+    expect(result).toMatchObject({ verified: false, reason: 'expired' });
+  });
+
+  it('rejects a signature that is not yet valid', async () => {
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      created: now + 10_000,
+      expires: now + 10_300,
+    });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'not_yet_valid' });
+  });
+
+  it('rejects a signature valid for longer than an hour', async () => {
+    // A long-lived signature is a bearer token: anyone who sees it can reuse it.
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      created: 1735689600,
+      expires: 1735689600 + 86_400,
+    });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'lifetime_too_long' });
+  });
+
+  it('ignores signatures that are not tagged web-bot-auth', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid, tag: 'other' });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'no_web_bot_auth_signature' });
+  });
+
+  it('reports an unsigned request without erroring', async () => {
+    const result = await verifyWebBotAuth(
+      { method: 'GET', url: URL_UNDER_TEST, headers: {} },
+      { now, resolveDirectory: directory }
+    );
+    expect(result).toMatchObject({ verified: false, reason: 'missing_headers' });
+  });
+
+  it('requires a Signature-Agent to locate the key', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid });
+    delete (req.headers as any)['signature-agent'];
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'missing_headers' });
+  });
+
+  it('surfaces a directory fetch failure distinctly from a bad signature', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid });
+
+    const result = await verifyWebBotAuth(req, {
+      now,
+      resolveDirectory: async () => {
+        throw new Error('HTTP 503');
+      },
+    });
+    expect(result).toMatchObject({ verified: false, reason: 'directory_error' });
+  });
+
+  it('rejects an algorithm other than ed25519', async () => {
+    const req = signRequest({ privateKey: key.privateKey, keyid: key.keyid });
+    req.headers['signature-input'] = req.headers['signature-input'].replace(
+      'alg="ed25519"',
+      'alg="rsa-pss-sha512"'
+    );
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'unsupported_algorithm' });
+  });
+
+  it('verifies when extra components are covered', async () => {
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      components: ['@authority', '@method', '@path', 'signature-agent'],
+    });
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result.verified).toBe(true);
+  });
+
+  it('rejects when a covered header was altered in transit', async () => {
+    const req = signRequest({
+      privateKey: key.privateKey,
+      keyid: key.keyid,
+      components: ['@authority', 'x-crawler-budget'],
+      extraHeaders: { 'x-crawler-budget': '100' },
+    });
+    req.headers['x-crawler-budget'] = '999999';
+
+    const result = await verifyWebBotAuth(req, { now, resolveDirectory: directory });
+    expect(result).toMatchObject({ verified: false, reason: 'bad_signature' });
+  });
+});

--- a/supabase/migrations/20260813140000_create_web_bot_auth_keys.sql
+++ b/supabase/migrations/20260813140000_create_web_bot_auth_keys.sql
@@ -1,0 +1,77 @@
+-- Web Bot Auth key registry.
+--
+-- Verifying a Web Bot Auth signature proves control of a key published at some
+-- directory URL. That is an identity, but an anonymous one. This table is what
+-- turns it into a CoinPay identity: it maps a key thumbprint to an agent DID,
+-- so a verified request can carry a reputation and a trust tier rather than
+-- just a domain name.
+--
+-- Rows serve two purposes, distinguished by `published`:
+--   * published = true  -> a key CoinPay hosts and serves in its own directory
+--                          at /.well-known/http-message-signatures-directory,
+--                          making CoinPay-hosted agents verifiable by anyone.
+--   * published = false -> a third-party key someone has mapped to a DID so
+--                          their traffic resolves to a known agent here.
+
+CREATE TABLE IF NOT EXISTS web_bot_auth_keys (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- RFC 7638 JWK thumbprint, base64url. This is the `keyid` a signer puts in
+  -- Signature-Input, and the join key between a signature and an identity.
+  keyid           text NOT NULL,
+
+  -- The Ed25519 public JWK itself: {kty:'OKP', crv:'Ed25519', x:'...'}.
+  jwk             jsonb NOT NULL,
+
+  -- Directory URL the key is published at, as it appears in Signature-Agent.
+  -- NULL for keys CoinPay itself publishes.
+  signature_agent text,
+
+  -- The CoinPay identity this key speaks for.
+  agent_did       text,
+
+  -- Owner, when the key belongs to a merchant's agent.
+  merchant_id     uuid REFERENCES merchants(id) ON DELETE CASCADE,
+
+  label           text,
+  published       boolean NOT NULL DEFAULT false,
+  active          boolean NOT NULL DEFAULT true,
+
+  -- Directory validity window, mirrored into the served JWKS.
+  not_before      timestamptz,
+  expires_at      timestamptz,
+
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  revoked_at      timestamptz
+);
+
+-- A thumbprint identifies exactly one key, so it must resolve to one identity.
+-- Two rows for one keyid would make "who is this?" ambiguous at verify time.
+CREATE UNIQUE INDEX IF NOT EXISTS web_bot_auth_keys_keyid_idx
+  ON web_bot_auth_keys (keyid);
+
+CREATE INDEX IF NOT EXISTS web_bot_auth_keys_agent_did_idx
+  ON web_bot_auth_keys (agent_did);
+
+CREATE INDEX IF NOT EXISTS web_bot_auth_keys_merchant_id_idx
+  ON web_bot_auth_keys (merchant_id);
+
+-- The directory endpoint reads exactly this slice on every request.
+CREATE INDEX IF NOT EXISTS web_bot_auth_keys_published_idx
+  ON web_bot_auth_keys (published, active)
+  WHERE published AND active;
+
+ALTER TABLE web_bot_auth_keys ENABLE ROW LEVEL SECURITY;
+
+-- Server-side reads and writes go through the service role.
+DROP POLICY IF EXISTS "service_role_all_web_bot_auth_keys" ON web_bot_auth_keys;
+CREATE POLICY "service_role_all_web_bot_auth_keys" ON web_bot_auth_keys
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Merchants may list their own registered keys in the dashboard. Only public
+-- key material is stored, so SELECT exposes nothing secret.
+DROP POLICY IF EXISTS "merchants_select_own_web_bot_auth_keys" ON web_bot_auth_keys;
+CREATE POLICY "merchants_select_own_web_bot_auth_keys" ON web_bot_auth_keys
+  FOR SELECT TO authenticated
+  USING (merchant_id = auth.uid());


### PR DESCRIPTION
Second piece from the Cloudflare pay-per-crawl article. Their architecture resolves identity, permission and payment at one hop; CoinPay already had the payment third (x402) and the reputation third (DIDs, trust tiers), but nothing connecting them — a paying caller was still anonymous, so a merchant could not price, rate-limit or trust one agent differently from another.

This adds the identity third, at the origin rather than at a CDN edge.

## What's here

**Verifier** — RFC 9421 HTTP Message Signatures tagged `web-bot-auth`, Ed25519 only, `keyid` checked as an RFC 7638 thumbprint against the JWKS named in `Signature-Agent`.

**Directory** — `GET /.well-known/http-message-signatures-directory` serving keys CoinPay hosts, content type `application/http-message-signatures-directory+json`. This is what makes CoinPay-hosted agents verifiable by anyone who speaks the protocol, Cloudflare included.

**Identity** — `web_bot_auth_keys` maps a key thumbprint to an agent DID, so a verified request arrives carrying the existing reputation and trust tier instead of just a domain name. `POST /api/web-bot-auth/verify` returns verification, identity and tier in one call.

## Where the bodies are buried

The **signature base** is what most implementations get subtly wrong. `@signature-params` reuses the signer's own parameter text verbatim rather than re-serializing a parsed value — normalize the whitespace or reorder the parameters and every signature from that signer fails, looking exactly like a key problem. There's a test pinning that specifically.

Correctness is checked against external references, not just itself: the thumbprint matches the published RFC 8037 vector (`kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k`), and every signature in the tests is made with a real Ed25519 key. A mocked verifier would happily agree with a base no real signer produces.

## Judgement calls I'd like a second opinion on

- **One-hour maximum signature lifetime.** Past that a signature is a bearer token — anyone who observes it replays it until expiry. Rejected outright rather than warned about.
- **SSRF surface.** Directory fetches take a caller-supplied URL: HTTPS-only, redirect-refusing, 5s timeout, 128KB cap, private/link-local literals refused. That stops address literals, **not** DNS rebinding — a hostname resolving internally at connect time is still attempted. Documented plainly rather than overclaimed.
- **`known: false` means unknown, not untrusted.** Every legitimate agent that never registered here looks identical to a hostile one. Treating it as a signal to block would block the honest majority, so the three states are kept distinct in the response and spelled out in the docs.
- **Registration is scoped to its directory origin**, and binds a DID only if the caller owns it — otherwise republishing someone else's public key at your own directory would inherit their reputation. Both are tested.

## Not done, deliberately

`nonce` is parsed but not checked against a replay store, so a signature is replayable within its (short) validity window — Cloudflare doesn't validate nonces today either. There's no curated allowlist of "real" crawler operators, and no purpose signal (search vs agent vs training) yet; that's the natural next piece and pairs with per-purpose pricing.

## Verification

- `npx vitest run` — **277 files, 3847 passed, 0 failed**
- `npx tsc --noEmit` — clean
- `npx next build --webpack` — compiles; all three new routes register
- `npx eslint` on new code — 0 errors, 0 warnings

⚠️ One honest note: an earlier full-suite run showed 2 failures in `src/app/escrow/` (copy button, multisig blur). They pass in isolation, pass alongside the new tests, and the full suite passed clean on re-run — and clean master passed too. They look like timing-sensitive flakes surfaced under load rather than anything from this branch, but flagging them since I did see them go red once.

## Migration not applied

`supabase/migrations/20260813140000_create_web_bot_auth_keys.sql` has **not** been applied to production. Nothing reads the table until this deploys, so unlike last time there's no breakage either way — say the word and I'll apply it via MCP (ref `mlywdeoogwsebabohskk`), ideally just before merge so the table exists before the code that wants it.

Docs: [`docs/WEB_BOT_AUTH.md`](docs/WEB_BOT_AUTH.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)