### PR TITLE
Business categorization, pre-Stripe fraud screening, and admin console

### DIFF
--- a/src/app/admin/AdminContent.tsx
+++ b/src/app/admin/AdminContent.tsx
@@ -171,6 +171,12 @@ export default function AdminContent() {
             User stats →
           </Link>
           <Link
+            href="/admin/businesses"
+            className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
+          >
+            Businesses →
+          </Link>
+          <Link
             href="/admin/email-broadcast"
             className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
           >

--- a/src/app/admin/businesses/BusinessesContent.tsx
+++ b/src/app/admin/businesses/BusinessesContent.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  BUSINESS_CATEGORIES,
+  CATEGORY_GROUPS,
+  getCategory,
+  type RiskLevel,
+} from '@/lib/business/taxonomy';
+
+type AdminBusiness = {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  tags: string[] | null;
+  risk_level: RiskLevel | null;
+  risk_flags: { code: string; label: string; severity: string; matched: string[] }[] | null;
+  review_status: string | null;
+  active: boolean;
+  created_at: string;
+  merchant_id: string | null;
+  owner_email: string | null;
+  webhook_url: string | null;
+};
+
+type LinkedBusiness = {
+  id: string;
+  name: string;
+  category: string | null;
+  risk_level: RiskLevel | null;
+  review_status: string | null;
+  link: { kinds: string[]; evidence: string[] } | null;
+};
+
+const RISK_STYLES: Record<string, string> = {
+  low: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800',
+  medium: 'bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800',
+  high: 'bg-orange-50 text-orange-800 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400 dark:border-orange-800',
+  prohibited: 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800',
+};
+
+const PAGE_SIZE = 50;
+
+function authHeaders(extra?: HeadersInit): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+  const headers: Record<string, string> = { ...(extra as Record<string, string>) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+export default function BusinessesContent() {
+  const [businesses, setBusinesses] = useState<AdminBusiness[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [authState, setAuthState] = useState<'unknown' | 'unauthenticated' | 'forbidden' | 'ok'>('unknown');
+
+  // Filters
+  const [search, setSearch] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
+  const [category, setCategory] = useState('');
+  const [risk, setRisk] = useState('');
+  const [review, setReview] = useState('');
+
+  // Row expansion + tag editing
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [linked, setLinked] = useState<LinkedBusiness[]>([]);
+  const [tagDraft, setTagDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (search.trim()) params.set('search', search.trim());
+      for (const tag of tagFilter.split(',').map((t) => t.trim()).filter(Boolean)) {
+        params.append('tag', tag);
+      }
+      if (category) params.set('category', category);
+      if (risk) params.set('risk', risk);
+      if (review) params.set('review', review);
+      params.set('limit', String(PAGE_SIZE));
+      params.set('offset', String(offset));
+
+      const res = await fetch(`/api/admin/businesses?${params}`, { headers: authHeaders() });
+      if (res.status === 401) return setAuthState('unauthenticated');
+      if (res.status === 403) return setAuthState('forbidden');
+      if (!res.ok) return setError('Failed to load businesses');
+
+      const data = await res.json();
+      setBusinesses(data.businesses || []);
+      setTotal(data.total || 0);
+      setAuthState('ok');
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, tagFilter, category, risk, review, offset]);
+
+  useEffect(() => {
+    const timer = setTimeout(load, 250);
+    return () => clearTimeout(timer);
+  }, [load]);
+
+  const openRow = async (business: AdminBusiness) => {
+    if (expanded === business.id) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(business.id);
+    setTagDraft((business.tags ?? []).join(', '));
+    setLinked([]);
+    try {
+      const res = await fetch(`/api/admin/businesses/${business.id}`, { headers: authHeaders() });
+      if (res.ok) {
+        const data = await res.json();
+        setLinked(data.linkedBusinesses || []);
+      }
+    } catch {
+      // Linkage is supplementary; the row is still usable without it.
+    }
+  };
+
+  const patch = async (id: string, body: Record<string, unknown>) => {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/admin/businesses/${id}`, {
+        method: 'PATCH',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Update failed');
+        return;
+      }
+      await load();
+    } catch {
+      setError('Network error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (authState === 'unauthenticated') {
+    return <Shell><p className="text-gray-600 dark:text-gray-300">Please <Link href="/login" className="text-purple-600 hover:underline">sign in</Link>.</p></Shell>;
+  }
+  if (authState === 'forbidden') {
+    return <Shell><p className="text-gray-600 dark:text-gray-300">Admin access required.</p></Shell>;
+  }
+
+  return (
+    <Shell>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Businesses</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {total} total across every merchant
+          </p>
+        </div>
+        <Link href="/admin" className="text-sm font-medium text-purple-600 hover:text-purple-500">
+          ← Admin
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-3 mb-6">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => { setOffset(0); setSearch(e.target.value); }}
+          placeholder="Search name or description"
+          className="md:col-span-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+        />
+        <input
+          type="search"
+          value={tagFilter}
+          onChange={(e) => { setOffset(0); setTagFilter(e.target.value); }}
+          placeholder="Tags, comma separated"
+          className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+        />
+        <select
+          value={category}
+          onChange={(e) => { setOffset(0); setCategory(e.target.value); }}
+          className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+        >
+          <option value="">All categories</option>
+          {CATEGORY_GROUPS.map((group) => (
+            <optgroup key={group} label={group}>
+              {BUSINESS_CATEGORIES.filter((c) => c.group === group).map((c) => (
+                <option key={c.slug} value={c.slug}>{c.label}</option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        <div className="flex gap-2">
+          <select
+            value={risk}
+            onChange={(e) => { setOffset(0); setRisk(e.target.value); }}
+            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+          >
+            <option value="">Any risk</option>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+            <option value="prohibited">Prohibited</option>
+          </select>
+          <select
+            value={review}
+            onChange={(e) => { setOffset(0); setReview(e.target.value); }}
+            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+          >
+            <option value="">Any review</option>
+            <option value="pending">Pending</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+            <option value="not_required">Not required</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      ) : businesses.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400">No businesses match those filters.</p>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 dark:bg-gray-900 text-left text-gray-600 dark:text-gray-300">
+              <tr>
+                <th className="px-4 py-3 font-medium">Business</th>
+                <th className="px-4 py-3 font-medium">Owner</th>
+                <th className="px-4 py-3 font-medium">Category</th>
+                <th className="px-4 py-3 font-medium">Tags</th>
+                <th className="px-4 py-3 font-medium">Risk</th>
+                <th className="px-4 py-3 font-medium">Review</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {businesses.map((b) => (
+                <Fragment key={b.id}>
+                  <tr
+                    onClick={() => openRow(b)}
+                    className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                  >
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900 dark:text-white">{b.name}</div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        {new Date(b.created_at).toLocaleDateString()}
+                        {!b.active && ' · inactive'}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{b.owner_email ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
+                      {getCategory(b.category)?.label ?? <span className="text-gray-400">Uncategorized</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {(b.tags ?? []).slice(0, 4).map((tag) => (
+                          <span key={tag} className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      {b.risk_level && (
+                        <span className={`inline-flex px-2 py-0.5 rounded-full border text-xs ${RISK_STYLES[b.risk_level] ?? ''}`}>
+                          {b.risk_level}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
+                      {b.review_status === 'pending' ? (
+                        <span className="inline-flex px-2 py-0.5 rounded-full border border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-900/20 text-orange-800 dark:text-orange-400 text-xs">
+                          pending
+                        </span>
+                      ) : (
+                        b.review_status
+                      )}
+                    </td>
+                  </tr>
+
+                  {expanded === b.id && (
+                    <tr className="bg-gray-50 dark:bg-gray-900">
+                      <td colSpan={6} className="px-4 py-4 space-y-4">
+                        {b.description && (
+                          <p className="text-gray-700 dark:text-gray-300">{b.description}</p>
+                        )}
+
+                        {(b.risk_flags ?? []).length > 0 && (
+                          <div>
+                            <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Why it scored</div>
+                            <ul className="list-disc list-inside text-gray-700 dark:text-gray-300">
+                              {(b.risk_flags ?? []).map((f) => (
+                                <li key={f.code}>
+                                  {f.label} ({f.severity})
+                                  {f.matched?.length > 0 && ` — ${f.matched.join(', ')}`}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {linked.length > 0 && (
+                          <div>
+                            <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                              Linked accounts
+                            </div>
+                            <ul className="space-y-1">
+                              {linked.map((l) => (
+                                <li key={l.id} className="text-gray-700 dark:text-gray-300">
+                                  <Link href={`/businesses/${l.id}`} className="text-purple-600 hover:underline">
+                                    {l.name}
+                                  </Link>
+                                  {l.link && (
+                                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                                      {' '}— {l.link.kinds.join(', ')}: {l.link.evidence.join(', ')}
+                                    </span>
+                                  )}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        <div>
+                          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                            Tags (comma separated)
+                          </label>
+                          <div className="flex gap-2">
+                            <input
+                              value={tagDraft}
+                              onChange={(e) => setTagDraft(e.target.value)}
+                              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white dark:bg-gray-700"
+                            />
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() =>
+                                patch(b.id, {
+                                  tags: tagDraft.split(',').map((t) => t.trim()).filter(Boolean),
+                                })
+                              }
+                              className="px-3 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-500 disabled:opacity-50"
+                            >
+                              Save tags
+                            </button>
+                          </div>
+                          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Saving re-runs the classifier, so risk and review status update with it.
+                          </p>
+                        </div>
+
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => patch(b.id, { review_status: 'approved' })}
+                            className="px-3 py-2 border border-green-300 dark:border-green-700 text-green-700 dark:text-green-400 rounded-lg text-sm hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-50"
+                          >
+                            Approve
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => patch(b.id, { review_status: 'rejected' })}
+                            className="px-3 py-2 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 rounded-lg text-sm hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
+                          >
+                            Reject
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => patch(b.id, { active: !b.active })}
+                            className="px-3 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg text-sm hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+                          >
+                            {b.active ? 'Deactivate' : 'Reactivate'}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {total > PAGE_SIZE && (
+        <div className="flex items-center justify-between mt-4 text-sm">
+          <button
+            type="button"
+            disabled={offset === 0}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-40 text-gray-700 dark:text-gray-300"
+          >
+            Previous
+          </button>
+          <span className="text-gray-500 dark:text-gray-400">
+            {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+          </span>
+          <button
+            type="button"
+            disabled={offset + PAGE_SIZE >= total}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-40 text-gray-700 dark:text-gray-300"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">{children}</div>
+    </div>
+  );
+}

--- a/src/app/admin/businesses/page.tsx
+++ b/src/app/admin/businesses/page.tsx
@@ -1,0 +1,14 @@
+import { requireAdminPage } from '@/lib/auth/admin-guard';
+import BusinessesContent from './BusinessesContent';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Businesses · Admin · CoinPay',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminBusinessesPage() {
+  await requireAdminPage('/admin/businesses');
+  return <BusinessesContent />;
+}

--- a/src/app/api/admin/businesses/[id]/route.ts
+++ b/src/app/api/admin/businesses/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { mutateBusinessTags } from '@/lib/business/service';
+import { isValidCategory } from '@/lib/business/taxonomy';
+import { findLinkedBusinesses } from '@/lib/fraud/linkage';
+
+const REVIEW_STATUSES = new Set(['not_required', 'pending', 'approved', 'rejected']);
+
+/**
+ * GET /api/admin/businesses/[id] — one business plus the other accounts that
+ * share an identity signal with it. The linkage is the point: a business only
+ * looks clean until you see what else sits behind the same webhook host or
+ * payout wallet.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const { id } = await params;
+  const supabase = getSupabaseAdmin();
+
+  const { data: business, error } = await supabase
+    .from('businesses')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error || !business) {
+    return NextResponse.json({ error: 'Business not found' }, { status: 404 });
+  }
+
+  const linkage = await findLinkedBusinesses(supabase, id).catch(() => null);
+
+  // Name the linked businesses so the response is readable on its own.
+  let linkedBusinesses: any[] = [];
+  if (linkage && linkage.linkedBusinessIds.length > 0) {
+    const { data } = await supabase
+      .from('businesses')
+      .select('id, name, category, risk_level, review_status, created_at, merchant_id')
+      .in('id', linkage.linkedBusinessIds);
+    linkedBusinesses = (data ?? []).map((b) => ({
+      ...b,
+      link: linkage.links.find((l) => l.businessId === b.id) ?? null,
+    }));
+  }
+
+  return NextResponse.json(
+    { business, linkage: linkage ?? null, linkedBusinesses },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}
+
+/**
+ * PATCH /api/admin/businesses/[id] — work the review queue.
+ *
+ * Accepts `review_status`, `category` and `tags`. Tag and category edits go
+ * through the same path a merchant uses, so risk is re-derived; a review_status
+ * change is the admin's verdict and is written as given.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const supabase = getSupabaseAdmin();
+
+  const updates: Record<string, unknown> = {};
+
+  if (body.review_status !== undefined) {
+    if (!REVIEW_STATUSES.has(body.review_status)) {
+      return NextResponse.json({ error: 'Invalid review_status' }, { status: 400 });
+    }
+    updates.review_status = body.review_status;
+  }
+
+  if (body.active !== undefined) {
+    updates.active = !!body.active;
+  }
+
+  if (body.category !== undefined) {
+    if (!isValidCategory(body.category)) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
+    }
+    updates.category = body.category;
+  }
+
+  // Tags first: that write reclassifies, and an explicit review verdict in the
+  // same request must survive it.
+  if (Array.isArray(body.tags)) {
+    const result = await mutateBusinessTags(supabase, id, 'replace', body.tags);
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const { error } = await supabase.from('businesses').update(updates).eq('id', id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+  }
+
+  const { data: business } = await supabase.from('businesses').select('*').eq('id', id).maybeSingle();
+  return NextResponse.json({ success: true, business });
+}

--- a/src/app/api/admin/businesses/route.ts
+++ b/src/app/api/admin/businesses/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { applyBusinessFilters } from '@/lib/business/service';
+
+const SORTABLE = new Set(['created_at', 'name', 'risk_level', 'review_status', 'category']);
+
+/**
+ * GET /api/admin/businesses — every business on the platform.
+ *
+ * This is other merchants' data, so `requireAdmin` is the whole security
+ * boundary. Supports the same search and facet params as the merchant list,
+ * plus owner email and pagination.
+ *
+ * ?search= &tag= &category= &risk= &review= &sort= &dir= &limit= &offset=
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const params = req.nextUrl.searchParams;
+  const sort = SORTABLE.has(params.get('sort') ?? '') ? params.get('sort')! : 'created_at';
+  const ascending = params.get('dir') === 'asc';
+
+  const parsedLimit = Number.parseInt(params.get('limit') ?? '', 10);
+  const parsedOffset = Number.parseInt(params.get('offset') ?? '', 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), 500) : 50;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  try {
+    const supabase = getSupabaseAdmin();
+
+    let query = supabase
+      .from('businesses')
+      .select(
+        'id, name, description, category, tags, risk_level, risk_flags, review_status, active, created_at, merchant_id, webhook_url',
+        { count: 'exact' }
+      );
+
+    query = applyBusinessFilters(query, {
+      search: params.get('search'),
+      tags: params.getAll('tag'),
+      category: params.get('category'),
+      riskLevel: params.get('risk'),
+      reviewStatus: params.get('review'),
+    });
+
+    const { data, error, count } = await query
+      .order(sort, { ascending })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      console.error('[admin/businesses] query failed', error);
+      return NextResponse.json({ error: 'Failed to load businesses' }, { status: 500 });
+    }
+
+    // Attach the owner's email so an admin can see who is behind each one.
+    const merchantIds = [...new Set((data ?? []).map((b) => b.merchant_id).filter(Boolean))];
+    const ownerEmails = new Map<string, string>();
+    if (merchantIds.length > 0) {
+      const { data: merchants } = await supabase
+        .from('merchants')
+        .select('id, email')
+        .in('id', merchantIds);
+      for (const m of merchants ?? []) ownerEmails.set(m.id, m.email);
+    }
+
+    const businesses = (data ?? []).map((b) => ({
+      ...b,
+      owner_email: b.merchant_id ? ownerEmails.get(b.merchant_id) ?? null : null,
+    }));
+
+    return NextResponse.json(
+      { businesses, total: count ?? 0, limit, offset, sort, dir: ascending ? 'asc' : 'desc' },
+      // Never cache: platform-wide data about every merchant.
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (err) {
+    console.error('[admin/businesses] failed', err);
+    return NextResponse.json({ error: 'Failed to load businesses' }, { status: 500 });
+  }
+}

--- a/src/app/api/businesses/[id]/route.ts
+++ b/src/app/api/businesses/[id]/route.ts
@@ -158,7 +158,7 @@ export async function PATCH(
     }
 
     return NextResponse.json(
-      { success: true, business: result.business },
+      { success: true, business: result.business, classification: result.classification },
       { status: 200 }
     );
   } catch (error) {

--- a/src/app/api/businesses/[id]/tags/route.ts
+++ b/src/app/api/businesses/[id]/tags/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { getBusinessTags, mutateBusinessTags } from '@/lib/business/service';
+import { verifyToken } from '@/lib/auth/jwt';
+import { getJwtSecret } from '@/lib/secrets';
+import { authorizeBusiness } from '@/lib/auth/authz';
+
+function createSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) return null;
+  return createClient(supabaseUrl, supabaseKey);
+}
+
+function verifyAuth(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { error: 'Missing authorization header', status: 401 as const };
+  }
+
+  const jwtSecret = getJwtSecret();
+  if (!jwtSecret) {
+    return { error: 'Server configuration error', status: 500 as const };
+  }
+
+  try {
+    const decoded = verifyToken(authHeader.substring(7), jwtSecret);
+    return { merchantId: decoded.userId };
+  } catch {
+    return { error: 'Invalid or expired token', status: 401 as const };
+  }
+}
+
+/**
+ * Shared setup: authenticate, then check the caller may act on this business.
+ * Reads need `business.read`, writes need `business.update`.
+ */
+async function setup(request: NextRequest, businessId: string, permission: 'business.read' | 'business.update') {
+  const auth = verifyAuth(request);
+  if ('error' in auth) {
+    return { response: NextResponse.json({ success: false, error: auth.error }, { status: auth.status }) };
+  }
+
+  const supabase = createSupabaseClient();
+  if (!supabase) {
+    return {
+      response: NextResponse.json({ success: false, error: 'Server configuration error' }, { status: 500 }),
+    };
+  }
+
+  const authz = await authorizeBusiness(supabase, auth.merchantId!, businessId, permission);
+  if (!authz.ok) {
+    return { response: NextResponse.json({ success: false, error: authz.error }, { status: authz.status }) };
+  }
+
+  return { supabase };
+}
+
+/** Accept either `{ tags: [...] }` or a single `{ tag: "iptv" }`. */
+function tagsFromBody(body: any): string[] {
+  if (Array.isArray(body?.tags)) return body.tags;
+  if (typeof body?.tag === 'string') return [body.tag];
+  return [];
+}
+
+/**
+ * GET /api/businesses/[id]/tags — list the keyword tags.
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ctx = await setup(request, id, 'business.read');
+  if (ctx.response) return ctx.response;
+
+  const result = await getBusinessTags(ctx.supabase!, id);
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 404 });
+  }
+  return NextResponse.json({ success: true, tags: result.tags });
+}
+
+/**
+ * POST /api/businesses/[id]/tags — add tags, keeping the existing ones.
+ */
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ctx = await setup(request, id, 'business.update');
+  if (ctx.response) return ctx.response;
+
+  const body = await request.json().catch(() => ({}));
+  const tags = tagsFromBody(body);
+  if (tags.length === 0) {
+    return NextResponse.json({ success: false, error: 'Provide tag or tags' }, { status: 400 });
+  }
+
+  const result = await mutateBusinessTags(ctx.supabase!, id, 'add', tags);
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  }
+  return NextResponse.json({ success: true, tags: result.tags, classification: result.classification });
+}
+
+/**
+ * PUT /api/businesses/[id]/tags — replace the whole set.
+ */
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ctx = await setup(request, id, 'business.update');
+  if (ctx.response) return ctx.response;
+
+  const body = await request.json().catch(() => ({}));
+  if (!Array.isArray(body?.tags)) {
+    return NextResponse.json({ success: false, error: 'tags must be an array' }, { status: 400 });
+  }
+
+  const result = await mutateBusinessTags(ctx.supabase!, id, 'replace', body.tags);
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  }
+  return NextResponse.json({ success: true, tags: result.tags, classification: result.classification });
+}
+
+/**
+ * DELETE /api/businesses/[id]/tags?tag=iptv — remove one or more tags.
+ * Also accepts a JSON body for removing several at once.
+ */
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ctx = await setup(request, id, 'business.update');
+  if (ctx.response) return ctx.response;
+
+  const queryTags = request.nextUrl.searchParams.getAll('tag');
+  const body = queryTags.length > 0 ? {} : await request.json().catch(() => ({}));
+  const tags = queryTags.length > 0 ? queryTags : tagsFromBody(body);
+
+  if (tags.length === 0) {
+    return NextResponse.json({ success: false, error: 'Provide tag or tags' }, { status: 400 });
+  }
+
+  const result = await mutateBusinessTags(ctx.supabase!, id, 'remove', tags);
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  }
+  return NextResponse.json({ success: true, tags: result.tags, classification: result.classification });
+}

--- a/src/app/api/businesses/route.ts
+++ b/src/app/api/businesses/route.ts
@@ -136,7 +136,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json(
-      { success: true, business: result.business },
+      { success: true, business: result.business, classification: result.classification },
       { status: 201 }
     );
   } catch (error) {

--- a/src/app/api/businesses/route.ts
+++ b/src/app/api/businesses/route.ts
@@ -84,7 +84,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const result = await listAccessibleBusinesses(supabase, merchantId);
+    // Search and facets: ?search=&tag=iptv&tag=streaming&category=&risk=&review=
+    const params = request.nextUrl.searchParams;
+    const result = await listAccessibleBusinesses(supabase, merchantId, {
+      search: params.get('search'),
+      tags: params.getAll('tag'),
+      category: params.get('category'),
+      riskLevel: params.get('risk'),
+      reviewStatus: params.get('review'),
+    });
 
     if (!result.success) {
       return NextResponse.json(

--- a/src/app/api/stripe/payments/create/route.test.ts
+++ b/src/app/api/stripe/payments/create/route.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const { mockStripe, mockSupabase } = vi.hoisted(() => {
+const { mockStripe, mockSupabase, mockAuthorize } = vi.hoisted(() => {
+  const mockAuthorize = vi.fn();
   const mockStripe = {
     checkout: {
       sessions: {
@@ -17,8 +18,14 @@ const { mockStripe, mockSupabase } = vi.hoisted(() => {
     from: vi.fn(),
   };
 
-  return { mockStripe, mockSupabase };
+  return { mockStripe, mockSupabase, mockAuthorize };
 });
+
+// The gate itself is unit-tested in src/lib/auth/payment-auth.test.ts; here we
+// only care that the route refuses to act when it says no.
+vi.mock('@/lib/auth/payment-auth', () => ({
+  authorizePaymentCreation: mockAuthorize,
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(() => mockStripe),
@@ -72,6 +79,7 @@ describe('POST /api/stripe/payments/create', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
     process.env.NEXT_PUBLIC_APP_URL = 'https://coinpayportal.com';
+    mockAuthorize.mockResolvedValue({ ok: true, via: 'api_key', merchantId: 'merchant_123' });
     mockFromChain();
   });
 
@@ -127,5 +135,45 @@ describe('POST /api/stripe/payments/create', () => {
 
     const response = await POST(request);
     expect(response.status).toBe(404);
+  });
+
+  it('rejects an unauthenticated request before touching Stripe', async () => {
+    mockAuthorize.mockResolvedValue({ ok: false, status: 401, error: 'Missing API key' });
+
+    const request = new NextRequest('http://localhost:3000/api/stripe/payments/create', {
+      method: 'POST',
+      body: JSON.stringify({ businessId: 'biz_123', amount: 10000, currency: 'usd' }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a key belonging to a different business', async () => {
+    mockAuthorize.mockResolvedValue({
+      ok: false,
+      status: 403,
+      error: 'API key does not belong to this business',
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/stripe/payments/create', {
+      method: 'POST',
+      body: JSON.stringify({ businessId: 'biz_someone_else', amount: 10000, currency: 'usd' }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('checks authorization against the business being charged', async () => {
+    const request = new NextRequest('http://localhost:3000/api/stripe/payments/create', {
+      method: 'POST',
+      body: JSON.stringify({ businessId: 'biz_123', amount: 10000, currency: 'usd' }),
+    });
+
+    await POST(request);
+    expect(mockAuthorize).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'biz_123');
   });
 });

--- a/src/app/api/stripe/payments/create/route.ts
+++ b/src/app/api/stripe/payments/create/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getStripe } from '@/lib/server/optional-deps';
+import { screenCheckout } from '@/lib/fraud/screen';
+import { getClientIp } from '@/lib/web-wallet/client-ip';
 
 function getSupabase() {
   return createClient(
@@ -66,6 +68,35 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Screen before the session exists — this is the last point at which we
+    // can stop a payment without Stripe ever seeing it.
+    const screening = await screenCheckout(supabase, {
+      businessId,
+      email: customerEmailValue,
+      ip: getClientIp(request),
+      amount,
+      currency,
+      description,
+    });
+
+    if (screening.decision === 'block') {
+      console.warn(
+        `[Fraud] Blocked checkout for business ${businessId} (score ${screening.score}):`,
+        screening.findings.map((f) => f.code).join(', ')
+      );
+      return NextResponse.json({ error: screening.buyerMessage }, { status: 403 });
+    }
+
+    // Elevated risk: let the payment through but force 3-D Secure, which moves
+    // liability for a stolen card back to the issuer.
+    const requiresVerification = screening.decision === 'verify';
+    if (requiresVerification) {
+      console.warn(
+        `[Fraud] Forcing 3DS for business ${businessId} (score ${screening.score}):`,
+        screening.findings.map((f) => f.code).join(', ')
+      );
+    }
+
     // Calculate platform fee (0.5% default)
     const platformFeeRate = 0.005;
     const platformFeeAmount = Math.round(amount * platformFeeRate);
@@ -94,6 +125,9 @@ export async function POST(request: NextRequest) {
         // Prefill the buyer's email on Stripe Checkout when the integration
         // already knows it (also captured on our side below, up front).
         ...(customerEmailValue ? { customer_email: customerEmailValue } : {}),
+        ...(requiresVerification
+          ? { payment_method_options: { card: { request_three_d_secure: 'any' as const } } }
+          : {}),
         payment_intent_data: {
           application_fee_amount: platformFeeAmount,
           on_behalf_of: stripeAccount.stripe_account_id,

--- a/src/app/api/stripe/payments/create/route.ts
+++ b/src/app/api/stripe/payments/create/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getStripe } from '@/lib/server/optional-deps';
 import { screenCheckout } from '@/lib/fraud/screen';
+import { authorizePaymentCreation } from '@/lib/auth/payment-auth';
 import { getClientIp } from '@/lib/web-wallet/client-ip';
 
 function getSupabase() {
@@ -32,6 +33,13 @@ export async function POST(request: NextRequest) {
         { error: 'businessId, amount, and currency are required' },
         { status: 400 }
       );
+    }
+
+    // Only the merchant being charged for (or the platform) may open a session
+    // against their Stripe account.
+    const auth = await authorizePaymentCreation(supabase, request, businessId);
+    if (!auth.ok) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
     }
 
     // Stable invoice number returned to the caller now, so an integration can

--- a/src/app/api/stripe/payments/create/route.ts
+++ b/src/app/api/stripe/payments/create/route.ts
@@ -88,10 +88,11 @@ export async function POST(request: NextRequest) {
     });
 
     if (screening.decision === 'block') {
-      console.warn(
-        `[Fraud] Blocked checkout for business ${businessId} (score ${screening.score}):`,
-        screening.findings.map((f) => f.code).join(', ')
-      );
+      console.warn('[Fraud] Blocked checkout', {
+        businessId,
+        score: screening.score,
+        findings: screening.findings.map((f) => f.code).join(', '),
+      });
       return NextResponse.json({ error: screening.buyerMessage }, { status: 403 });
     }
 
@@ -99,10 +100,11 @@ export async function POST(request: NextRequest) {
     // liability for a stolen card back to the issuer.
     const requiresVerification = screening.decision === 'verify';
     if (requiresVerification) {
-      console.warn(
-        `[Fraud] Forcing 3DS for business ${businessId} (score ${screening.score}):`,
-        screening.findings.map((f) => f.code).join(', ')
-      );
+      console.warn('[Fraud] Forcing 3DS', {
+        businessId,
+        score: screening.score,
+        findings: screening.findings.map((f) => f.code).join(', '),
+      });
     }
 
     // Calculate platform fee (0.5% default)

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getStripe } from '@/lib/server/optional-deps';
 import { sendPaymentWebhook } from '@/lib/webhooks/service';
+import { recordFraudEvent } from '@/lib/fraud/store';
+import { emailDomain, normalizeEmail } from '@/lib/fraud/signals';
 
 // Background-dispatch wrapper for merchant webhooks. sendPaymentWebhook
 // retries up to 3 times with a 30s timeout each — awaiting it inline could
@@ -370,6 +372,23 @@ async function recordCardFailure(supabase: ReturnType<typeof getSupabase>, strip
         .from('stripe_transactions')
         .upsert({ ...failFields, stripe_checkout_session_id: sessionId ?? null }, { onConflict: 'stripe_payment_intent_id' });
     }
+
+    // Feed the decline back into fraud screening. A run of these on one
+    // merchant or one network is what card testing looks like from our side.
+    const declineEmail = failFields.customer_email ?? session?.customer_details?.email ?? null;
+    await recordFraudEvent(supabase, {
+      businessId: businessId ?? null,
+      merchantId: merchantId ?? null,
+      kind: 'card_declined',
+      signals: {
+        email: declineEmail,
+        emailDomain: emailDomain(declineEmail),
+        emailNormalized: normalizeEmail(declineEmail),
+        amount: paymentIntent.amount ?? null,
+        currency: paymentIntent.currency || 'usd',
+      },
+      stripePaymentIntentId: paymentIntent.id,
+    });
   } catch (e) {
     console.error('[Stripe Webhook] recordCardFailure error:', e);
   }
@@ -575,11 +594,27 @@ async function handleDisputeCreated(dispute: any) {
     // Get merchant info from payment intent
     const { data: transaction } = await supabase
       .from('stripe_transactions')
-      .select('merchant_id')
+      .select('merchant_id, business_id, customer_email')
       .eq('stripe_payment_intent_id', paymentIntent)
       .single();
 
     if (!transaction) return;
+
+    // A dispute is the strongest confirmation that a card was not the buyer's.
+    await recordFraudEvent(supabase, {
+      businessId: transaction.business_id ?? null,
+      merchantId: transaction.merchant_id ?? null,
+      kind: 'dispute',
+      signals: {
+        email: transaction.customer_email ?? null,
+        emailDomain: emailDomain(transaction.customer_email),
+        emailNormalized: normalizeEmail(transaction.customer_email),
+        amount: dispute.amount ?? null,
+        currency: dispute.currency ?? null,
+        description: dispute.reason ? `dispute:${dispute.reason}` : null,
+      },
+      stripePaymentIntentId: paymentIntent,
+    });
 
     // Create dispute record
     await supabase

--- a/src/app/businesses/page.test.tsx
+++ b/src/app/businesses/page.test.tsx
@@ -205,10 +205,13 @@ describe('BusinessesPage', () => {
         screen.getByLabelText(/business name/i);
       });
 
-      // Fill form - now only name and description are required
+      // Fill form - name and category are required, description optional
       const nameInput = screen.getByLabelText(/business name/i);
 
       fireEvent.change(nameInput, { target: { value: 'New Business' } });
+      fireEvent.change(screen.getByLabelText(/^category/i), {
+        target: { value: 'saas' },
+      });
 
       // Mock create request
       vi.mocked(fetch).mockResolvedValueOnce({

--- a/src/app/businesses/page.tsx
+++ b/src/app/businesses/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { authFetch } from '@/lib/auth/client';
+import { ClassificationFields, CategoryBadge } from '@/components/business/ClassificationFields';
+import type { RiskLevel } from '@/lib/business/taxonomy';
 
 interface Business {
   id: string;
@@ -10,6 +12,10 @@ interface Business {
   description: string | null;
   webhook_url: string | null;
   organization_id: string | null;
+  category: string | null;
+  tags: string[] | null;
+  risk_level: RiskLevel | null;
+  review_status: string | null;
   created_at: string;
 }
 
@@ -30,6 +36,8 @@ export default function BusinessesPage() {
   const [formData, setFormData] = useState({
     name: '',
     description: '',
+    category: '',
+    tags: [] as string[],
   });
   const [saving, setSaving] = useState(false);
 
@@ -87,6 +95,8 @@ export default function BusinessesPage() {
     setFormData({
       name: '',
       description: '',
+      category: '',
+      tags: [],
     });
     setEditingBusiness(null);
     setShowCreateModal(true);
@@ -96,6 +106,8 @@ export default function BusinessesPage() {
     setFormData({
       name: business.name,
       description: business.description || '',
+      category: business.category || '',
+      tags: business.tags || [],
     });
     setEditingBusiness(business);
     setShowCreateModal(true);
@@ -276,10 +288,33 @@ export default function BusinessesPage() {
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
                     {business.name}
                   </h3>
+                  <div className="flex flex-wrap items-center gap-2 mb-2">
+                    <CategoryBadge
+                      category={business.category}
+                      riskLevel={business.risk_level}
+                    />
+                    {business.review_status === 'pending' && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full border border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-900/20 text-orange-800 dark:text-orange-400 text-xs">
+                        Pending review
+                      </span>
+                    )}
+                  </div>
                   {business.description && (
                     <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
                       {business.description}
                     </p>
+                  )}
+                  {business.tags && business.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mb-4">
+                      {business.tags.slice(0, 5).map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
                   )}
                   <div className="space-y-2 text-sm">
                     <div className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
@@ -358,10 +393,19 @@ export default function BusinessesPage() {
                       setFormData({ ...formData, description: e.target.value })
                     }
                     className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent text-gray-900 dark:text-white dark:bg-gray-700"
-                    placeholder="Optional description"
+                    placeholder="What does this business sell?"
                     rows={3}
                   />
                 </div>
+
+                <ClassificationFields
+                  value={{ category: formData.category, tags: formData.tags }}
+                  onChange={(v) =>
+                    setFormData({ ...formData, category: v.category, tags: v.tags })
+                  }
+                  name={formData.name}
+                  description={formData.description}
+                />
 
                 <p className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-900 p-3 rounded-lg">
                   💡 After creating your business, you can configure wallet addresses and webhooks in the business management page.

--- a/src/app/businesses/page.tsx
+++ b/src/app/businesses/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { authFetch } from '@/lib/auth/client';
 import { ClassificationFields, CategoryBadge } from '@/components/business/ClassificationFields';
-import type { RiskLevel } from '@/lib/business/taxonomy';
+import { getCategory, type RiskLevel } from '@/lib/business/taxonomy';
 
 interface Business {
   id: string;
@@ -40,6 +40,8 @@ export default function BusinessesPage() {
     tags: [] as string[],
   });
   const [saving, setSaving] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeTags, setActiveTags] = useState<string[]>([]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -87,9 +89,38 @@ export default function BusinessesPage() {
   };
 
   // Filter by the selected organization (empty = all).
-  const visibleBusinesses = activeOrg
+  const orgBusinesses = activeOrg
     ? businesses.filter((b) => b.organization_id === activeOrg)
     : businesses;
+
+  // Every tag in play, so they can be offered as one-click filters.
+  const allTags = [...new Set(orgBusinesses.flatMap((b) => b.tags ?? []))].sort();
+
+  // Search runs client-side: a merchant has few businesses, and filtering what
+  // is already loaded keeps it instant. The API supports ?search= and ?tag= for
+  // consumers with more.
+  const needle = query.trim().toLowerCase();
+  const visibleBusinesses = orgBusinesses.filter((b) => {
+    if (activeTags.length > 0 && !activeTags.every((t) => (b.tags ?? []).includes(t))) {
+      return false;
+    }
+    if (!needle) return true;
+    const haystack = [
+      b.name,
+      b.description ?? '',
+      (b.tags ?? []).join(' '),
+      getCategory(b.category)?.label ?? '',
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(needle);
+  });
+
+  const toggleTag = (tag: string) => {
+    setActiveTags((current) =>
+      current.includes(tag) ? current.filter((t) => t !== tag) : [...current, tag]
+    );
+  };
 
   const handleCreate = () => {
     setFormData({
@@ -229,6 +260,51 @@ export default function BusinessesPage() {
             </button>
           </div>
         </div>
+
+        {/* Search + tag filters */}
+        {businesses.length > 0 && (
+          <div className="mb-6 space-y-3">
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name, description, keyword or category"
+              aria-label="Search businesses"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent text-gray-900 dark:text-white dark:bg-gray-700"
+            />
+            {allTags.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                {allTags.map((tag) => {
+                  const active = activeTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => toggleTag(tag)}
+                      aria-pressed={active}
+                      className={`px-2 py-1 rounded-full text-xs border ${
+                        active
+                          ? 'bg-purple-600 text-white border-purple-600'
+                          : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                      }`}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+                {activeTags.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setActiveTags([])}
+                    className="text-xs text-purple-600 hover:text-purple-500"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Error Message */}
         {error && (

--- a/src/components/business/ClassificationFields.tsx
+++ b/src/components/business/ClassificationFields.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  BUSINESS_CATEGORIES,
+  CATEGORY_GROUPS,
+  MAX_TAGS,
+  classifyBusiness,
+  getCategory,
+  normalizeTags,
+  suggestCategories,
+  suggestTags,
+  type RiskLevel,
+} from '@/lib/business/taxonomy';
+
+export interface ClassificationValue {
+  category: string;
+  tags: string[];
+}
+
+interface ClassificationFieldsProps {
+  value: ClassificationValue;
+  onChange: (value: ClassificationValue) => void;
+  /** Used to suggest a category and to preview the risk level. */
+  name?: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+const RISK_STYLES: Record<RiskLevel, string> = {
+  low: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800',
+  medium:
+    'bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800',
+  high: 'bg-orange-50 text-orange-800 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400 dark:border-orange-800',
+  prohibited:
+    'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800',
+};
+
+const RISK_LABELS: Record<RiskLevel, string> = {
+  low: 'Standard',
+  medium: 'Standard — extra detail helps',
+  high: 'Needs review before going live',
+  prohibited: 'Not supported',
+};
+
+export function ClassificationFields({
+  value,
+  onChange,
+  name = '',
+  description = '',
+  disabled = false,
+}: ClassificationFieldsProps) {
+  const [tagDraft, setTagDraft] = useState('');
+
+  const categorySuggestions = useMemo(
+    () => suggestCategories(`${name} ${description}`),
+    [name, description]
+  );
+
+  const tagSuggestions = useMemo(
+    () =>
+      suggestTags(tagDraft, value.category, 6).filter((tag) => !value.tags.includes(tag)),
+    [tagDraft, value.category, value.tags]
+  );
+
+  // Preview only — the server re-runs the same classifier on save.
+  const preview = useMemo(
+    () =>
+      classifyBusiness({
+        name,
+        description,
+        category: value.category,
+        tags: value.tags,
+      }),
+    [name, description, value.category, value.tags]
+  );
+
+  const addTag = (raw: string) => {
+    const [tag] = normalizeTags([raw]);
+    if (!tag || value.tags.includes(tag) || value.tags.length >= MAX_TAGS) {
+      setTagDraft('');
+      return;
+    }
+    onChange({ ...value, tags: [...value.tags, tag] });
+    setTagDraft('');
+  };
+
+  const removeTag = (tag: string) => {
+    onChange({ ...value, tags: value.tags.filter((t) => t !== tag) });
+  };
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',' || e.key === 'Tab') {
+      if (!tagDraft.trim()) return;
+      e.preventDefault();
+      addTag(tagDraft);
+      return;
+    }
+    if (e.key === 'Backspace' && !tagDraft && value.tags.length > 0) {
+      removeTag(value.tags[value.tags.length - 1]);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="category"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+        >
+          Category *
+        </label>
+        <select
+          id="category"
+          required
+          disabled={disabled}
+          value={value.category}
+          onChange={(e) => onChange({ ...value, category: e.target.value })}
+          className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent text-gray-900 dark:text-white dark:bg-gray-700"
+        >
+          <option value="">Select a category…</option>
+          {CATEGORY_GROUPS.map((group) => (
+            <optgroup key={group} label={group}>
+              {BUSINESS_CATEGORIES.filter((c) => c.group === group).map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+
+        {categorySuggestions.length > 0 && !value.category && (
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-gray-500 dark:text-gray-400">Looks like:</span>
+            {categorySuggestions.map((s) => (
+              <button
+                key={s.slug}
+                type="button"
+                disabled={disabled}
+                onClick={() => onChange({ ...value, category: s.slug })}
+                className="px-2 py-1 rounded-full border border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/20"
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="tags"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+        >
+          Keywords
+        </label>
+
+        <div className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus-within:ring-2 focus-within:ring-purple-500 dark:bg-gray-700 flex flex-wrap gap-2">
+          {value.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200 text-sm"
+            >
+              {tag}
+              <button
+                type="button"
+                aria-label={`Remove ${tag}`}
+                disabled={disabled}
+                onClick={() => removeTag(tag)}
+                className="text-purple-500 hover:text-purple-800 dark:hover:text-white"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            id="tags"
+            type="text"
+            disabled={disabled || value.tags.length >= MAX_TAGS}
+            value={tagDraft}
+            onChange={(e) => setTagDraft(e.target.value)}
+            onKeyDown={handleTagKeyDown}
+            onBlur={() => tagDraft.trim() && addTag(tagDraft)}
+            className="flex-1 min-w-[8rem] px-2 py-1 bg-transparent outline-none text-gray-900 dark:text-white"
+            placeholder={
+              value.tags.length >= MAX_TAGS
+                ? `Limit ${MAX_TAGS} keywords`
+                : 'e.g. streaming, iptv — press Enter'
+            }
+          />
+        </div>
+
+        {tagSuggestions.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tagSuggestions.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                disabled={disabled}
+                onClick={() => addTag(tag)}
+                className="px-2 py-1 rounded-full border border-gray-300 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                + {tag}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          What do you actually sell? These help us route your account correctly.
+        </p>
+      </div>
+
+      {value.category && (
+        <div className={`border rounded-lg p-3 text-sm ${RISK_STYLES[preview.riskLevel]}`}>
+          <div className="font-medium">{RISK_LABELS[preview.riskLevel]}</div>
+          {preview.riskLevel !== 'low' && preview.flags.length > 0 && (
+            <ul className="mt-1 list-disc list-inside space-y-0.5">
+              {preview.flags.slice(0, 4).map((flag) => (
+                <li key={flag.code}>
+                  {flag.label}
+                  {flag.matched.length > 0 && ` (${flag.matched.slice(0, 3).join(', ')})`}
+                </li>
+              ))}
+            </ul>
+          )}
+          {preview.reviewRequired && (
+            <p className="mt-1">
+              We&apos;ll review this before it can accept payments. You can still finish
+              setup now.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Small read-only badge for list and detail views. */
+export function CategoryBadge({
+  category,
+  riskLevel,
+}: {
+  category?: string | null;
+  riskLevel?: RiskLevel | null;
+}) {
+  const def = getCategory(category);
+  if (!def) return null;
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full border text-xs ${
+        riskLevel ? RISK_STYLES[riskLevel] : RISK_STYLES.low
+      }`}
+    >
+      {def.label}
+    </span>
+  );
+}

--- a/src/components/business/GeneralTab.tsx
+++ b/src/components/business/GeneralTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Business } from './types';
+import { ClassificationFields, CategoryBadge } from './ClassificationFields';
 
 interface GeneralTabProps {
   business: Business;
@@ -14,6 +15,8 @@ export function GeneralTab({ business, onUpdate, onCopy }: GeneralTabProps) {
   const [formData, setFormData] = useState({
     name: business.name,
     description: business.description || '',
+    category: business.category || '',
+    tags: business.tags || [],
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -116,6 +119,13 @@ export function GeneralTab({ business, onUpdate, onCopy }: GeneralTabProps) {
             />
           </div>
 
+          <ClassificationFields
+            value={{ category: formData.category, tags: formData.tags }}
+            onChange={(v) => setFormData({ ...formData, category: v.category, tags: v.tags })}
+            name={formData.name}
+            description={formData.description}
+          />
+
           <div className="flex items-center space-x-3 pt-4">
             <button
               type="submit"
@@ -131,6 +141,8 @@ export function GeneralTab({ business, onUpdate, onCopy }: GeneralTabProps) {
                 setFormData({
                   name: business.name,
                   description: business.description || '',
+                  category: business.category || '',
+                  tags: business.tags || [],
                 });
                 setError('');
               }}
@@ -172,6 +184,44 @@ export function GeneralTab({ business, onUpdate, onCopy }: GeneralTabProps) {
                 Description
               </label>
               <p className="text-gray-900 dark:text-white">{business.description}</p>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+              Category
+            </label>
+            {business.category ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <CategoryBadge category={business.category} riskLevel={business.risk_level} />
+                {business.review_status === 'pending' && (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full border border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-900/20 text-orange-800 dark:text-orange-400 text-xs">
+                    Pending review
+                  </span>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Not categorized yet — edit to add one.
+              </p>
+            )}
+          </div>
+
+          {business.tags && business.tags.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                Keywords
+              </label>
+              <div className="flex flex-wrap gap-1">
+                {business.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
 

--- a/src/components/business/types.ts
+++ b/src/components/business/types.ts
@@ -1,3 +1,5 @@
+import type { RiskLevel } from '@/lib/business/taxonomy';
+
 export interface Business {
   id: string;
   name: string;
@@ -5,6 +7,10 @@ export interface Business {
   webhook_url: string | null;
   webhook_secret: string | null;
   api_key: string | null;
+  category: string | null;
+  tags: string[] | null;
+  risk_level: RiskLevel | null;
+  review_status: string | null;
   created_at: string;
 }
 

--- a/src/lib/auth/payment-auth.test.ts
+++ b/src/lib/auth/payment-auth.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockAuthenticate, mockRoles } = vi.hoisted(() => ({
+  mockAuthenticate: vi.fn(),
+  mockRoles: vi.fn(),
+}));
+
+vi.mock('./middleware', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./middleware')>();
+  return { ...actual, authenticateRequest: mockAuthenticate };
+});
+
+vi.mock('./authz', () => ({ getAccessibleBusinessRoles: mockRoles }));
+
+import { authorizePaymentCreation } from './payment-auth';
+
+const supabase = {} as any;
+
+function requestWith(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/stripe/payments/create', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('authorizePaymentCreation', () => {
+  const originalInternalKey = process.env.INTERNAL_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.INTERNAL_API_KEY;
+    mockRoles.mockResolvedValue(new Map());
+  });
+
+  afterEach(() => {
+    if (originalInternalKey === undefined) delete process.env.INTERNAL_API_KEY;
+    else process.env.INTERNAL_API_KEY = originalInternalKey;
+  });
+
+  it('rejects a request with no credentials', async () => {
+    const result = await authorizePaymentCreation(supabase, requestWith(), 'biz-1');
+    expect(result).toEqual({ ok: false, status: 401, error: 'Missing API key' });
+  });
+
+  it('rejects credentials that do not authenticate', async () => {
+    mockAuthenticate.mockResolvedValue({ success: false, error: 'Invalid API key' });
+    const result = await authorizePaymentCreation(
+      supabase,
+      requestWith({ authorization: 'Bearer cp_live_bogus' }),
+      'biz-1'
+    );
+    expect(result).toEqual({ ok: false, status: 401, error: 'Invalid API key' });
+  });
+
+  describe('business API keys', () => {
+    it('accepts a key scoped to the business being charged', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'business', businessId: 'biz-1', merchantId: 'm-1', businessName: 'B', scopes: ['*'] },
+      });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer cp_live_key' }),
+        'biz-1'
+      );
+      expect(result).toEqual({ ok: true, via: 'api_key', merchantId: 'm-1' });
+    });
+
+    it('refuses a valid key for a different business', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'business', businessId: 'biz-other', merchantId: 'm-2', businessName: 'B', scopes: ['*'] },
+      });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer cp_live_key' }),
+        'biz-1'
+      );
+      expect(result).toEqual({
+        ok: false,
+        status: 403,
+        error: 'API key does not belong to this business',
+      });
+    });
+
+    it('requires the payments:create scope', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'business', businessId: 'biz-1', merchantId: 'm-1', businessName: 'B', scopes: ['payments:read'] },
+      });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer cp_live_key' }),
+        'biz-1'
+      );
+      expect(result.ok).toBe(false);
+      expect((result as any).status).toBe(403);
+    });
+
+    it('accepts the key from the x-api-key header too', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'business', businessId: 'biz-1', merchantId: 'm-1', businessName: 'B', scopes: ['payments:create'] },
+      });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ 'x-api-key': 'cp_live_key' }),
+        'biz-1'
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('merchant JWTs', () => {
+    it('accepts a merchant with write access', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'merchant', merchantId: 'm-1', email: 'a@b.c' },
+      });
+      mockRoles.mockResolvedValue(new Map([['biz-1', 'owner']]));
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer jwt' }),
+        'biz-1'
+      );
+      expect(result).toEqual({ ok: true, via: 'jwt', merchantId: 'm-1' });
+    });
+
+    it('refuses a merchant with no access to the business', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'merchant', merchantId: 'm-1', email: 'a@b.c' },
+      });
+      mockRoles.mockResolvedValue(new Map());
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer jwt' }),
+        'biz-1'
+      );
+      expect(result).toEqual({ ok: false, status: 403, error: 'No access to this business' });
+    });
+
+    it('refuses a read-only team member', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: true,
+        context: { type: 'merchant', merchantId: 'm-1', email: 'a@b.c' },
+      });
+      mockRoles.mockResolvedValue(new Map([['biz-1', 'readonly']]));
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer jwt' }),
+        'biz-1'
+      );
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('internal key', () => {
+    it('accepts the configured internal key', async () => {
+      process.env.INTERNAL_API_KEY = 'internal-secret';
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer internal-secret' }),
+        'biz-1'
+      );
+      expect(result).toEqual({ ok: true, via: 'internal', merchantId: null });
+      expect(mockAuthenticate).not.toHaveBeenCalled();
+    });
+
+    it('does not treat an unset internal key as a match', async () => {
+      delete process.env.INTERNAL_API_KEY;
+      mockAuthenticate.mockResolvedValue({ success: false, error: 'Invalid API key' });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer undefined' }),
+        'biz-1'
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it('does not let a blank internal key authorize anything', async () => {
+      process.env.INTERNAL_API_KEY = '   ';
+      mockAuthenticate.mockResolvedValue({ success: false, error: 'Invalid API key' });
+
+      const result = await authorizePaymentCreation(
+        supabase,
+        requestWith({ authorization: 'Bearer    ' }),
+        'biz-1'
+      );
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/src/lib/auth/payment-auth.ts
+++ b/src/lib/auth/payment-auth.ts
@@ -1,0 +1,83 @@
+/**
+ * Authorization for payment-session creation.
+ *
+ * Creating a checkout session spends a merchant's Stripe account and puts their
+ * name on the payment page, so it must be something only that merchant (or the
+ * platform itself) can do. This gate accepts three callers:
+ *
+ *   1. A business API key — the SDKs and the WHMCS/WooCommerce plugins already
+ *      send one. It must belong to the business being charged for.
+ *   2. A merchant JWT — the dashboard. The merchant needs write access to the
+ *      business, directly or through their org/team.
+ *   3. INTERNAL_API_KEY — server-to-server, used by the recurring-payment
+ *      monitor. Never accepted when the env var is unset or blank.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+import { authenticateRequest, extractBearerToken, isMerchantAuth } from './middleware';
+import { getAccessibleBusinessRoles } from './authz';
+import { can } from './permissions';
+import { scopesSatisfy } from './scoped-keys';
+
+export type PaymentAuthResult =
+  | { ok: true; via: 'api_key' | 'jwt' | 'internal'; merchantId: string | null }
+  | { ok: false; status: number; error: string };
+
+/** Accept the key from `Authorization: Bearer` or the `x-api-key` header. */
+function tokenFrom(request: NextRequest): string | null {
+  const bearer = extractBearerToken(request.headers.get('authorization'));
+  if (bearer) return bearer;
+  const apiKeyHeader = request.headers.get('x-api-key');
+  return apiKeyHeader?.trim() || null;
+}
+
+/**
+ * Decide whether this request may create a payment session for `businessId`.
+ */
+export async function authorizePaymentCreation(
+  supabase: SupabaseClient,
+  request: NextRequest,
+  businessId: string
+): Promise<PaymentAuthResult> {
+  const token = tokenFrom(request);
+  if (!token) {
+    return { ok: false, status: 401, error: 'Missing API key' };
+  }
+
+  // Service-to-service. Compared only when configured, so an unset env var can
+  // never turn an empty or absent token into a valid one.
+  const internalKey = process.env.INTERNAL_API_KEY;
+  if (internalKey && internalKey.trim() && token === internalKey) {
+    return { ok: true, via: 'internal', merchantId: null };
+  }
+
+  const auth = await authenticateRequest(supabase, `Bearer ${token}`);
+  if (!auth.success || !auth.context) {
+    return { ok: false, status: 401, error: auth.error || 'Invalid credentials' };
+  }
+
+  // Merchant JWT: needs write access to this business.
+  if (isMerchantAuth(auth.context)) {
+    const merchantId = auth.context.merchantId;
+    const roles = await getAccessibleBusinessRoles(supabase, merchantId);
+    const role = roles.get(businessId);
+    if (!role || !can(role, 'paymentlink.write')) {
+      return { ok: false, status: 403, error: 'No access to this business' };
+    }
+    return { ok: true, via: 'jwt', merchantId };
+  }
+
+  // Business API key: must be a key for the business being charged for.
+  // Without this check, any valid key on the platform could bill any merchant.
+  const context = auth.context;
+  if (context.businessId !== businessId) {
+    return { ok: false, status: 403, error: 'API key does not belong to this business' };
+  }
+
+  if (!scopesSatisfy(context.scopes, 'payments:create')) {
+    return { ok: false, status: 403, error: 'API key is missing the payments:create scope' };
+  }
+
+  return { ok: true, via: 'api_key', merchantId: context.merchantId };
+}

--- a/src/lib/business/service.test.ts
+++ b/src/lib/business/service.test.ts
@@ -95,6 +95,7 @@ describe('Business Service', () => {
       const result = await createBusiness(mockSupabase, 'merchant-123', {
         name: 'Test Business',
         description: 'Test Description',
+        category: 'saas',
         webhook_url: 'https://example.com/webhook',
         webhook_secret: 'my-secret',
       });
@@ -138,6 +139,7 @@ describe('Business Service', () => {
 
       const result = await createBusiness(mockSupabase, 'merchant-123', {
         name: 'Test Business',
+        category: 'saas',
       });
 
       if (!result.success) {

--- a/src/lib/business/service.ts
+++ b/src/lib/business/service.ts
@@ -9,6 +9,7 @@ import { can } from '../auth/permissions';
 import {
   classifyBusiness,
   isValidCategory,
+  normalizeTags,
   type Classification,
   type RiskFlag,
   type RiskLevel,
@@ -218,6 +219,47 @@ export interface BusinessListResult {
   error?: string;
 }
 
+export interface BusinessFilters {
+  /** Free text matched against name and description. */
+  search?: string | null;
+  /** Every one of these tags must be present. */
+  tags?: string[] | null;
+  category?: string | null;
+  riskLevel?: string | null;
+  reviewStatus?: string | null;
+}
+
+/** PostgREST treats these as operators inside `or(...)`, so they must go. */
+function escapeForOr(value: string): string {
+  return value.replace(/[,()]/g, ' ').trim();
+}
+
+/**
+ * Apply search and facet filters to a `businesses` query. Shared by the merchant
+ * list and the admin console so both understand the same query string.
+ */
+export function applyBusinessFilters<T>(query: T, filters: BusinessFilters): T {
+  let q = query as any;
+
+  const search = typeof filters.search === 'string' ? escapeForOr(filters.search) : '';
+  if (search) {
+    q = q.or(`name.ilike.%${search}%,description.ilike.%${search}%`);
+  }
+
+  const tags = normalizeTags(filters.tags ?? []);
+  if (tags.length > 0) {
+    // `contains` is an AND across the array — narrowing, which is what a tag
+    // filter should do.
+    q = q.contains('tags', tags);
+  }
+
+  if (filters.category) q = q.eq('category', filters.category);
+  if (filters.riskLevel) q = q.eq('risk_level', filters.riskLevel);
+  if (filters.reviewStatus) q = q.eq('review_status', filters.reviewStatus);
+
+  return q as T;
+}
+
 /**
  * Get encryption key for business data
  */
@@ -386,7 +428,8 @@ export async function listBusinesses(
  */
 export async function listAccessibleBusinesses(
   supabase: SupabaseClient,
-  merchantId: string
+  merchantId: string,
+  filters: BusinessFilters = {}
 ): Promise<BusinessListResult> {
   try {
     const roleMap = await getAccessibleBusinessRoles(supabase, merchantId);
@@ -395,10 +438,10 @@ export async function listAccessibleBusinesses(
       return { success: true, businesses: [] };
     }
 
-    const { data: businesses, error } = await supabase
-      .from('businesses')
-      .select('*')
-      .in('id', ids);
+    let query = supabase.from('businesses').select('*').in('id', ids);
+    query = applyBusinessFilters(query, filters);
+
+    const { data: businesses, error } = await query;
 
     if (error) {
       return { success: false, error: error.message };
@@ -597,6 +640,105 @@ export async function updateBusiness(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Business update failed',
+    };
+  }
+}
+
+export type TagOperation = 'replace' | 'add' | 'remove';
+
+export interface TagsResult {
+  success: boolean;
+  tags?: string[];
+  classification?: Classification;
+  error?: string;
+}
+
+/**
+ * Read the keyword tags on a business.
+ */
+export async function getBusinessTags(
+  supabase: SupabaseClient,
+  businessId: string
+): Promise<TagsResult> {
+  try {
+    const { data, error } = await supabase
+      .from('businesses')
+      .select('tags')
+      .eq('id', businessId)
+      .maybeSingle();
+
+    if (error || !data) {
+      return { success: false, error: error?.message || 'Business not found' };
+    }
+    return { success: true, tags: (data.tags as string[]) ?? [] };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to read tags',
+    };
+  }
+}
+
+/**
+ * Add, remove or replace keyword tags, then reclassify.
+ *
+ * Tags feed the risk classifier, so every write here re-derives risk_level and
+ * review_status — a business cannot quietly drop the "iptv" tag to shed its
+ * rating, because the name and description still carry the signal.
+ */
+export async function mutateBusinessTags(
+  supabase: SupabaseClient,
+  businessId: string,
+  operation: TagOperation,
+  tags: string[]
+): Promise<TagsResult> {
+  try {
+    const { data: current, error: fetchError } = await supabase
+      .from('businesses')
+      .select('name, description, category, tags')
+      .eq('id', businessId)
+      .maybeSingle();
+
+    if (fetchError || !current) {
+      return { success: false, error: fetchError?.message || 'Business not found' };
+    }
+
+    const incoming = normalizeTags(tags);
+    const existing = normalizeTags((current.tags as string[]) ?? []);
+
+    let nextTags: string[];
+    if (operation === 'replace') {
+      nextTags = incoming;
+    } else if (operation === 'add') {
+      nextTags = normalizeTags([...existing, ...incoming]);
+    } else {
+      const drop = new Set(incoming);
+      nextTags = existing.filter((tag) => !drop.has(tag));
+    }
+
+    const { classification, columns } = classificationColumns({
+      name: current.name,
+      description: current.description,
+      category: current.category,
+      tags: nextTags,
+    });
+
+    const { data: updated, error } = await supabase
+      .from('businesses')
+      .update(columns)
+      .eq('id', businessId)
+      .select('tags')
+      .single();
+
+    if (error || !updated) {
+      return { success: false, error: error?.message || 'Failed to update tags' };
+    }
+
+    return { success: true, tags: (updated.tags as string[]) ?? [], classification };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update tags',
     };
   }
 }

--- a/src/lib/business/service.ts
+++ b/src/lib/business/service.ts
@@ -6,6 +6,14 @@ import { z } from 'zod';
 import { resolveWebhookSecret } from '../webhooks/secret';
 import { getAccessibleBusinessRoles } from '../auth/authz';
 import { can } from '../auth/permissions';
+import {
+  classifyBusiness,
+  isValidCategory,
+  normalizeTags,
+  type Classification,
+  type RiskFlag,
+  type RiskLevel,
+} from './taxonomy';
 
 /**
  * Generate a secure webhook secret
@@ -108,11 +116,58 @@ const webhookUrlSchema = z.string().url('Invalid webhook URL').optional();
 const descriptionSchema = z.string().max(500).optional();
 
 /**
+ * Categorization is required on create so no business goes live unclassified.
+ * The slug must exist in the taxonomy — see src/lib/business/taxonomy.ts.
+ */
+function validateCategory(category: unknown): string | undefined {
+  if (!isValidCategory(category)) {
+    return 'Select a valid business category';
+  }
+  return undefined;
+}
+
+/**
+ * Run the classifier and turn it into the derived columns. Merchants never set
+ * these directly — a merchant-supplied risk_level would be worthless.
+ */
+function classificationColumns(input: {
+  name?: string | null;
+  description?: string | null;
+  category?: string | null;
+  tags?: string[] | null;
+}): {
+  classification: Classification;
+  columns: {
+    category: string | null;
+    tags: string[];
+    risk_level: RiskLevel;
+    risk_flags: RiskFlag[];
+    review_status: string;
+    classified_at: string;
+  };
+} {
+  const classification = classifyBusiness(input);
+  return {
+    classification,
+    columns: {
+      category: classification.category,
+      tags: classification.tags,
+      risk_level: classification.riskLevel,
+      risk_flags: classification.flags,
+      review_status: classification.reviewRequired ? 'pending' : 'not_required',
+      classified_at: new Date().toISOString(),
+    },
+  };
+}
+
+/**
  * Types
  */
 export interface CreateBusinessInput {
   name: string;
   description?: string;
+  category?: string;
+  tags?: string[];
   webhook_url?: string;
   webhook_secret?: string;
   webhook_events?: string[];
@@ -121,6 +176,8 @@ export interface CreateBusinessInput {
 export interface UpdateBusinessInput {
   name?: string;
   description?: string;
+  category?: string;
+  tags?: string[];
   webhook_url?: string;
   webhook_secret?: string;
   webhook_events?: string[];
@@ -132,6 +189,12 @@ export interface Business {
   merchant_id: string;
   name: string;
   description?: string;
+  category?: string | null;
+  tags?: string[];
+  risk_level?: RiskLevel | null;
+  risk_flags?: RiskFlag[];
+  review_status?: string;
+  classified_at?: string | null;
   webhook_url?: string;
   webhook_secret?: string;
   webhook_events?: string[];
@@ -145,6 +208,8 @@ export interface Business {
 export interface BusinessResult {
   success: boolean;
   business?: Business;
+  /** Present when this call (re)classified the business. */
+  classification?: Classification;
   error?: string;
 }
 
@@ -205,6 +270,23 @@ export async function createBusiness(
       }
     }
 
+    // Categorize before anything else — an unclassified business should never
+    // reach the point of collecting money.
+    const categoryError = validateCategory(input.category);
+    if (categoryError) {
+      return {
+        success: false,
+        error: categoryError,
+      };
+    }
+
+    const { classification, columns: classificationData } = classificationColumns({
+      name: input.name,
+      description: input.description,
+      category: input.category,
+      tags: input.tags,
+    });
+
     // Generate and encrypt webhook secret if webhook URL is provided
     let encryptedSecret: string | undefined;
     if (input.webhook_url) {
@@ -235,6 +317,7 @@ export async function createBusiness(
         organization_id: merchant?.default_org_id ?? null,
         name: input.name,
         description: input.description,
+        ...classificationData,
         webhook_url: input.webhook_url,
         webhook_secret: encryptedSecret,
         webhook_events: input.webhook_events || ['payment.confirmed', 'payment.forwarded'],
@@ -255,6 +338,7 @@ export async function createBusiness(
     return {
       success: true,
       business: business as Business,
+      classification,
     };
   } catch (error) {
     return {
@@ -415,10 +499,21 @@ export async function updateBusiness(
       }
     }
 
-    // Fetch current business to check if webhook URL has changed
+    if (input.category !== undefined) {
+      const categoryError = validateCategory(input.category);
+      if (categoryError) {
+        return {
+          success: false,
+          error: categoryError,
+        };
+      }
+    }
+
+    // Fetch current business to check if webhook URL has changed, and to
+    // reclassify against the merged record rather than the partial patch.
     const { data: currentBusiness, error: fetchError } = await supabase
       .from('businesses')
-      .select('webhook_url, webhook_secret')
+      .select('webhook_url, webhook_secret, name, description, category, tags')
       .eq('id', businessId)
       .eq('merchant_id', merchantId)
       .single();
@@ -436,6 +531,26 @@ export async function updateBusiness(
     if (input.name !== undefined) updateData.name = input.name;
     if (input.description !== undefined) updateData.description = input.description;
     if (input.webhook_url !== undefined) updateData.webhook_url = input.webhook_url;
+
+    // Anything the classifier reads changing means the verdict is stale.
+    let classification: Classification | undefined;
+    const reclassify =
+      input.name !== undefined ||
+      input.description !== undefined ||
+      input.category !== undefined ||
+      input.tags !== undefined;
+
+    if (reclassify) {
+      const merged = classificationColumns({
+        name: input.name ?? currentBusiness.name,
+        description: input.description ?? currentBusiness.description,
+        category: input.category ?? currentBusiness.category,
+        tags: input.tags ?? currentBusiness.tags,
+      });
+      classification = merged.classification;
+      Object.assign(updateData, merged.columns);
+    }
+
     if (input.webhook_events !== undefined) updateData.webhook_events = input.webhook_events;
     if (input.active !== undefined) updateData.active = input.active;
 
@@ -477,6 +592,7 @@ export async function updateBusiness(
     return {
       success: true,
       business: business as Business,
+      classification,
     };
   } catch (error) {
     return {

--- a/src/lib/business/service.ts
+++ b/src/lib/business/service.ts
@@ -9,7 +9,6 @@ import { can } from '../auth/permissions';
 import {
   classifyBusiness,
   isValidCategory,
-  normalizeTags,
   type Classification,
   type RiskFlag,
   type RiskLevel,

--- a/src/lib/business/tags.test.ts
+++ b/src/lib/business/tags.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { applyBusinessFilters, getBusinessTags, mutateBusinessTags } from './service';
+
+/** Minimal PostgREST-ish chain recorder. */
+function makeQuery() {
+  const calls: { method: string; args: any[] }[] = [];
+  const query: any = {};
+  for (const method of ['or', 'contains', 'eq', 'in', 'select']) {
+    query[method] = (...args: any[]) => {
+      calls.push({ method, args });
+      return query;
+    };
+  }
+  query.__calls = calls;
+  return query;
+}
+
+describe('applyBusinessFilters', () => {
+  it('does nothing without filters', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, {});
+    expect(q.__calls).toHaveLength(0);
+  });
+
+  it('searches name and description together', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, { search: 'stream' });
+    expect(q.__calls[0].method).toBe('or');
+    expect(q.__calls[0].args[0]).toBe('name.ilike.%stream%,description.ilike.%stream%');
+  });
+
+  it('strips characters that would break the or() grammar', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, { search: 'a,b(c)' });
+    expect(q.__calls[0].args[0]).not.toMatch(/[(),].*ilike.*[(),]/);
+    expect(q.__calls[0].args[0]).toContain('a b c');
+  });
+
+  it('narrows on every tag, normalized', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, { tags: ['#IPTV', 'Streaming'] });
+    const contains = q.__calls.find((c: any) => c.method === 'contains');
+    expect(contains.args).toEqual(['tags', ['iptv', 'streaming']]);
+  });
+
+  it('ignores empty tag lists', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, { tags: [] });
+    expect(q.__calls.find((c: any) => c.method === 'contains')).toBeUndefined();
+  });
+
+  it('applies the facets', () => {
+    const q = makeQuery();
+    applyBusinessFilters(q, { category: 'saas', riskLevel: 'high', reviewStatus: 'pending' });
+    const eqs = q.__calls.filter((c: any) => c.method === 'eq').map((c: any) => c.args);
+    expect(eqs).toEqual([
+      ['category', 'saas'],
+      ['risk_level', 'high'],
+      ['review_status', 'pending'],
+    ]);
+  });
+});
+
+describe('tag CRUD', () => {
+  let current: any;
+  let updated: any;
+  let supabase: any;
+
+  beforeEach(() => {
+    current = {
+      name: 'StreamBox',
+      description: 'Subscriptions',
+      category: 'saas',
+      tags: ['streaming', 'vod'],
+    };
+    updated = null;
+
+    supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: current, error: null }),
+          })),
+        })),
+        update: vi.fn((columns: any) => {
+          updated = columns;
+          return {
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({ data: { tags: columns.tags }, error: null }),
+              })),
+            })),
+          };
+        }),
+      })),
+    };
+  });
+
+  it('reads the current tags', async () => {
+    supabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: { tags: ['a', 'b'] }, error: null }),
+        })),
+      })),
+    }));
+    const result = await getBusinessTags(supabase, 'biz-1');
+    expect(result.success).toBe(true);
+    expect(result.tags).toEqual(['a', 'b']);
+  });
+
+  it('adds without dropping what is there', async () => {
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'add', ['IPTV']);
+    expect(result.success).toBe(true);
+    expect(result.tags).toEqual(['streaming', 'vod', 'iptv']);
+  });
+
+  it('does not duplicate an existing tag', async () => {
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'add', ['#Streaming']);
+    expect(result.tags).toEqual(['streaming', 'vod']);
+  });
+
+  it('removes a tag', async () => {
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'remove', ['vod']);
+    expect(result.tags).toEqual(['streaming']);
+  });
+
+  it('replaces the whole set', async () => {
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'replace', ['iptv']);
+    expect(result.tags).toEqual(['iptv']);
+  });
+
+  it('reclassifies on every write', async () => {
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'add', ['iptv']);
+    expect(updated.risk_level).toBe('high');
+    expect(updated.review_status).toBe('pending');
+    expect(result.classification?.flags.map((f) => f.code)).toContain('piracy');
+  });
+
+  it('cannot shed a rating by dropping the tag when the name still carries it', async () => {
+    current.name = 'IPTV Reseller Panel';
+    const result = await mutateBusinessTags(supabase, 'biz-1', 'replace', []);
+    expect(result.tags).toEqual([]);
+    expect(updated.risk_level).toBe('high');
+  });
+
+  it('reports a missing business', async () => {
+    supabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      })),
+    }));
+    const result = await mutateBusinessTags(supabase, 'nope', 'add', ['x']);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Business not found');
+  });
+});

--- a/src/lib/business/taxonomy.test.ts
+++ b/src/lib/business/taxonomy.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BUSINESS_CATEGORIES,
+  CATEGORY_GROUPS,
+  classifyBusiness,
+  isValidCategory,
+  normalizeTags,
+  suggestCategories,
+  suggestTags,
+  maxRisk,
+  MAX_TAGS,
+  MAX_TAG_LENGTH,
+} from './taxonomy';
+
+describe('taxonomy integrity', () => {
+  it('has unique slugs', () => {
+    const slugs = BUSINESS_CATEGORIES.map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('only uses declared groups', () => {
+    for (const category of BUSINESS_CATEGORIES) {
+      expect(CATEGORY_GROUPS).toContain(category.group as (typeof CATEGORY_GROUPS)[number]);
+    }
+  });
+
+  it('validates slugs', () => {
+    expect(isValidCategory('streaming-iptv')).toBe(true);
+    expect(isValidCategory('not-a-category')).toBe(false);
+    expect(isValidCategory(undefined)).toBe(false);
+  });
+});
+
+describe('normalizeTags', () => {
+  it('lowercases, strips hashes and dedupes', () => {
+    expect(normalizeTags(['#IPTV', 'iptv', '  Streaming  '])).toEqual(['iptv', 'streaming']);
+  });
+
+  it('drops non-strings and empties', () => {
+    expect(normalizeTags(['ok', 42, '', '   ', null])).toEqual(['ok']);
+  });
+
+  it('caps count and length', () => {
+    const many = Array.from({ length: 50 }, (_, i) => `tag${i}`);
+    expect(normalizeTags(many)).toHaveLength(MAX_TAGS);
+    const long = 'a'.repeat(100);
+    expect(normalizeTags([long])[0]).toHaveLength(MAX_TAG_LENGTH);
+  });
+
+  it('returns empty for non-arrays', () => {
+    expect(normalizeTags('iptv')).toEqual([]);
+    expect(normalizeTags(undefined)).toEqual([]);
+  });
+});
+
+describe('maxRisk', () => {
+  it('picks the more severe level', () => {
+    expect(maxRisk('low', 'high')).toBe('high');
+    expect(maxRisk('prohibited', 'high')).toBe('prohibited');
+    expect(maxRisk('medium', 'medium')).toBe('medium');
+  });
+});
+
+describe('classifyBusiness', () => {
+  it('leaves a plain low-risk business alone', () => {
+    const result = classifyBusiness({
+      name: 'Bean There Coffee',
+      description: 'Neighborhood cafe and bakery',
+      category: 'food-beverage',
+      tags: ['coffee'],
+    });
+    expect(result.riskLevel).toBe('low');
+    expect(result.reviewRequired).toBe(false);
+    expect(result.flags).toEqual([]);
+  });
+
+  it('flags the IPTV category as high risk', () => {
+    const result = classifyBusiness({
+      name: 'StreamBox',
+      category: 'streaming-iptv',
+      tags: ['streaming', 'iptv'],
+    });
+    expect(result.riskLevel).toBe('high');
+    expect(result.reviewRequired).toBe(true);
+    expect(result.flags.map((f) => f.code)).toContain('piracy');
+  });
+
+  it('catches IPTV keywords even when the merchant self-declares as SaaS', () => {
+    const result = classifyBusiness({
+      name: 'CloudPanel',
+      description: 'Subscription platform',
+      category: 'saas',
+      tags: ['iptv', 'restream'],
+    });
+    expect(result.riskLevel).toBe('high');
+    const piracy = result.flags.find((f) => f.code === 'piracy');
+    expect(piracy?.matched).toEqual(expect.arrayContaining(['iptv', 'restream']));
+  });
+
+  it('marks prohibited categories prohibited', () => {
+    const result = classifyBusiness({ name: 'Lucky Spin', category: 'gambling' });
+    expect(result.riskLevel).toBe('prohibited');
+    expect(result.reviewRequired).toBe(true);
+  });
+
+  it('escalates on prohibited keywords regardless of category', () => {
+    const result = classifyBusiness({
+      name: 'Fast Coins',
+      description: 'We offer a coin mixer for privacy',
+      category: 'ecommerce-retail',
+    });
+    expect(result.riskLevel).toBe('prohibited');
+    expect(result.flags.map((f) => f.code)).toContain('money-laundering');
+  });
+
+  it('treats a missing or invalid category as medium and reviewable-adjacent', () => {
+    const result = classifyBusiness({ name: 'Unknown Co' });
+    expect(result.riskLevel).toBe('medium');
+    expect(result.reviewRequired).toBe(false);
+    expect(result.flags.map((f) => f.code)).toContain('category:missing');
+
+    const bogus = classifyBusiness({ name: 'Unknown Co', category: 'not-real' });
+    expect(bogus.category).toBeNull();
+    expect(bogus.flags.map((f) => f.code)).toContain('category:missing');
+  });
+
+  it('normalizes tags into the result', () => {
+    const result = classifyBusiness({
+      name: 'Shop',
+      category: 'ecommerce-retail',
+      tags: ['#Apparel', 'apparel', 'MERCH'],
+    });
+    expect(result.tags).toEqual(['apparel', 'merch']);
+  });
+
+  it('matches plurals and punctuation variants', () => {
+    const result = classifyBusiness({
+      name: 'Casinos-Online!',
+      category: 'ecommerce-retail',
+    });
+    expect(result.flags.map((f) => f.code)).toContain('gambling');
+  });
+
+  it('does not match keywords embedded inside other words', () => {
+    const result = classifyBusiness({
+      name: 'Gunther Woodworks',
+      description: 'Handmade furniture',
+      category: 'ecommerce-retail',
+    });
+    expect(result.flags.map((f) => f.code)).not.toContain('firearms');
+    expect(result.riskLevel).toBe('low');
+  });
+
+  it('sorts the worst flag first', () => {
+    const result = classifyBusiness({
+      name: 'Mixed Bag',
+      description: 'iptv and a coin mixer',
+      category: 'saas',
+    });
+    expect(result.flags[0].severity).toBe('prohibited');
+  });
+});
+
+describe('suggestCategories', () => {
+  it('suggests IPTV for streaming copy', () => {
+    const suggestions = suggestCategories('We sell IPTV streaming subscriptions with VOD');
+    expect(suggestions[0].slug).toBe('streaming-iptv');
+  });
+
+  it('returns nothing for empty input', () => {
+    expect(suggestCategories('')).toEqual([]);
+    expect(suggestCategories('zzzz qqqq')).toEqual([]);
+  });
+
+  it('respects the limit', () => {
+    expect(suggestCategories('shop store hosting vpn course ticket', 2)).toHaveLength(2);
+  });
+});
+
+describe('suggestTags', () => {
+  it('puts the selected category keywords first', () => {
+    const tags = suggestTags('', 'streaming-iptv', 3);
+    expect(tags).toContain('streaming');
+  });
+
+  it('filters by what is being typed', () => {
+    const tags = suggestTags('vp', null, 5);
+    expect(tags).toContain('vpn');
+    expect(tags.every((t) => t.includes('vp'))).toBe(true);
+  });
+});

--- a/src/lib/business/taxonomy.ts
+++ b/src/lib/business/taxonomy.ts
@@ -1,0 +1,632 @@
+/**
+ * Business taxonomy and risk classification.
+ *
+ * Every business gets one `category` from the list below plus free-form `tags`
+ * (keywords like "streaming", "iptv"). Category and tags together drive a
+ * derived `risk_level` so onboarding can route the risky ones to review
+ * instead of discovering the problem after the first chargeback.
+ *
+ * The taxonomy lives in code rather than a table so it can be versioned with
+ * the rules that read it. There is deliberately no DB check constraint on
+ * `category` — validation happens here.
+ */
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'prohibited';
+
+export const RISK_ORDER: RiskLevel[] = ['low', 'medium', 'high', 'prohibited'];
+
+export interface BusinessCategory {
+  slug: string;
+  label: string;
+  group: string;
+  /** Floor risk for anything in this category, before keyword rules apply. */
+  baseRisk: RiskLevel;
+  /** Keywords that suggest this category and double as tag autocomplete. */
+  keywords: string[];
+}
+
+export const CATEGORY_GROUPS = [
+  'Digital & Media',
+  'Commerce',
+  'Services',
+  'Finance & Crypto',
+  'Restricted',
+  'Other',
+] as const;
+
+export const BUSINESS_CATEGORIES: BusinessCategory[] = [
+  // ---------------------------------------------------------------- Digital
+  {
+    slug: 'streaming-iptv',
+    label: 'Streaming / IPTV',
+    group: 'Digital & Media',
+    baseRisk: 'high',
+    keywords: [
+      'streaming', 'iptv', 'vod', 'restream', 'live tv', 'm3u', 'xtream',
+      'cccam', 'firestick', 'ppv', 'pay per view', 'sports streaming',
+    ],
+  },
+  {
+    slug: 'digital-goods',
+    label: 'Digital Goods & Downloads',
+    group: 'Digital & Media',
+    baseRisk: 'medium',
+    keywords: [
+      'digital goods', 'download', 'ebook', 'license key', 'template',
+      'preset', 'stock photo', 'font', 'plugin', 'theme',
+    ],
+  },
+  {
+    slug: 'saas',
+    label: 'SaaS & Software',
+    group: 'Digital & Media',
+    baseRisk: 'low',
+    keywords: ['saas', 'software', 'api', 'platform', 'web app', 'b2b software'],
+  },
+  {
+    slug: 'hosting-infrastructure',
+    label: 'Hosting & Infrastructure',
+    group: 'Digital & Media',
+    baseRisk: 'medium',
+    keywords: [
+      'hosting', 'vps', 'vpn', 'proxy', 'domain', 'dedicated server', 'cdn',
+      'rdp', 'colocation',
+    ],
+  },
+  {
+    slug: 'gaming',
+    label: 'Gaming & Virtual Goods',
+    group: 'Digital & Media',
+    baseRisk: 'medium',
+    keywords: [
+      'gaming', 'game key', 'in game', 'skins', 'game currency', 'top up',
+      'boosting', 'steam',
+    ],
+  },
+  {
+    slug: 'nft-collectibles',
+    label: 'NFTs & Digital Collectibles',
+    group: 'Digital & Media',
+    baseRisk: 'high',
+    keywords: ['nft', 'mint', 'collectible', 'pfp', 'digital art drop'],
+  },
+  {
+    slug: 'media-publishing',
+    label: 'Media & Publishing',
+    group: 'Digital & Media',
+    baseRisk: 'low',
+    keywords: ['blog', 'news', 'magazine', 'podcast', 'newsletter', 'publisher'],
+  },
+
+  // --------------------------------------------------------------- Commerce
+  {
+    slug: 'ecommerce-retail',
+    label: 'E-commerce & Retail',
+    group: 'Commerce',
+    baseRisk: 'low',
+    keywords: ['ecommerce', 'retail', 'shop', 'store', 'apparel', 'clothing', 'merch'],
+  },
+  {
+    slug: 'marketplace',
+    label: 'Marketplace / Multi-vendor',
+    group: 'Commerce',
+    baseRisk: 'medium',
+    keywords: ['marketplace', 'multi vendor', 'classifieds', 'peer to peer', 'sellers'],
+  },
+  {
+    slug: 'dropshipping',
+    label: 'Dropshipping',
+    group: 'Commerce',
+    baseRisk: 'medium',
+    keywords: ['dropshipping', 'dropship', 'print on demand', 'aliexpress'],
+  },
+  {
+    slug: 'food-beverage',
+    label: 'Food & Beverage',
+    group: 'Commerce',
+    baseRisk: 'low',
+    keywords: ['restaurant', 'cafe', 'food', 'catering', 'bakery', 'coffee', 'food delivery'],
+  },
+  {
+    slug: 'electronics-hardware',
+    label: 'Electronics & Hardware',
+    group: 'Commerce',
+    baseRisk: 'medium',
+    keywords: ['electronics', 'hardware', 'laptop', 'gpu', 'asic', 'mining rig', 'phones'],
+  },
+  {
+    slug: 'manufacturing-wholesale',
+    label: 'Manufacturing & Wholesale',
+    group: 'Commerce',
+    baseRisk: 'low',
+    keywords: ['manufacturing', 'wholesale', 'factory', 'oem', 'bulk supply'],
+  },
+
+  // --------------------------------------------------------------- Services
+  {
+    slug: 'professional-services',
+    label: 'Professional Services',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['consulting', 'consultant', 'accounting', 'bookkeeping', 'legal', 'advisory'],
+  },
+  {
+    slug: 'creative-marketing',
+    label: 'Creative & Marketing Agency',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['agency', 'marketing', 'seo', 'branding', 'design studio', 'social media'],
+  },
+  {
+    slug: 'dev-it-services',
+    label: 'Development & IT Services',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['web development', 'developer', 'it services', 'devops', 'web design'],
+  },
+  {
+    slug: 'freelance',
+    label: 'Freelance / Contract Work',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['freelance', 'contractor', 'gig', 'hourly work'],
+  },
+  {
+    slug: 'education',
+    label: 'Education & Courses',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['course', 'training', 'tutoring', 'bootcamp', 'coaching', 'academy', 'elearning'],
+  },
+  {
+    slug: 'events-ticketing',
+    label: 'Events & Ticketing',
+    group: 'Services',
+    baseRisk: 'medium',
+    keywords: ['event', 'ticket', 'conference', 'festival', 'venue', 'concert'],
+  },
+  {
+    slug: 'travel-hospitality',
+    label: 'Travel & Hospitality',
+    group: 'Services',
+    baseRisk: 'medium',
+    keywords: ['travel', 'flight', 'hotel', 'tour', 'vacation', 'booking'],
+  },
+  {
+    slug: 'real-estate',
+    label: 'Real Estate & Rentals',
+    group: 'Services',
+    baseRisk: 'medium',
+    keywords: ['real estate', 'rental', 'property', 'lease', 'landlord'],
+  },
+  {
+    slug: 'logistics',
+    label: 'Logistics & Shipping',
+    group: 'Services',
+    baseRisk: 'low',
+    keywords: ['shipping', 'freight', 'courier', 'logistics', 'fulfillment', 'warehouse'],
+  },
+  {
+    slug: 'health-wellness',
+    label: 'Health & Wellness',
+    group: 'Services',
+    baseRisk: 'medium',
+    keywords: ['clinic', 'therapy', 'telehealth', 'fitness', 'gym', 'wellness', 'spa', 'massage'],
+  },
+  {
+    slug: 'nonprofit',
+    label: 'Nonprofit & Fundraising',
+    group: 'Services',
+    baseRisk: 'medium',
+    keywords: ['charity', 'nonprofit', 'donation', 'fundraiser', 'ngo', 'crowdfunding'],
+  },
+
+  // -------------------------------------------------------- Finance & Crypto
+  {
+    slug: 'crypto-exchange',
+    label: 'Crypto Exchange / Swap',
+    group: 'Finance & Crypto',
+    baseRisk: 'high',
+    keywords: ['exchange', 'swap', 'otc', 'on ramp', 'off ramp', 'fiat ramp', 'crypto trading'],
+  },
+  {
+    slug: 'crypto-services',
+    label: 'Crypto Services & Tooling',
+    group: 'Finance & Crypto',
+    baseRisk: 'high',
+    keywords: ['wallet', 'staking', 'validator', 'node', 'defi', 'bridge', 'custody'],
+  },
+  {
+    slug: 'payments-fintech',
+    label: 'Payments & Fintech',
+    group: 'Finance & Crypto',
+    baseRisk: 'high',
+    keywords: ['payments', 'remittance', 'money transfer', 'payout', 'fintech', 'prepaid card'],
+  },
+  {
+    slug: 'lending-credit',
+    label: 'Lending & Credit',
+    group: 'Finance & Crypto',
+    baseRisk: 'high',
+    keywords: ['loan', 'lending', 'credit', 'borrow', 'mortgage', 'buy now pay later'],
+  },
+  {
+    slug: 'investment-trading',
+    label: 'Investment & Trading',
+    group: 'Finance & Crypto',
+    baseRisk: 'high',
+    keywords: ['investment', 'fund', 'portfolio', 'trading signals', 'trading bot', 'forex', 'copy trading'],
+  },
+  {
+    slug: 'insurance',
+    label: 'Insurance',
+    group: 'Finance & Crypto',
+    baseRisk: 'medium',
+    keywords: ['insurance', 'underwriting', 'policy', 'claims'],
+  },
+
+  // ------------------------------------------------------------- Restricted
+  {
+    slug: 'gambling',
+    label: 'Gambling, Casino & Betting',
+    group: 'Restricted',
+    baseRisk: 'prohibited',
+    keywords: ['casino', 'betting', 'gambling', 'poker', 'lottery', 'sportsbook', 'wager', 'slots'],
+  },
+  {
+    slug: 'adult',
+    label: 'Adult Content',
+    group: 'Restricted',
+    baseRisk: 'high',
+    keywords: ['adult', 'nsfw', 'cam site', 'fetish', 'escort'],
+  },
+  {
+    slug: 'cannabis-vape',
+    label: 'Cannabis, CBD & Vape',
+    group: 'Restricted',
+    baseRisk: 'high',
+    keywords: ['cannabis', 'cbd', 'thc', 'hemp', 'vape', 'kratom', 'nicotine', 'tobacco'],
+  },
+  {
+    slug: 'pharmacy',
+    label: 'Pharmacy & Prescription',
+    group: 'Restricted',
+    baseRisk: 'high',
+    keywords: ['pharmacy', 'prescription', 'medication', 'peptide', 'sarms', 'steroid'],
+  },
+  {
+    slug: 'supplements',
+    label: 'Supplements & Nutraceuticals',
+    group: 'Restricted',
+    baseRisk: 'medium',
+    keywords: ['supplement', 'vitamin', 'nootropic', 'protein powder', 'weight loss'],
+  },
+  {
+    slug: 'firearms',
+    label: 'Firearms, Weapons & Ammo',
+    group: 'Restricted',
+    baseRisk: 'prohibited',
+    keywords: ['firearm', 'gun', 'ammo', 'ammunition', 'rifle', 'weapon', 'silencer'],
+  },
+
+  // ------------------------------------------------------------------ Other
+  {
+    slug: 'other',
+    label: 'Other',
+    group: 'Other',
+    baseRisk: 'medium',
+    keywords: [],
+  },
+];
+
+export const CATEGORY_SLUGS = BUSINESS_CATEGORIES.map((c) => c.slug);
+
+const CATEGORY_BY_SLUG = new Map(BUSINESS_CATEGORIES.map((c) => [c.slug, c]));
+
+export function getCategory(slug: string | null | undefined): BusinessCategory | undefined {
+  return slug ? CATEGORY_BY_SLUG.get(slug) : undefined;
+}
+
+export function isValidCategory(slug: unknown): slug is string {
+  return typeof slug === 'string' && CATEGORY_BY_SLUG.has(slug);
+}
+
+/**
+ * Keyword rules that apply regardless of the category the merchant picked.
+ * These exist because the category is self-declared — a merchant selling IPTV
+ * subscriptions will happily file themselves under "SaaS".
+ */
+export interface KeywordRule {
+  code: string;
+  label: string;
+  severity: RiskLevel;
+  keywords: string[];
+}
+
+export const KEYWORD_RULES: KeywordRule[] = [
+  {
+    code: 'fraud-instruments',
+    label: 'Stolen card / account data',
+    severity: 'prohibited',
+    keywords: ['carding', 'cvv', 'fullz', 'dumps', 'stolen card', 'stolen account', 'cracked account', 'bin lookup'],
+  },
+  {
+    code: 'money-laundering',
+    label: 'Mixing / laundering',
+    severity: 'prohibited',
+    keywords: ['mixer', 'tumbler', 'coin mixer', 'money laundering', 'launder', 'clean coins', 'wash trading'],
+  },
+  {
+    code: 'counterfeit',
+    label: 'Counterfeit or forged goods',
+    severity: 'prohibited',
+    keywords: ['counterfeit', 'replica watch', 'fake id', 'fake passport', 'forged document', 'knockoff'],
+  },
+  {
+    code: 'darknet',
+    label: 'Darknet marketplace',
+    severity: 'prohibited',
+    keywords: ['darknet', 'dark web', 'onion market', 'hidden service market'],
+  },
+  {
+    code: 'controlled-substances',
+    label: 'Controlled substances',
+    severity: 'prohibited',
+    keywords: ['cocaine', 'heroin', 'methamphetamine', 'mdma', 'research chemical', 'street drugs'],
+  },
+  {
+    code: 'csae',
+    label: 'Child sexual abuse material',
+    severity: 'prohibited',
+    keywords: ['csam', 'child porn', 'underage porn', 'jailbait', 'loli'],
+  },
+  {
+    code: 'violence-for-hire',
+    label: 'Violence for hire',
+    severity: 'prohibited',
+    keywords: ['hitman', 'assassination', 'contract killing'],
+  },
+  {
+    code: 'cybercrime',
+    label: 'Attack tooling / cybercrime',
+    severity: 'prohibited',
+    keywords: ['ddos', 'booter', 'stresser', 'botnet', 'ransomware', 'malware', 'phishing kit', 'otp bot', 'spam service'],
+  },
+  {
+    code: 'ponzi',
+    label: 'Guaranteed-return scheme',
+    severity: 'prohibited',
+    keywords: ['ponzi', 'hyip', 'pyramid scheme', 'matrix scheme', 'money doubler', 'guaranteed returns', 'guaranteed roi'],
+  },
+  {
+    code: 'piracy',
+    label: 'Unlicensed content resale',
+    severity: 'high',
+    keywords: [
+      'iptv', 'restream', 'cracked software', 'nulled', 'warez', 'keygen',
+      'netflix account', 'account sharing', 'premium account resale', 'pirated',
+    ],
+  },
+  {
+    code: 'kyc-evasion',
+    label: 'KYC / traceability evasion',
+    severity: 'high',
+    keywords: ['no kyc', 'bypass kyc', 'anonymous payments', 'untraceable', 'privacy coin only'],
+  },
+  {
+    code: 'gambling',
+    label: 'Gambling and betting',
+    severity: 'high',
+    keywords: ['casino', 'sportsbook', 'betting site', 'online gambling', 'slots', 'wager', 'lottery'],
+  },
+  {
+    code: 'adult',
+    label: 'Adult content',
+    severity: 'high',
+    keywords: ['porn', 'xxx', 'escort service', 'cam girl', 'onlyfans'],
+  },
+  {
+    code: 'stored-value',
+    label: 'Gift cards and stored value',
+    severity: 'high',
+    keywords: ['gift card', 'prepaid card', 'voucher resale', 'e-gift'],
+  },
+  {
+    code: 'ticket-resale',
+    label: 'Ticket resale',
+    severity: 'medium',
+    keywords: ['ticket resale', 'scalping', 'secondary tickets'],
+  },
+];
+
+export interface RiskFlag {
+  code: string;
+  label: string;
+  severity: RiskLevel;
+  /** Which keywords actually matched, so a reviewer can see the evidence. */
+  matched: string[];
+  source: 'category' | 'keyword';
+}
+
+export interface Classification {
+  category: string | null;
+  tags: string[];
+  riskLevel: RiskLevel;
+  /** True when a human should look before the business goes live. */
+  reviewRequired: boolean;
+  flags: RiskFlag[];
+}
+
+export interface ClassifyInput {
+  name?: string | null;
+  description?: string | null;
+  category?: string | null;
+  tags?: string[] | null;
+}
+
+/** Lowercase, strip punctuation, collapse whitespace. */
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+const KEYWORD_PATTERNS = new Map<string, RegExp>();
+
+function patternFor(keyword: string): RegExp {
+  let pattern = KEYWORD_PATTERNS.get(keyword);
+  if (!pattern) {
+    const escaped = normalize(keyword).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Allow a plural on the last word: "casinos" matches "casino".
+    pattern = new RegExp(`\\b${escaped.replace(/ /g, '\\s+')}(?:s|es)?\\b`);
+    KEYWORD_PATTERNS.set(keyword, pattern);
+  }
+  return pattern;
+}
+
+function matchKeywords(haystack: string, keywords: string[]): string[] {
+  return keywords.filter((keyword) => patternFor(keyword).test(haystack));
+}
+
+export function maxRisk(a: RiskLevel, b: RiskLevel): RiskLevel {
+  return RISK_ORDER.indexOf(a) >= RISK_ORDER.indexOf(b) ? a : b;
+}
+
+export const MAX_TAGS = 20;
+export const MAX_TAG_LENGTH = 32;
+
+/**
+ * Clean up merchant-entered keywords: lowercase, drop the leading '#', collapse
+ * whitespace, dedupe, and cap length and count.
+ */
+export function normalizeTags(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== 'string') continue;
+    const tag = raw
+      .toLowerCase()
+      .replace(/^#+/, '')
+      .replace(/[^a-z0-9+&.\- ]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, MAX_TAG_LENGTH);
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+    if (out.length >= MAX_TAGS) break;
+  }
+  return out;
+}
+
+/**
+ * Derive a risk level from the declared category plus keyword rules run over
+ * the name, description and tags.
+ */
+export function classifyBusiness(input: ClassifyInput): Classification {
+  const tags = normalizeTags(input.tags ?? []);
+  const category = isValidCategory(input.category) ? input.category : null;
+  const categoryDef = getCategory(category);
+
+  const haystack = normalize(
+    [input.name ?? '', input.description ?? '', tags.join(' '), categoryDef?.label ?? ''].join(' ')
+  );
+
+  const flags: RiskFlag[] = [];
+  let riskLevel: RiskLevel = 'low';
+
+  if (categoryDef && categoryDef.baseRisk !== 'low') {
+    riskLevel = maxRisk(riskLevel, categoryDef.baseRisk);
+    flags.push({
+      code: `category:${categoryDef.slug}`,
+      label: categoryDef.label,
+      severity: categoryDef.baseRisk,
+      matched: [],
+      source: 'category',
+    });
+  }
+
+  // No category at all is itself a reason to look twice.
+  if (!categoryDef) {
+    riskLevel = maxRisk(riskLevel, 'medium');
+    flags.push({
+      code: 'category:missing',
+      label: 'No category selected',
+      severity: 'medium',
+      matched: [],
+      source: 'category',
+    });
+  }
+
+  for (const rule of KEYWORD_RULES) {
+    const matched = matchKeywords(haystack, rule.keywords);
+    if (matched.length === 0) continue;
+    riskLevel = maxRisk(riskLevel, rule.severity);
+    flags.push({
+      code: rule.code,
+      label: rule.label,
+      severity: rule.severity,
+      matched,
+      source: 'keyword',
+    });
+  }
+
+  // Keep the worst flags first so a reviewer reads the reason for the level.
+  flags.sort((a, b) => RISK_ORDER.indexOf(b.severity) - RISK_ORDER.indexOf(a.severity));
+
+  return {
+    category,
+    tags,
+    riskLevel,
+    reviewRequired: riskLevel === 'high' || riskLevel === 'prohibited',
+    flags,
+  };
+}
+
+export interface CategorySuggestion {
+  slug: string;
+  label: string;
+  score: number;
+  matched: string[];
+}
+
+/**
+ * Rank categories against free text, for the "we think this is X" hint on the
+ * create form. Never returns 'other'.
+ */
+export function suggestCategories(text: string, limit = 3): CategorySuggestion[] {
+  const haystack = normalize(text || '');
+  if (!haystack) return [];
+
+  return BUSINESS_CATEGORIES.filter((c) => c.keywords.length > 0)
+    .map((c) => {
+      const matched = matchKeywords(haystack, c.keywords);
+      return { slug: c.slug, label: c.label, score: matched.length, matched };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.slug.localeCompare(b.slug))
+    .slice(0, limit);
+}
+
+/**
+ * Tag autocomplete: every keyword in the taxonomy, optionally filtered by a
+ * prefix the merchant is typing and biased toward the selected category.
+ */
+export function suggestTags(query: string, category?: string | null, limit = 8): string[] {
+  const q = normalize(query || '');
+  const preferred = getCategory(category)?.keywords ?? [];
+  const rest = BUSINESS_CATEGORIES.flatMap((c) => (c.slug === category ? [] : c.keywords));
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const keyword of [...preferred, ...rest]) {
+    if (seen.has(keyword)) continue;
+    if (q && !normalize(keyword).includes(q)) continue;
+    seen.add(keyword);
+    out.push(keyword);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/src/lib/fraud/linkage.ts
+++ b/src/lib/fraud/linkage.ts
@@ -1,0 +1,211 @@
+/**
+ * Identity linkage between businesses.
+ *
+ * One person running several accounts is the pattern behind most merchant-side
+ * abuse: an account gets shut down, a new one appears the same week selling the
+ * same thing. They rarely change everything — the payout wallet, the Stripe
+ * account, the webhook domain or the mailbox usually carries over.
+ *
+ * Nothing here is proof on its own. It surfaces candidates for a human, and
+ * feeds one input into scoring.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { normalizeEmail } from './signals';
+
+export type LinkKind =
+  | 'same_merchant'
+  | 'merchant_email'
+  | 'stripe_account'
+  | 'stripe_email'
+  | 'wallet_address'
+  | 'webhook_domain'
+  | 'checkout_ip';
+
+export interface BusinessLink {
+  businessId: string;
+  kinds: LinkKind[];
+  /** The shared values, for a reviewer to eyeball. */
+  evidence: string[];
+}
+
+export interface LinkageResult {
+  businessId: string;
+  links: BusinessLink[];
+  linkedBusinessIds: string[];
+  linkedToBlockedBusiness: boolean;
+}
+
+function hostOf(url: string | null | undefined): string | null {
+  if (typeof url !== 'string' || !url.trim()) return null;
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find businesses sharing an identity signal with `businessId`.
+ *
+ * Best-effort: any individual lookup that fails is skipped rather than failing
+ * the whole call, because this runs inline on the checkout path.
+ */
+export async function findLinkedBusinesses(
+  supabase: SupabaseClient,
+  businessId: string
+): Promise<LinkageResult> {
+  const links = new Map<string, BusinessLink>();
+  const addLink = (id: string, kind: LinkKind, evidence: string) => {
+    if (!id || id === businessId) return;
+    const existing = links.get(id);
+    if (existing) {
+      if (!existing.kinds.includes(kind)) existing.kinds.push(kind);
+      if (!existing.evidence.includes(evidence)) existing.evidence.push(evidence);
+      return;
+    }
+    links.set(id, { businessId: id, kinds: [kind], evidence: [evidence] });
+  };
+
+  const { data: business } = await supabase
+    .from('businesses')
+    .select('id, merchant_id, webhook_url')
+    .eq('id', businessId)
+    .maybeSingle();
+
+  if (!business) {
+    return { businessId, links: [], linkedBusinessIds: [], linkedToBlockedBusiness: false };
+  }
+
+  // Same owner — the cheapest link, and the one that matters most.
+  if (business.merchant_id) {
+    const { data: siblings } = await supabase
+      .from('businesses')
+      .select('id')
+      .eq('merchant_id', business.merchant_id);
+    for (const sibling of siblings ?? []) {
+      addLink(sibling.id, 'same_merchant', business.merchant_id);
+    }
+
+    // Same human behind different merchant accounts: gmail dots and +suffixes
+    // make one mailbox look like many, so compare normalized addresses.
+    const { data: owner } = await supabase
+      .from('merchants')
+      .select('email')
+      .eq('id', business.merchant_id)
+      .maybeSingle();
+
+    const normalized = normalizeEmail(owner?.email);
+    if (normalized) {
+      const { data: merchants } = await supabase.from('merchants').select('id, email');
+      const twins = (merchants ?? []).filter(
+        (candidate: { id: string; email: string | null }) =>
+          candidate.id !== business.merchant_id && normalizeEmail(candidate.email) === normalized
+      );
+      if (twins.length > 0) {
+        const { data: twinBusinesses } = await supabase
+          .from('businesses')
+          .select('id')
+          .in(
+            'merchant_id',
+            twins.map((t: { id: string }) => t.id)
+          );
+        for (const b of twinBusinesses ?? []) {
+          addLink(b.id, 'merchant_email', normalized);
+        }
+      }
+    }
+  }
+
+  // Shared Stripe account or Stripe-side email.
+  const { data: stripeAccount } = await supabase
+    .from('stripe_accounts')
+    .select('stripe_account_id, email')
+    .eq('business_id', businessId)
+    .maybeSingle();
+
+  if (stripeAccount?.stripe_account_id) {
+    const { data: shared } = await supabase
+      .from('stripe_accounts')
+      .select('business_id')
+      .eq('stripe_account_id', stripeAccount.stripe_account_id);
+    for (const row of shared ?? []) {
+      if (row.business_id) addLink(row.business_id, 'stripe_account', stripeAccount.stripe_account_id);
+    }
+  }
+
+  const stripeEmail = normalizeEmail(stripeAccount?.email);
+  if (stripeEmail) {
+    const { data: accounts } = await supabase.from('stripe_accounts').select('business_id, email');
+    for (const row of accounts ?? []) {
+      if (row.business_id && normalizeEmail(row.email) === stripeEmail) {
+        addLink(row.business_id, 'stripe_email', stripeEmail);
+      }
+    }
+  }
+
+  // Shared payout wallet — money landing in one place is a hard link.
+  const { data: wallets } = await supabase
+    .from('business_wallets')
+    .select('wallet_address')
+    .eq('business_id', businessId);
+
+  const addresses = (wallets ?? [])
+    .map((w: { wallet_address: string | null }) => w.wallet_address)
+    .filter((a: string | null): a is string => !!a);
+
+  if (addresses.length > 0) {
+    const { data: shared } = await supabase
+      .from('business_wallets')
+      .select('business_id, wallet_address')
+      .in('wallet_address', addresses);
+    for (const row of shared ?? []) {
+      if (row.business_id) addLink(row.business_id, 'wallet_address', row.wallet_address);
+    }
+  }
+
+  // Shared webhook host — same backend behind two storefronts.
+  const host = hostOf(business.webhook_url);
+  if (host) {
+    const { data: others } = await supabase
+      .from('businesses')
+      .select('id, webhook_url')
+      .not('webhook_url', 'is', null);
+    for (const row of others ?? []) {
+      if (hostOf(row.webhook_url) === host) addLink(row.id, 'webhook_domain', host);
+    }
+  }
+
+  const linkedBusinessIds = [...links.keys()];
+
+  // Does any linked business carry a hard stop of its own?
+  let linkedToBlockedBusiness = false;
+  if (linkedBusinessIds.length > 0) {
+    const { data: linkedBusinesses } = await supabase
+      .from('businesses')
+      .select('id, risk_level, review_status')
+      .in('id', linkedBusinessIds);
+
+    linkedToBlockedBusiness = (linkedBusinesses ?? []).some(
+      (b: { risk_level: string | null; review_status: string | null }) =>
+        b.risk_level === 'prohibited' || b.review_status === 'rejected'
+    );
+
+    if (!linkedToBlockedBusiness) {
+      const { data: blocked } = await supabase
+        .from('fraud_blocklist')
+        .select('value')
+        .eq('kind', 'business')
+        .eq('action', 'block')
+        .in('value', linkedBusinessIds);
+      linkedToBlockedBusiness = (blocked ?? []).length > 0;
+    }
+  }
+
+  return {
+    businessId,
+    links: [...links.values()],
+    linkedBusinessIds,
+    linkedToBlockedBusiness,
+  };
+}

--- a/src/lib/fraud/misrepresentation.test.ts
+++ b/src/lib/fraud/misrepresentation.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { detectMisrepresentation } from './misrepresentation';
+
+describe('detectMisrepresentation', () => {
+  it('catches a VPN business billing for IPTV', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: 'hosting-infrastructure',
+      texts: [
+        'VPN Premium - 1 month',
+        '12 month IPTV subscription, 20000 live channels',
+        'Restream reseller panel credits',
+      ],
+    });
+
+    expect(result.mismatch).toBe(true);
+    expect(result.declaredRisk).toBe('medium');
+    expect(result.observedRisk).toBe('high');
+    expect(result.observedCategories).toContain('streaming-iptv');
+    expect(result.observedFlags).toContain('piracy');
+    expect(result.matchedKeywords).toEqual(expect.arrayContaining(['iptv']));
+  });
+
+  it('accepts activity that matches the declaration', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: 'streaming-iptv',
+      texts: ['12 month IPTV subscription'],
+    });
+    // Declared high, observed high — no gap, so nothing to report.
+    expect(result.mismatch).toBe(false);
+  });
+
+  it('flags a retail shop taking gambling payments', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: 'ecommerce-retail',
+      texts: ['Casino chips top-up', 'sportsbook deposit'],
+    });
+    expect(result.mismatch).toBe(true);
+    expect(result.observedRisk).toBe('high');
+    expect(result.observedFlags).toContain('gambling');
+  });
+
+  it('does not call a mismatch on a merely suggestive word', () => {
+    // "wallet" points at crypto tooling in the taxonomy, but a leather wallet
+    // in a retail shop is not a misrepresentation.
+    const result = detectMisrepresentation({
+      declaredCategory: 'ecommerce-retail',
+      texts: ['Leather wallet, brown'],
+    });
+    expect(result.mismatch).toBe(false);
+  });
+
+  it('is quiet when there is nothing to look at', () => {
+    const result = detectMisrepresentation({ declaredCategory: 'saas', texts: [] });
+    expect(result.mismatch).toBe(false);
+    expect(result.observedCategories).toEqual([]);
+  });
+
+  it('ignores blank and null entries', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: 'saas',
+      texts: [null, '   ', undefined],
+    });
+    expect(result.mismatch).toBe(false);
+  });
+
+  it('treats an undeclared category as medium risk', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: null,
+      texts: ['Monthly subscription'],
+    });
+    expect(result.declaredRisk).toBe('medium');
+    expect(result.declaredCategory).toBeNull();
+  });
+
+  it('does not flag ordinary retail wording', () => {
+    const result = detectMisrepresentation({
+      declaredCategory: 'ecommerce-retail',
+      texts: ['Blue cotton t-shirt', 'Leather wallet', 'Shipping to Ohio'],
+    });
+    expect(result.mismatch).toBe(false);
+    expect(result.observedFlags).toEqual([]);
+  });
+});

--- a/src/lib/fraud/misrepresentation.ts
+++ b/src/lib/fraud/misrepresentation.ts
@@ -1,0 +1,93 @@
+/**
+ * Declared-vs-observed category checking.
+ *
+ * A merchant tells us what they sell once, at signup. What they actually sell
+ * shows up afterwards, in the description on every payment they take. When a
+ * business filed under "Hosting & Infrastructure" starts running charges
+ * labelled "12 month IPTV subscription", the declaration is the thing that's
+ * wrong — and that gap is worth more than either signal alone.
+ */
+
+import {
+  RISK_ORDER,
+  classifyBusiness,
+  getCategory,
+  suggestCategories,
+  type RiskLevel,
+} from '../business/taxonomy';
+
+export interface MisrepresentationResult {
+  /** True when observed activity implies more risk than what was declared. */
+  mismatch: boolean;
+  declaredCategory: string | null;
+  declaredRisk: RiskLevel;
+  observedRisk: RiskLevel;
+  /** Categories the observed text actually looks like. */
+  observedCategories: string[];
+  /** Keyword-rule codes that fired on the observed text. */
+  observedFlags: string[];
+  matchedKeywords: string[];
+}
+
+/**
+ * Compare a declared category against free text observed on real activity —
+ * payment descriptions, line items, invoice memos.
+ */
+export function detectMisrepresentation(input: {
+  declaredCategory?: string | null;
+  texts: (string | null | undefined)[];
+}): MisrepresentationResult {
+  const declared = getCategory(input.declaredCategory);
+  const declaredRisk: RiskLevel = declared?.baseRisk ?? 'medium';
+
+  const corpus = input.texts.filter((t): t is string => typeof t === 'string' && t.trim().length > 0);
+
+  if (corpus.length === 0) {
+    return {
+      mismatch: false,
+      declaredCategory: declared?.slug ?? null,
+      declaredRisk,
+      observedRisk: 'low',
+      observedCategories: [],
+      observedFlags: [],
+      matchedKeywords: [],
+    };
+  }
+
+  const joined = corpus.join(' . ');
+
+  // Classify the observed text on its own merits, with no category to lean on,
+  // so only the keyword rules speak.
+  const observed = classifyBusiness({ name: '', description: joined, category: null, tags: [] });
+
+  const observedFlags = observed.flags
+    .filter((f) => f.source === 'keyword')
+    .map((f) => f.code);
+  const matchedKeywords = observed.flags.flatMap((f) => f.matched);
+
+  // classifyBusiness floors an absent category at medium; ignore that here —
+  // we only care what the keywords themselves imply.
+  const keywordRisk = observed.flags
+    .filter((f) => f.source === 'keyword')
+    .reduce<RiskLevel>(
+      (worst, f) => (RISK_ORDER.indexOf(f.severity) > RISK_ORDER.indexOf(worst) ? f.severity : worst),
+      'low'
+    );
+
+  // Category suggestions are informational only. They are tuned for a "did you
+  // mean?" hint on a form, where a stray match costs nothing — "leather wallet"
+  // reads as crypto tooling to them. Only the deliberate keyword rules are
+  // allowed to call something a mismatch.
+  const observedCategories = suggestCategories(joined, 3);
+  const observedRisk = keywordRisk;
+
+  return {
+    mismatch: RISK_ORDER.indexOf(observedRisk) > RISK_ORDER.indexOf(declaredRisk),
+    declaredCategory: declared?.slug ?? null,
+    declaredRisk,
+    observedRisk,
+    observedCategories: observedCategories.map((c) => c.slug),
+    observedFlags,
+    matchedKeywords,
+  };
+}

--- a/src/lib/fraud/rules.test.ts
+++ b/src/lib/fraud/rules.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BLOCK_THRESHOLD,
+  VERIFY_THRESHOLD,
+  scoreCheckout,
+  type MerchantSnapshot,
+  type ScoringInput,
+  type VelocitySnapshot,
+} from './rules';
+import { detectMisrepresentation } from './misrepresentation';
+
+const quietVelocity: VelocitySnapshot = {
+  attemptsPerIp10m: 1,
+  distinctEmailsPerIp1h: 1,
+  attemptsPerEmail10m: 1,
+  declinesPerBusiness1h: 0,
+  declinesPerIp1h: 0,
+  smallAmountAttempts10m: 0,
+  disputesPerBusiness30d: 0,
+};
+
+const cleanMerchant: MerchantSnapshot = {
+  riskLevel: 'low',
+  reviewStatus: 'not_required',
+  category: 'ecommerce-retail',
+  linkedBusinessIds: [],
+  linkedToBlockedBusiness: false,
+};
+
+function score(overrides: Partial<ScoringInput> = {}) {
+  return scoreCheckout({
+    velocity: quietVelocity,
+    merchant: cleanMerchant,
+    email: 'buyer@example.com',
+    amount: 4999,
+    ...overrides,
+  });
+}
+
+describe('scoreCheckout', () => {
+  it('allows an ordinary payment', () => {
+    const result = score();
+    expect(result.decision).toBe('allow');
+    expect(result.score).toBe(0);
+  });
+
+  it('blocks outright on a blocklist match and stops scoring', () => {
+    const result = score({ blocklistAction: 'block', blocklistReason: 'chargeback ring' });
+    expect(result.decision).toBe('block');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].code).toBe('blocklist');
+    expect(result.findings[0].detail).toBe('chargeback ring');
+  });
+
+  it('blocks a prohibited merchant category', () => {
+    const result = score({ merchant: { ...cleanMerchant, riskLevel: 'prohibited', category: 'gambling' } });
+    expect(result.decision).toBe('block');
+  });
+
+  it('blocks a merchant rejected in review', () => {
+    const result = score({ merchant: { ...cleanMerchant, reviewStatus: 'rejected' } });
+    expect(result.decision).toBe('block');
+  });
+
+  it('caps the score at 100', () => {
+    const result = score({
+      merchant: { ...cleanMerchant, riskLevel: 'prohibited', reviewStatus: 'rejected' },
+    });
+    expect(result.score).toBe(100);
+  });
+
+  describe('card testing patterns', () => {
+    it('blocks a burst of declines from one network', () => {
+      const result = score({
+        velocity: {
+          ...quietVelocity,
+          declinesPerIp1h: 4,
+          attemptsPerIp10m: 6,
+          distinctEmailsPerIp1h: 4,
+        },
+      });
+      expect(result.score).toBeGreaterThanOrEqual(BLOCK_THRESHOLD);
+      expect(result.decision).toBe('block');
+      expect(result.findings.map((f) => f.code)).toContain('ip-declines');
+    });
+
+    it('escalates a run of small charges to verification', () => {
+      const result = score({
+        amount: 100,
+        velocity: { ...quietVelocity, smallAmountAttempts10m: 4, declinesPerBusiness1h: 5 },
+      });
+      expect(result.decision).toBe('verify');
+      expect(result.findings.map((f) => f.code)).toEqual(
+        expect.arrayContaining(['small-amount-burst', 'merchant-declines'])
+      );
+    });
+
+    it('flags many buyers behind one IP', () => {
+      const result = score({ velocity: { ...quietVelocity, distinctEmailsPerIp1h: 7 } });
+      expect(result.score).toBeGreaterThanOrEqual(VERIFY_THRESHOLD);
+      expect(result.findings.map((f) => f.code)).toContain('ip-many-emails');
+    });
+
+    it('does not fire on a single quiet attempt', () => {
+      expect(score({ velocity: { ...quietVelocity, distinctEmailsPerIp1h: 2 } }).decision).toBe('allow');
+    });
+  });
+
+  describe('merchant signals', () => {
+    it('adds score for a high-risk merchant awaiting review', () => {
+      const result = score({
+        merchant: { ...cleanMerchant, riskLevel: 'high', reviewStatus: 'pending', category: 'streaming-iptv' },
+      });
+      expect(result.score).toBe(40);
+      expect(result.decision).toBe('verify');
+    });
+
+    it('escalates when linked to a blocked business', () => {
+      const result = score({
+        merchant: {
+          ...cleanMerchant,
+          linkedBusinessIds: ['biz-2'],
+          linkedToBlockedBusiness: true,
+        },
+      });
+      expect(result.decision).toBe('verify');
+      expect(result.findings.map((f) => f.code)).toContain('linked-to-blocked');
+    });
+  });
+
+  describe('misrepresentation', () => {
+    it('scores a VPN business actually selling IPTV', () => {
+      const mis = detectMisrepresentation({
+        declaredCategory: 'hosting-infrastructure',
+        texts: ['12 month IPTV subscription with VOD'],
+      });
+      expect(mis.mismatch).toBe(true);
+
+      const result = score({
+        misrepresentation: mis,
+        merchant: { ...cleanMerchant, category: 'hosting-infrastructure' },
+      });
+      expect(result.findings.map((f) => f.code)).toContain('category-misrepresentation');
+      expect(result.decision).toBe('verify');
+    });
+
+    it('ignores activity consistent with the declaration', () => {
+      const mis = detectMisrepresentation({
+        declaredCategory: 'ecommerce-retail',
+        texts: ['Blue cotton t-shirt, size medium'],
+      });
+      expect(mis.mismatch).toBe(false);
+      expect(score({ misrepresentation: mis }).decision).toBe('allow');
+    });
+  });
+
+  describe('buyer signals', () => {
+    it('adds score for a disposable mailbox', () => {
+      const result = score({ email: 'x@mailinator.com' });
+      expect(result.findings.map((f) => f.code)).toContain('disposable-email');
+    });
+
+    it('adds a little for no email at all', () => {
+      const result = score({ email: null });
+      expect(result.findings.map((f) => f.code)).toContain('no-email');
+      expect(result.decision).toBe('allow');
+    });
+  });
+
+  it('sorts findings worst first', () => {
+    const result = score({
+      email: 'x@mailinator.com',
+      velocity: { ...quietVelocity, declinesPerIp1h: 5 },
+    });
+    expect(result.findings[0].code).toBe('ip-declines');
+  });
+});

--- a/src/lib/fraud/rules.ts
+++ b/src/lib/fraud/rules.ts
@@ -1,0 +1,201 @@
+/**
+ * Fraud scoring rules.
+ *
+ * Pure functions over a snapshot the caller has already gathered. Each rule
+ * contributes score; the total maps to a decision. Nothing here touches the
+ * database or the network so the thresholds can be exercised directly.
+ */
+
+import type { RiskLevel } from '../business/taxonomy';
+import type { MisrepresentationResult } from './misrepresentation';
+import { isDisposableEmail } from './signals';
+
+export type Decision = 'allow' | 'verify' | 'block';
+
+export interface Finding {
+  code: string;
+  label: string;
+  score: number;
+  /** Detail for the reviewer — never shown to the buyer. */
+  detail?: string;
+}
+
+/** Score at or above which we stop the payment outright. */
+export const BLOCK_THRESHOLD = 70;
+/** Score at or above which we force 3-D Secure instead of blocking. */
+export const VERIFY_THRESHOLD = 35;
+
+export interface VelocitySnapshot {
+  /** Checkout attempts from this IP in the last 10 minutes. */
+  attemptsPerIp10m: number;
+  /** Distinct normalized buyer emails seen on this IP in the last hour. */
+  distinctEmailsPerIp1h: number;
+  /** Checkout attempts for this buyer email in the last 10 minutes. */
+  attemptsPerEmail10m: number;
+  /** Declines for this business in the last hour. */
+  declinesPerBusiness1h: number;
+  /** Declines from this IP in the last hour. */
+  declinesPerIp1h: number;
+  /** Attempts under $5 for this business in the last 10 minutes. */
+  smallAmountAttempts10m: number;
+  /** Disputes raised against this business in the last 30 days. */
+  disputesPerBusiness30d: number;
+}
+
+export interface MerchantSnapshot {
+  riskLevel: RiskLevel | null;
+  reviewStatus: string | null;
+  category: string | null;
+  /** Businesses that share an identity signal with this one. */
+  linkedBusinessIds: string[];
+  /** True when any linked business is blocklisted or prohibited. */
+  linkedToBlockedBusiness: boolean;
+}
+
+export interface ScoringInput {
+  velocity: VelocitySnapshot;
+  merchant: MerchantSnapshot;
+  misrepresentation?: MisrepresentationResult | null;
+  email: string | null;
+  amount: number | null;
+  /** A blocklist entry that already matched, if any. */
+  blocklistAction?: 'block' | 'verify' | null;
+  blocklistReason?: string | null;
+}
+
+export interface ScoringResult {
+  decision: Decision;
+  score: number;
+  findings: Finding[];
+}
+
+/**
+ * Card testers run many small charges through one merchant to find live
+ * numbers. The thresholds below are deliberately conservative: a real store
+ * doing five checkouts a minute from one IP is already unusual.
+ */
+export function scoreCheckout(input: ScoringInput): ScoringResult {
+  const findings: Finding[] = [];
+  const add = (code: string, label: string, score: number, detail?: string) => {
+    findings.push({ code, label, score, detail });
+  };
+
+  const { velocity: v, merchant: m } = input;
+
+  // ---------------------------------------------------------------- overrides
+  if (input.blocklistAction === 'block') {
+    return {
+      decision: 'block',
+      score: 100,
+      findings: [
+        {
+          code: 'blocklist',
+          label: 'Blocklist match',
+          score: 100,
+          detail: input.blocklistReason || undefined,
+        },
+      ],
+    };
+  }
+
+  if (input.blocklistAction === 'verify') {
+    add('blocklist-verify', 'Blocklist match (verify)', VERIFY_THRESHOLD, input.blocklistReason || undefined);
+  }
+
+  // ----------------------------------------------------------- merchant risk
+  if (m.riskLevel === 'prohibited') {
+    add('merchant-prohibited', 'Merchant category is not supported', 100);
+  } else if (m.riskLevel === 'high') {
+    add('merchant-high-risk', 'Merchant is high risk', 25, `category=${m.category ?? 'none'}`);
+  }
+
+  if (m.reviewStatus === 'pending') {
+    add('merchant-pending-review', 'Merchant has not cleared review', 15);
+  } else if (m.reviewStatus === 'rejected') {
+    add('merchant-rejected', 'Merchant was rejected in review', 100);
+  }
+
+  if (m.linkedToBlockedBusiness) {
+    add(
+      'linked-to-blocked',
+      'Shares identity signals with a blocked business',
+      45,
+      `linked=${m.linkedBusinessIds.join(',')}`
+    );
+  }
+
+  // ------------------------------------------------------- misrepresentation
+  const mis = input.misrepresentation;
+  if (mis?.mismatch) {
+    // Selling something riskier than declared is the strongest merchant-side
+    // signal we have — it is deliberate, not incidental. On its own this is
+    // enough to force 3-D Secure on everything the merchant takes.
+    const score = mis.observedRisk === 'prohibited' ? 60 : VERIFY_THRESHOLD;
+    add(
+      'category-misrepresentation',
+      'Activity does not match the declared category',
+      score,
+      `declared=${mis.declaredCategory ?? 'none'} observed=${mis.observedCategories.join(',')} keywords=${mis.matchedKeywords.join(',')}`
+    );
+  }
+
+  // ------------------------------------------------------------- velocity
+  if (v.distinctEmailsPerIp1h >= 6) {
+    add('ip-many-emails', 'Many different buyers from one IP', 45, `${v.distinctEmailsPerIp1h} emails/hour`);
+  } else if (v.distinctEmailsPerIp1h >= 3) {
+    add('ip-several-emails', 'Several different buyers from one IP', 25, `${v.distinctEmailsPerIp1h} emails/hour`);
+  }
+
+  if (v.attemptsPerIp10m >= 10) {
+    add('ip-burst', 'Burst of attempts from one IP', 40, `${v.attemptsPerIp10m} in 10min`);
+  } else if (v.attemptsPerIp10m >= 5) {
+    add('ip-rapid', 'Rapid attempts from one IP', 25, `${v.attemptsPerIp10m} in 10min`);
+  }
+
+  if (v.attemptsPerEmail10m >= 4) {
+    add('email-retries', 'Repeated attempts from one buyer', 20, `${v.attemptsPerEmail10m} in 10min`);
+  }
+
+  // ----------------------------------------------------------- card testing
+  if (v.declinesPerIp1h >= 3) {
+    add('ip-declines', 'Declined cards from this IP', 40, `${v.declinesPerIp1h} in 1h`);
+  }
+
+  if (v.declinesPerBusiness1h >= 10) {
+    add('merchant-declines-high', 'Heavy decline rate on this merchant', 40, `${v.declinesPerBusiness1h} in 1h`);
+  } else if (v.declinesPerBusiness1h >= 5) {
+    add('merchant-declines', 'Elevated decline rate on this merchant', 25, `${v.declinesPerBusiness1h} in 1h`);
+  }
+
+  if (v.smallAmountAttempts10m >= 3) {
+    add(
+      'small-amount-burst',
+      'Burst of small charges',
+      25,
+      `${v.smallAmountAttempts10m} under $5 in 10min`
+    );
+  }
+
+  if (v.disputesPerBusiness30d >= 3) {
+    add('merchant-disputes', 'Merchant has recent disputes', 20, `${v.disputesPerBusiness30d} in 30d`);
+  }
+
+  // -------------------------------------------------------------- buyer
+  if (isDisposableEmail(input.email)) {
+    add('disposable-email', 'Disposable email address', 20);
+  }
+
+  if (!input.email) {
+    add('no-email', 'No buyer email supplied', 10);
+  }
+
+  const score = Math.min(100, findings.reduce((total, f) => total + f.score, 0));
+
+  let decision: Decision = 'allow';
+  if (score >= BLOCK_THRESHOLD) decision = 'block';
+  else if (score >= VERIFY_THRESHOLD) decision = 'verify';
+
+  findings.sort((a, b) => b.score - a.score);
+
+  return { decision, score, findings };
+}

--- a/src/lib/fraud/screen.ts
+++ b/src/lib/fraud/screen.ts
@@ -1,0 +1,134 @@
+/**
+ * Checkout screening — the entry point called before we hand a buyer a Stripe
+ * Checkout URL.
+ *
+ * With Stripe Checkout the card never touches our servers, so "before Stripe"
+ * means before the session exists. What we can act on at that moment is the
+ * merchant, the buyer's email and network, the amount, and the history of both.
+ * Three outcomes:
+ *
+ *   allow  — create the session as normal
+ *   verify — create it, but force 3-D Secure, which shifts liability for a
+ *            stolen card back to the issuer
+ *   block  — never create the session
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { RiskLevel } from '../business/taxonomy';
+import { detectMisrepresentation, type MisrepresentationResult } from './misrepresentation';
+import { findLinkedBusinesses } from './linkage';
+import { scoreCheckout, type Decision, type Finding } from './rules';
+import { extractCheckoutSignals, type CheckoutSignals } from './signals';
+import {
+  checkBlocklist,
+  getRecentDescriptions,
+  getVelocitySnapshot,
+  recordFraudEvent,
+} from './store';
+
+export interface ScreenCheckoutInput {
+  businessId: string;
+  email?: string | null;
+  ip?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  description?: string | null;
+}
+
+export interface ScreenResult {
+  decision: Decision;
+  score: number;
+  findings: Finding[];
+  signals: CheckoutSignals;
+  misrepresentation: MisrepresentationResult | null;
+  /** Message safe to return to the caller. Deliberately vague. */
+  buyerMessage?: string;
+}
+
+const BLOCK_MESSAGE =
+  'This payment could not be processed. Please contact the merchant.';
+
+/**
+ * Screen a checkout attempt. Records the decision either way so the next
+ * attempt has history to read.
+ *
+ * Fails open: if screening itself errors, the payment proceeds. A broken
+ * fraud check must not become an outage.
+ */
+export async function screenCheckout(
+  supabase: SupabaseClient,
+  input: ScreenCheckoutInput
+): Promise<ScreenResult> {
+  const signals = extractCheckoutSignals(input);
+
+  try {
+    const { data: business } = await supabase
+      .from('businesses')
+      .select('id, merchant_id, category, risk_level, review_status')
+      .eq('id', input.businessId)
+      .maybeSingle();
+
+    const merchantId = business?.merchant_id ?? null;
+
+    const [blocklistHit, velocity, linkage, priorDescriptions] = await Promise.all([
+      checkBlocklist(supabase, signals, merchantId),
+      getVelocitySnapshot(supabase, signals),
+      findLinkedBusinesses(supabase, input.businessId).catch(() => ({
+        businessId: input.businessId,
+        links: [],
+        linkedBusinessIds: [],
+        linkedToBlockedBusiness: false,
+      })),
+      getRecentDescriptions(supabase, input.businessId),
+    ]);
+
+    // Compare the declared category against what this merchant actually bills
+    // for — this attempt's description plus recent history.
+    const misrepresentation = detectMisrepresentation({
+      declaredCategory: business?.category ?? null,
+      texts: [signals.description, ...priorDescriptions],
+    });
+
+    const result = scoreCheckout({
+      velocity,
+      merchant: {
+        riskLevel: (business?.risk_level as RiskLevel | null) ?? null,
+        reviewStatus: business?.review_status ?? null,
+        category: business?.category ?? null,
+        linkedBusinessIds: linkage.linkedBusinessIds,
+        linkedToBlockedBusiness: linkage.linkedToBlockedBusiness,
+      },
+      misrepresentation,
+      email: signals.email,
+      amount: signals.amount,
+      blocklistAction: blocklistHit?.action ?? null,
+      blocklistReason: blocklistHit?.reason ?? null,
+    });
+
+    await recordFraudEvent(supabase, {
+      businessId: input.businessId,
+      merchantId,
+      kind: 'checkout_screen',
+      decision: result.decision,
+      score: result.score,
+      signals,
+      findings: result.findings,
+    });
+
+    return {
+      ...result,
+      signals,
+      misrepresentation,
+      buyerMessage: result.decision === 'block' ? BLOCK_MESSAGE : undefined,
+    };
+  } catch (error) {
+    console.error('[Fraud] Screening failed, allowing payment:', error);
+    return {
+      decision: 'allow',
+      score: 0,
+      findings: [],
+      signals,
+      misrepresentation: null,
+    };
+  }
+}

--- a/src/lib/fraud/signals.test.ts
+++ b/src/lib/fraud/signals.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emailDomain,
+  extractCheckoutSignals,
+  ipPrefix,
+  isDisposableEmail,
+  normalizeEmail,
+} from './signals';
+
+describe('emailDomain', () => {
+  it('extracts the domain', () => {
+    expect(emailDomain('Buyer@Example.COM')).toBe('example.com');
+  });
+
+  it('rejects malformed addresses', () => {
+    expect(emailDomain('no-at-sign')).toBeNull();
+    expect(emailDomain('@nolocal.com')).toBeNull();
+    expect(emailDomain('trailing@')).toBeNull();
+    expect(emailDomain(null)).toBeNull();
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('collapses gmail dots and plus-suffixes to one identity', () => {
+    expect(normalizeEmail('j.doe+vpn@gmail.com')).toBe('jdoe@gmail.com');
+    expect(normalizeEmail('JDoe@googlemail.com')).toBe('jdoe@gmail.com');
+    expect(normalizeEmail('jdoe@gmail.com')).toBe('jdoe@gmail.com');
+  });
+
+  it('keeps dots on providers that treat them as significant', () => {
+    expect(normalizeEmail('j.doe@fastmail.com')).toBe('j.doe@fastmail.com');
+  });
+
+  it('still strips plus-suffixes elsewhere', () => {
+    expect(normalizeEmail('sales+two@shop.io')).toBe('sales@shop.io');
+  });
+
+  it('rejects malformed addresses', () => {
+    expect(normalizeEmail('+only@gmail.com')).toBeNull();
+    expect(normalizeEmail('nope')).toBeNull();
+  });
+});
+
+describe('isDisposableEmail', () => {
+  it('recognises throwaway providers', () => {
+    expect(isDisposableEmail('a@mailinator.com')).toBe(true);
+    expect(isDisposableEmail('a@gmail.com')).toBe(false);
+  });
+});
+
+describe('ipPrefix', () => {
+  it('groups IPv4 by /24', () => {
+    expect(ipPrefix('203.0.113.42')).toBe('203.0.113.0/24');
+    expect(ipPrefix('203.0.113.99')).toBe('203.0.113.0/24');
+  });
+
+  it('groups IPv6 by /48', () => {
+    expect(ipPrefix('2001:db8:1234:5678::1')).toBe('2001:db8:1234::/48');
+  });
+
+  it('returns null for unusable values', () => {
+    expect(ipPrefix('unknown')).toBeNull();
+    expect(ipPrefix('')).toBeNull();
+    expect(ipPrefix('1.2.3')).toBeNull();
+    expect(ipPrefix(null)).toBeNull();
+  });
+});
+
+describe('extractCheckoutSignals', () => {
+  it('normalizes everything the rules read', () => {
+    const signals = extractCheckoutSignals({
+      businessId: 'biz-1',
+      email: '  J.Doe+Test@Gmail.com ',
+      ip: '203.0.113.42',
+      amount: 499,
+      currency: 'USD',
+      description: '  12 month IPTV subscription ',
+    });
+
+    expect(signals.email).toBe('j.doe+test@gmail.com');
+    expect(signals.emailNormalized).toBe('jdoe@gmail.com');
+    expect(signals.emailDomain).toBe('gmail.com');
+    expect(signals.ipPrefix).toBe('203.0.113.0/24');
+    expect(signals.currency).toBe('usd');
+    expect(signals.description).toBe('12 month IPTV subscription');
+  });
+
+  it('tolerates a request with nothing but a business id', () => {
+    const signals = extractCheckoutSignals({ businessId: 'biz-1' });
+    expect(signals.email).toBeNull();
+    expect(signals.ip).toBeNull();
+    expect(signals.ipPrefix).toBeNull();
+    expect(signals.amount).toBeNull();
+  });
+
+  it('treats an unknown IP as absent', () => {
+    expect(extractCheckoutSignals({ businessId: 'b', ip: 'unknown' }).ip).toBeNull();
+  });
+});

--- a/src/lib/fraud/signals.ts
+++ b/src/lib/fraud/signals.ts
@@ -1,0 +1,138 @@
+/**
+ * Signal extraction and normalization for fraud screening.
+ *
+ * Everything here is pure — no DB, no network — so the rules that depend on it
+ * stay testable.
+ */
+
+/** Providers that ignore dots and treat +suffix as the same inbox. */
+const DOT_INSENSITIVE_DOMAINS = new Set([
+  'gmail.com',
+  'googlemail.com',
+]);
+
+const DOMAIN_ALIASES: Record<string, string> = {
+  'googlemail.com': 'gmail.com',
+};
+
+/**
+ * Disposable and throwaway mailbox providers. Not exhaustive by design — this
+ * is a signal that adds score, never one that blocks on its own.
+ */
+export const DISPOSABLE_EMAIL_DOMAINS = new Set([
+  '10minutemail.com',
+  'guerrillamail.com',
+  'mailinator.com',
+  'tempmail.com',
+  'temp-mail.org',
+  'throwawaymail.com',
+  'yopmail.com',
+  'trashmail.com',
+  'getnada.com',
+  'dispostable.com',
+  'maildrop.cc',
+  'sharklasers.com',
+  'grr.la',
+  'spam4.me',
+  'fakeinbox.com',
+  'mohmal.com',
+  'emailondeck.com',
+  'tempr.email',
+  'moakt.com',
+  'inboxkitten.com',
+]);
+
+export function emailDomain(email: string | null | undefined): string | null {
+  if (typeof email !== 'string') return null;
+  const at = email.lastIndexOf('@');
+  if (at <= 0 || at === email.length - 1) return null;
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  return domain || null;
+}
+
+/**
+ * Collapse the aliases one person uses to look like several: case, dots and
+ * +suffix on providers that ignore them. `j.doe+vpn@gmail.com` and
+ * `JDoe@googlemail.com` both normalize to `jdoe@gmail.com`.
+ */
+export function normalizeEmail(email: string | null | undefined): string | null {
+  if (typeof email !== 'string') return null;
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf('@');
+  if (at <= 0 || at === trimmed.length - 1) return null;
+
+  let local = trimmed.slice(0, at);
+  const rawDomain = trimmed.slice(at + 1);
+  const domain = DOMAIN_ALIASES[rawDomain] ?? rawDomain;
+
+  // A leading '+' leaves nothing to identify, and falls through to the guard below.
+  const plus = local.indexOf('+');
+  if (plus >= 0) local = local.slice(0, plus);
+  if (DOT_INSENSITIVE_DOMAINS.has(rawDomain) || DOT_INSENSITIVE_DOMAINS.has(domain)) {
+    local = local.replace(/\./g, '');
+  }
+
+  if (!local) return null;
+  return `${local}@${domain}`;
+}
+
+export function isDisposableEmail(email: string | null | undefined): boolean {
+  const domain = emailDomain(email);
+  return domain ? DISPOSABLE_EMAIL_DOMAINS.has(domain) : false;
+}
+
+/**
+ * Coarse network grouping: /24 for IPv4, /48 for IPv6. Card testers rotate the
+ * last octet, so the prefix is the more useful velocity key.
+ */
+export function ipPrefix(ip: string | null | undefined): string | null {
+  if (typeof ip !== 'string') return null;
+  const trimmed = ip.trim();
+  if (!trimmed || trimmed === 'unknown') return null;
+
+  if (trimmed.includes(':')) {
+    const groups = trimmed.split(':').filter(Boolean);
+    if (groups.length < 3) return null;
+    return `${groups.slice(0, 3).join(':')}::/48`;
+  }
+
+  const octets = trimmed.split('.');
+  if (octets.length !== 4) return null;
+  return `${octets.slice(0, 3).join('.')}.0/24`;
+}
+
+export interface CheckoutSignals {
+  businessId: string;
+  email: string | null;
+  emailDomain: string | null;
+  emailNormalized: string | null;
+  ip: string | null;
+  ipPrefix: string | null;
+  amount: number | null;
+  currency: string | null;
+  description: string | null;
+}
+
+export function extractCheckoutSignals(input: {
+  businessId: string;
+  email?: string | null;
+  ip?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  description?: string | null;
+}): CheckoutSignals {
+  const ip = typeof input.ip === 'string' && input.ip !== 'unknown' ? input.ip.trim() : null;
+  return {
+    businessId: input.businessId,
+    email: typeof input.email === 'string' && input.email.trim() ? input.email.trim().toLowerCase() : null,
+    emailDomain: emailDomain(input.email),
+    emailNormalized: normalizeEmail(input.email),
+    ip: ip || null,
+    ipPrefix: ipPrefix(ip),
+    amount: typeof input.amount === 'number' && Number.isFinite(input.amount) ? input.amount : null,
+    currency: typeof input.currency === 'string' ? input.currency.toLowerCase() : null,
+    description: typeof input.description === 'string' && input.description.trim()
+      ? input.description.trim()
+      : null,
+  };
+}

--- a/src/lib/fraud/store.ts
+++ b/src/lib/fraud/store.ts
@@ -1,0 +1,268 @@
+/**
+ * Database access for fraud screening: velocity counters, the blocklist, and
+ * the append-only event log.
+ *
+ * Screening sits inline on the checkout path, so every read here is
+ * fail-open — a database hiccup must not stop legitimate payments. The one
+ * exception is recording, which is fire-and-forget.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Decision, Finding, VelocitySnapshot } from './rules';
+import type { CheckoutSignals } from './signals';
+
+/** Amounts (in minor units) below this count as "small" for card testing. */
+export const SMALL_AMOUNT_MINOR = 500;
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+async function countRows(
+  supabase: SupabaseClient,
+  build: (q: any) => any
+): Promise<number> {
+  try {
+    const { count, error } = await build(
+      supabase.from('fraud_events').select('id', { count: 'exact', head: true })
+    );
+    if (error) return 0;
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Gather every velocity counter the rules need. Counters that cannot be
+ * computed (no IP, no email) come back as 0 so they simply never fire.
+ */
+export async function getVelocitySnapshot(
+  supabase: SupabaseClient,
+  signals: CheckoutSignals
+): Promise<VelocitySnapshot> {
+  const tenMin = minutesAgo(10);
+  const oneHour = minutesAgo(60);
+  const thirtyDays = minutesAgo(60 * 24 * 30);
+
+  const ipKey = signals.ipPrefix ?? signals.ip;
+
+  const [
+    attemptsPerIp10m,
+    attemptsPerEmail10m,
+    declinesPerBusiness1h,
+    declinesPerIp1h,
+    smallAmountAttempts10m,
+    disputesPerBusiness30d,
+    distinctEmailsPerIp1h,
+  ] = await Promise.all([
+    ipKey
+      ? countRows(supabase, (q) =>
+          q
+            .eq('kind', 'checkout_screen')
+            .eq(signals.ipPrefix ? 'ip_prefix' : 'ip', ipKey)
+            .gte('created_at', tenMin)
+        )
+      : Promise.resolve(0),
+
+    signals.emailNormalized
+      ? countRows(supabase, (q) =>
+          q
+            .eq('kind', 'checkout_screen')
+            .eq('email_normalized', signals.emailNormalized)
+            .gte('created_at', tenMin)
+        )
+      : Promise.resolve(0),
+
+    countRows(supabase, (q) =>
+      q.eq('kind', 'card_declined').eq('business_id', signals.businessId).gte('created_at', oneHour)
+    ),
+
+    ipKey
+      ? countRows(supabase, (q) =>
+          q
+            .eq('kind', 'card_declined')
+            .eq(signals.ipPrefix ? 'ip_prefix' : 'ip', ipKey)
+            .gte('created_at', oneHour)
+        )
+      : Promise.resolve(0),
+
+    countRows(supabase, (q) =>
+      q
+        .eq('kind', 'checkout_screen')
+        .eq('business_id', signals.businessId)
+        .lt('amount', SMALL_AMOUNT_MINOR)
+        .gte('created_at', tenMin)
+    ),
+
+    countRows(supabase, (q) =>
+      q.eq('kind', 'dispute').eq('business_id', signals.businessId).gte('created_at', thirtyDays)
+    ),
+
+    countDistinctEmailsForIp(supabase, signals, oneHour),
+  ]);
+
+  return {
+    attemptsPerIp10m,
+    distinctEmailsPerIp1h,
+    attemptsPerEmail10m,
+    declinesPerBusiness1h,
+    declinesPerIp1h,
+    smallAmountAttempts10m,
+    disputesPerBusiness30d,
+  };
+}
+
+/**
+ * Distinct buyer mailboxes seen on one network in the window. Postgrest has no
+ * count(distinct), so this pulls the column and dedupes — capped, because the
+ * only thing the rules care about is "more than a handful".
+ */
+async function countDistinctEmailsForIp(
+  supabase: SupabaseClient,
+  signals: CheckoutSignals,
+  since: string
+): Promise<number> {
+  const ipKey = signals.ipPrefix ?? signals.ip;
+  if (!ipKey) return 0;
+
+  try {
+    const { data, error } = await supabase
+      .from('fraud_events')
+      .select('email_normalized')
+      .eq('kind', 'checkout_screen')
+      .eq(signals.ipPrefix ? 'ip_prefix' : 'ip', ipKey)
+      .gte('created_at', since)
+      .not('email_normalized', 'is', null)
+      .limit(200);
+
+    if (error || !data) return 0;
+    return new Set(data.map((row: { email_normalized: string }) => row.email_normalized)).size;
+  } catch {
+    return 0;
+  }
+}
+
+export interface BlocklistHit {
+  action: 'block' | 'verify';
+  reason: string | null;
+  kind: string;
+  value: string;
+}
+
+/**
+ * Look for a blocklist entry matching any signal on this attempt. Block beats
+ * verify when several match.
+ */
+export async function checkBlocklist(
+  supabase: SupabaseClient,
+  signals: CheckoutSignals,
+  merchantId?: string | null
+): Promise<BlocklistHit | null> {
+  const candidates: Array<{ kind: string; value: string }> = [];
+  if (signals.emailNormalized) candidates.push({ kind: 'email', value: signals.emailNormalized });
+  if (signals.emailDomain) candidates.push({ kind: 'email_domain', value: signals.emailDomain });
+  if (signals.ip) candidates.push({ kind: 'ip', value: signals.ip });
+  if (signals.ipPrefix) candidates.push({ kind: 'ip_prefix', value: signals.ipPrefix });
+  candidates.push({ kind: 'business', value: signals.businessId });
+  if (merchantId) candidates.push({ kind: 'merchant', value: merchantId });
+
+  try {
+    const { data, error } = await supabase
+      .from('fraud_blocklist')
+      .select('kind, value, action, reason, expires_at')
+      .in(
+        'value',
+        candidates.map((c) => c.value)
+      );
+
+    if (error || !data || data.length === 0) return null;
+
+    const now = Date.now();
+    const hits = data.filter((row: any) => {
+      if (row.expires_at && new Date(row.expires_at).getTime() < now) return false;
+      return candidates.some((c) => c.kind === row.kind && c.value === row.value);
+    });
+
+    if (hits.length === 0) return null;
+    const blocking = hits.find((h: any) => h.action === 'block');
+    const chosen = blocking ?? hits[0];
+    return {
+      action: chosen.action,
+      reason: chosen.reason ?? null,
+      kind: chosen.kind,
+      value: chosen.value,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface RecordEventInput {
+  businessId?: string | null;
+  merchantId?: string | null;
+  kind: 'checkout_screen' | 'card_declined' | 'dispute' | 'payment_succeeded';
+  decision?: Decision | null;
+  score?: number | null;
+  signals?: Partial<CheckoutSignals> | null;
+  findings?: Finding[];
+  stripePaymentIntentId?: string | null;
+}
+
+/**
+ * Append to the event log. Never throws — a failed write costs us a future
+ * velocity data point, not this payment.
+ */
+export async function recordFraudEvent(
+  supabase: SupabaseClient,
+  input: RecordEventInput
+): Promise<void> {
+  try {
+    await supabase.from('fraud_events').insert({
+      business_id: input.businessId ?? null,
+      merchant_id: input.merchantId ?? null,
+      kind: input.kind,
+      decision: input.decision ?? null,
+      score: input.score ?? null,
+      email: input.signals?.email ?? null,
+      email_domain: input.signals?.emailDomain ?? null,
+      email_normalized: input.signals?.emailNormalized ?? null,
+      ip: input.signals?.ip ?? null,
+      ip_prefix: input.signals?.ipPrefix ?? null,
+      amount: input.signals?.amount ?? null,
+      currency: input.signals?.currency ?? null,
+      description: input.signals?.description ?? null,
+      findings: input.findings ?? [],
+      stripe_payment_intent_id: input.stripePaymentIntentId ?? null,
+    });
+  } catch (error) {
+    console.error('[Fraud] Failed to record event:', error);
+  }
+}
+
+/**
+ * Recent payment descriptions for a business, used to compare what they
+ * actually sell against what they declared.
+ */
+export async function getRecentDescriptions(
+  supabase: SupabaseClient,
+  businessId: string,
+  limit = 50
+): Promise<string[]> {
+  try {
+    const { data, error } = await supabase
+      .from('fraud_events')
+      .select('description')
+      .eq('business_id', businessId)
+      .not('description', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error || !data) return [];
+    return data
+      .map((row: { description: string | null }) => row.description)
+      .filter((d: string | null): d is string => !!d);
+  } catch {
+    return [];
+  }
+}

--- a/supabase/migrations/20260813000000_add_business_categorization.sql
+++ b/supabase/migrations/20260813000000_add_business_categorization.sql
@@ -1,0 +1,47 @@
+-- Business categorization and risk classification.
+--
+-- Merchants pick a `category` and add free-form keyword `tags` when creating a
+-- business. `risk_level`, `risk_flags` and `review_status` are derived by
+-- src/lib/business/taxonomy.ts — never set directly by the merchant.
+--
+-- `category` intentionally has no check constraint: the taxonomy lives in code
+-- and changes more often than the schema should.
+
+ALTER TABLE businesses
+  ADD COLUMN IF NOT EXISTS category text,
+  ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS risk_level text,
+  ADD COLUMN IF NOT EXISTS risk_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS review_status text NOT NULL DEFAULT 'not_required',
+  ADD COLUMN IF NOT EXISTS classified_at timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'businesses_risk_level_check'
+  ) THEN
+    ALTER TABLE businesses
+      ADD CONSTRAINT businesses_risk_level_check
+      CHECK (risk_level IS NULL OR risk_level IN ('low', 'medium', 'high', 'prohibited'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'businesses_review_status_check'
+  ) THEN
+    ALTER TABLE businesses
+      ADD CONSTRAINT businesses_review_status_check
+      CHECK (review_status IN ('not_required', 'pending', 'approved', 'rejected'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_businesses_category ON businesses (category);
+CREATE INDEX IF NOT EXISTS idx_businesses_tags ON businesses USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_businesses_review_queue
+  ON businesses (created_at DESC)
+  WHERE review_status = 'pending';
+
+COMMENT ON COLUMN businesses.category IS 'Taxonomy slug from src/lib/business/taxonomy.ts';
+COMMENT ON COLUMN businesses.tags IS 'Merchant-entered keywords, normalized lowercase';
+COMMENT ON COLUMN businesses.risk_level IS 'Derived: low | medium | high | prohibited. NULL = never classified';
+COMMENT ON COLUMN businesses.risk_flags IS 'Derived: [{code,label,severity,matched,source}] evidence for risk_level';
+COMMENT ON COLUMN businesses.review_status IS 'not_required | pending | approved | rejected';

--- a/supabase/migrations/20260813010000_add_fraud_screening.sql
+++ b/supabase/migrations/20260813010000_add_fraud_screening.sql
@@ -1,0 +1,88 @@
+-- Pre-authorization fraud screening.
+--
+-- `fraud_events` is an append-only log of everything we learn about a payment
+-- attempt: the screening decision made before we hand the buyer a Stripe
+-- Checkout URL, and the outcomes (declines, disputes) that come back by
+-- webhook. Velocity rules read their own history out of this table.
+--
+-- `fraud_blocklist` is the manual/automatic override layer — an entry here
+-- short-circuits scoring.
+
+CREATE TABLE IF NOT EXISTS fraud_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id uuid REFERENCES businesses(id) ON DELETE CASCADE,
+  merchant_id uuid,
+
+  -- checkout_screen | card_declined | dispute | payment_succeeded
+  kind text NOT NULL,
+  -- allow | verify | block  (null for outcome events)
+  decision text,
+  score integer,
+
+  -- Buyer signals, all nullable: we only ever get what the integration sends.
+  email text,
+  email_domain text,
+  email_normalized text,
+  ip text,
+  ip_prefix text,
+  amount bigint,
+  currency text,
+  description text,
+
+  findings jsonb NOT NULL DEFAULT '[]'::jsonb,
+  stripe_payment_intent_id text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fraud_events_ip ON fraud_events (ip, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fraud_events_ip_prefix ON fraud_events (ip_prefix, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fraud_events_email ON fraud_events (email_normalized, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fraud_events_business ON fraud_events (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fraud_events_kind ON fraud_events (kind, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS fraud_blocklist (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- email | email_domain | ip | ip_prefix | business | merchant
+  kind text NOT NULL,
+  value text NOT NULL,
+  -- block | verify
+  action text NOT NULL DEFAULT 'block',
+  reason text,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fraud_blocklist_entry ON fraud_blocklist (kind, value);
+CREATE INDEX IF NOT EXISTS idx_fraud_blocklist_lookup ON fraud_blocklist (kind, value, expires_at);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fraud_events_kind_check') THEN
+    ALTER TABLE fraud_events ADD CONSTRAINT fraud_events_kind_check
+      CHECK (kind IN ('checkout_screen', 'card_declined', 'dispute', 'payment_succeeded'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fraud_events_decision_check') THEN
+    ALTER TABLE fraud_events ADD CONSTRAINT fraud_events_decision_check
+      CHECK (decision IS NULL OR decision IN ('allow', 'verify', 'block'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fraud_blocklist_kind_check') THEN
+    ALTER TABLE fraud_blocklist ADD CONSTRAINT fraud_blocklist_kind_check
+      CHECK (kind IN ('email', 'email_domain', 'ip', 'ip_prefix', 'business', 'merchant'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fraud_blocklist_action_check') THEN
+    ALTER TABLE fraud_blocklist ADD CONSTRAINT fraud_blocklist_action_check
+      CHECK (action IN ('block', 'verify'));
+  END IF;
+END $$;
+
+-- Service-role only: these tables are read and written by server routes, never
+-- by the browser.
+ALTER TABLE fraud_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fraud_blocklist ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE fraud_events IS 'Append-only log of screening decisions and payment outcomes';
+COMMENT ON TABLE fraud_blocklist IS 'Manual and automatic overrides checked before scoring';


### PR DESCRIPTION
Three commits, each independently tested.

## 1. Categorization (`fede6a4`)
Merchants pick a category and add keyword tags when creating a business. A classifier derives a risk level from the declared category **plus** keyword rules over name/description/tags — so filing IPTV resale under "SaaS" still gets flagged. High/prohibited land in a pending review queue; surfaced, not blocked.

## 2. Fraud screening (`76c027e`)
`screenCheckout()` runs before the Stripe Checkout Session is created — the last point we can act, since with Checkout the card never reaches our servers. Returns allow / verify / block:

- **verify** forces 3-D Secure, shifting stolen-card liability to the issuer
- **block** returns 403 and no session is created

Catches card testing (small-charge bursts, many buyers per network, decline runs), category misrepresentation (declared VPN, billing for IPTV), and multi-account operators (shared payout wallets, Stripe accounts, webhook hosts, normalized owner emails). Declines and disputes feed back from the Stripe webhook. Fails open throughout.

## 3. Admin console + tag CRUD (`eb74f37`)
`/admin/businesses` lists every business with search and facets; expand a row for the score rationale, linked accounts, inline tag editing and review actions. Tags get a real sub-resource (`GET/POST/PUT/DELETE /api/businesses/:id/tags`) that reclassifies on every write.

## Before merging

- **Migrations are already applied to prod** (additive only — new nullable columns plus `fraud_events` / `fraud_blocklist`). Current master ignores them, so there is no half-state.
- **Category becomes required** on new business creation. Existing businesses are unaffected.
- **Live payments start being screened on deploy.** Thresholds are untuned against real traffic — consider a log-only first pass.
- Admin Reject/Deactivate write immediately, with no confirmation dialog.

## Known, not addressed here

`POST /api/stripe/payments/create` has no auth — it takes `businessId` from the body, and `middleware.ts` only tracks referral codes. Screening now sits in front of it, but that route should be authenticated separately.

Verified: `tsc --noEmit` clean, 280 test files / 3,878 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)