### PR TITLE
fix(payments): stop invoice deposits stranding at the intermediary address

### DIFF
--- a/scripts/diagnose-stranded-address.ts
+++ b/scripts/diagnose-stranded-address.ts
@@ -1,0 +1,180 @@
+/**
+ * Diagnose a single stranded CoinPay payment address.
+ *
+ * Read-only. Answers three questions about an address whose funds never
+ * reached the merchant:
+ *   1. What is actually sitting on-chain at it right now?
+ *   2. Is it still spendable by us (does the stored key decrypt)?
+ *   3. Which defect stranded it, and therefore what the recovery has to fix?
+ *
+ * It never moves funds and never prints key material.
+ *
+ * Usage:
+ *   pnpm tsx scripts/diagnose-stranded-address.ts <payment_address>
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { decrypt } from '../src/lib/crypto/encryption';
+import { checkBalance } from '../src/lib/payments/monitor-balance';
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+async function main() {
+  const address = process.argv[2];
+  if (!address) {
+    fail('Usage: pnpm tsx scripts/diagnose-stranded-address.ts <payment_address>');
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    fail('Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // ── 1. The derived address record ─────────────────────────────────────
+  const { data: addr, error: addrErr } = await supabase
+    .from('payment_addresses')
+    .select('*')
+    .eq('address', address)
+    .maybeSingle();
+
+  if (addrErr) fail(`payment_addresses lookup failed: ${addrErr.message}`);
+  if (!addr) {
+    fail(
+      `No payment_addresses row for ${address}.\n` +
+        'This address was not derived by the system wallet — recovery via the ' +
+        'stored key is not possible. Check that the address was copied correctly.',
+    );
+  }
+
+  console.log('── Derived address ────────────────────────────────');
+  console.log(`address          : ${addr.address}`);
+  console.log(`cryptocurrency   : ${addr.cryptocurrency}`);
+  console.log(`derivation_path  : ${addr.derivation_path}`);
+  console.log(`derivation_index : ${addr.derivation_index}`);
+  console.log(`business_id      : ${addr.business_id}`);
+  console.log(`payment_id       : ${addr.payment_id}`);
+  console.log(`amount_expected  : ${addr.amount_expected}`);
+  console.log(`merchant_wallet  : ${addr.merchant_wallet === '' ? '(EMPTY)' : addr.merchant_wallet}`);
+  console.log(`commission_wallet: ${addr.commission_wallet}`);
+  console.log(`is_escrow        : ${addr.is_escrow ?? false}`);
+
+  // ── 2. The payment record ─────────────────────────────────────────────
+  const { data: payment } = await supabase
+    .from('payments')
+    .select('*')
+    .eq('id', addr.payment_id)
+    .maybeSingle();
+
+  console.log('\n── Payment ────────────────────────────────────────');
+  if (!payment) {
+    console.log('(no payments row — the address is orphaned)');
+  } else {
+    console.log(`status           : ${payment.status}`);
+    console.log(`crypto_amount    : ${payment.crypto_amount} ${payment.blockchain}`);
+    console.log(`created_at       : ${payment.created_at}`);
+    console.log(`expires_at       : ${payment.expires_at}`);
+    console.log(`confirmed_at     : ${payment.confirmed_at ?? '—'}`);
+    console.log(`forward_tx_hash  : ${payment.forward_tx_hash ?? '—'}`);
+    console.log(`merchant_wallet_address: ${payment.merchant_wallet_address || '(EMPTY)'}`);
+  }
+
+  // ── 3. The invoice, if any ────────────────────────────────────────────
+  const { data: invoices } = await supabase
+    .from('invoices')
+    .select('id, invoice_number, status, paid_at, tx_hash, crypto_currency, crypto_amount, merchant_wallet_address, business_id, user_id, metadata')
+    .eq('payment_address', address);
+
+  console.log('\n── Invoice ────────────────────────────────────────');
+  if (!invoices?.length) {
+    console.log('(no invoice references this address)');
+  } else {
+    for (const inv of invoices) {
+      console.log(`invoice_number   : ${inv.invoice_number}`);
+      console.log(`status           : ${inv.status}`);
+      console.log(`paid_at          : ${inv.paid_at ?? '—'}`);
+      console.log(`payee            : ${inv.merchant_wallet_address || '(EMPTY)'}`);
+      console.log(`linked payment   : ${(inv.metadata as any)?.coinpay_payment_id ?? '(none — unlinked invoice)'}`);
+    }
+  }
+
+  // ── 4. What is actually on-chain ──────────────────────────────────────
+  console.log('\n── On-chain ───────────────────────────────────────');
+  let onChain = 0;
+  try {
+    const balance = await checkBalance(addr.address, addr.cryptocurrency);
+    onChain = balance.balance;
+    console.log(`balance          : ${balance.balance} ${addr.cryptocurrency}`);
+    console.log(`deposit tx       : ${balance.txHash ?? '—'}`);
+  } catch (err) {
+    console.log(`balance lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // ── 5. Is it still spendable by us? ───────────────────────────────────
+  console.log('\n── Spendability ───────────────────────────────────');
+  const encryptionKey = process.env.ENCRYPTION_KEY;
+  if (!encryptionKey) {
+    console.log('ENCRYPTION_KEY not set — cannot verify the stored key decrypts.');
+  } else if (!addr.encrypted_private_key) {
+    console.log('NO STORED KEY — funds are only recoverable from the system mnemonic ' +
+      `at ${addr.derivation_path}.`);
+  } else {
+    try {
+      const pk = decrypt(addr.encrypted_private_key, encryptionKey);
+      // Never print key material — length alone proves a clean decrypt.
+      console.log(`stored key decrypts OK (${pk.length} chars). Funds are spendable.`);
+    } catch (err) {
+      console.log(`STORED KEY FAILED TO DECRYPT: ${err instanceof Error ? err.message : String(err)}`);
+      console.log('ENCRYPTION_KEY may have rotated since this address was created.');
+    }
+  }
+
+  // ── 6. Diagnosis ──────────────────────────────────────────────────────
+  console.log('\n── Diagnosis ──────────────────────────────────────');
+  const findings: string[] = [];
+
+  if (addr.merchant_wallet === '' || addr.merchant_wallet == null) {
+    findings.push(
+      'PAYEE MISSING: payment_addresses.merchant_wallet is empty, so forwarding ' +
+        'throws on an empty recipient and no leg of the split is sent. Recovery ' +
+        'must set a real payout address before re-forwarding.',
+    );
+  }
+  if (payment?.status === 'expired') {
+    findings.push(
+      'EXPIRED: the payment was marked expired by the 15-minute window, and ' +
+        'monitorPayments only polls status=pending — nothing will ever revisit ' +
+        'this address on its own.',
+    );
+  }
+  if (payment && !['forwarded'].includes(payment.status) && onChain > 0) {
+    findings.push(`FUNDS PRESENT AND UNFORWARDED: ${onChain} ${addr.cryptocurrency} is sitting at the derived address.`);
+  }
+  if (invoices?.some((i) => i.status === 'paid') && payment?.status !== 'forwarded') {
+    findings.push(
+      'INVOICE MARKED PAID WITHOUT FORWARDING: the invoice was settled by a path ' +
+        'that never triggered the forwarding pipeline (check-balance route or the ' +
+        'invoice monitor stub).',
+    );
+  }
+  if (addr.is_escrow) {
+    findings.push('ESCROW-HELD: auto-forwarding is intentionally skipped. Settle via /api/escrow/:id/settle, not a sweep.');
+  }
+
+  if (!findings.length) {
+    console.log('Nothing anomalous found — this address looks normal.');
+  } else {
+    for (const f of findings) console.log(`• ${f}`);
+  }
+
+  console.log('\n(read-only — nothing was modified)');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/recover-sol-payment.ts
+++ b/scripts/recover-sol-payment.ts
@@ -1,0 +1,226 @@
+/**
+ * Recover a single stranded Solana payment address, sending 100% to the merchant.
+ *
+ * This is deliberately NOT forwardPaymentSecurely: that path always splits off
+ * the platform commission. When funds were stranded by a platform defect rather
+ * than by anything the merchant did, the whole balance goes back to them.
+ *
+ * Safety rails, in order of how badly each would hurt if skipped:
+ *   - The destination is taken from ARGV, never from the database. A payout
+ *     address that someone edited in the DB cannot silently redirect the sweep.
+ *   - The keypair derived from the stored key must equal the address we are
+ *     draining, or the run aborts. (SolanaProvider only *logs* this mismatch —
+ *     see providers.ts:106 — which is not good enough when draining an account.)
+ *   - Dry run is the default. Nothing is signed without --execute.
+ *   - The DB is only updated after the transaction is confirmed on-chain.
+ *
+ * Usage:
+ *   pnpm tsx scripts/recover-sol-payment.ts <deposit_address> <destination_address>
+ *   pnpm tsx scripts/recover-sol-payment.ts <deposit_address> <destination_address> --execute
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import { decrypt } from '../src/lib/crypto/encryption';
+
+// Load .env.local if present, so ENCRYPTION_KEY never has to be typed on the
+// command line (where it would land in shell history). Anything already in the
+// environment — doppler, a CI secret — wins over the file.
+const envLocal = join(process.cwd(), '.env.local');
+if (existsSync(envLocal)) config({ path: envLocal, override: false });
+
+/** Matches SolanaProvider.SOLANA_TX_FEE_LAMPORTS (providers.ts). */
+const TX_FEE_LAMPORTS = 5000;
+
+function fail(msg: string): never {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+}
+
+const sol = (lamports: number) => (lamports / LAMPORTS_PER_SOL).toFixed(9);
+
+async function main() {
+  const [depositAddress, destinationAddress] = process.argv.slice(2);
+  const execute = process.argv.includes('--execute');
+
+  if (!depositAddress || !destinationAddress || destinationAddress.startsWith('--')) {
+    fail('Usage: pnpm tsx scripts/recover-sol-payment.ts <deposit_address> <destination_address> [--execute]');
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const encryptionKey = process.env.ENCRYPTION_KEY;
+  if (!supabaseUrl || !supabaseKey) fail('Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  if (!encryptionKey) fail('Missing ENCRYPTION_KEY — cannot decrypt the stored key');
+
+  const rpcUrl = process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com';
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const connection = new Connection(rpcUrl, 'confirmed');
+
+  // ── Load the address record ───────────────────────────────────────────
+  const { data: addr, error: addrErr } = await supabase
+    .from('payment_addresses')
+    .select('*')
+    .eq('address', depositAddress)
+    .maybeSingle();
+
+  if (addrErr) fail(`payment_addresses lookup failed: ${addrErr.message}`);
+  if (!addr) fail(`No payment_addresses row for ${depositAddress}`);
+  if (!['SOL', 'USDT_SOL', 'USDC_SOL'].includes(addr.cryptocurrency)) {
+    fail(`${depositAddress} is ${addr.cryptocurrency}, not a Solana address. This script only handles SOL.`);
+  }
+  if (addr.cryptocurrency !== 'SOL') {
+    fail(`${addr.cryptocurrency} is an SPL token — sweeping it needs a token-account transfer, not a lamport transfer.`);
+  }
+  if (addr.is_escrow) {
+    fail('This address holds escrow funds. Settle via /api/escrow/:id/settle, never a sweep.');
+  }
+  if (!addr.encrypted_private_key) {
+    fail(`No stored key. Recover from the system mnemonic at ${addr.derivation_path}.`);
+  }
+
+  // ── Rebuild the keypair and PROVE it owns the address ─────────────────
+  let keypair: Keypair;
+  try {
+    const seedHex = decrypt(addr.encrypted_private_key, encryptionKey);
+    const seed = Buffer.from(seedHex, 'hex');
+    if (seed.length !== 32) {
+      fail(`Stored key is ${seed.length} bytes; expected a 32-byte ed25519 seed.`);
+    }
+    keypair = Keypair.fromSeed(Uint8Array.from(seed));
+  } catch (err) {
+    fail(`Could not rebuild the keypair: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (keypair.publicKey.toBase58() !== depositAddress) {
+    fail(
+      `KEY MISMATCH — refusing to sign.\n` +
+        `  stored address : ${depositAddress}\n` +
+        `  key derives to : ${keypair.publicKey.toBase58()}\n` +
+        `  The ENCRYPTION_KEY or the stored key does not belong to this address.`,
+    );
+  }
+
+  let destination: PublicKey;
+  try {
+    destination = new PublicKey(destinationAddress);
+  } catch {
+    fail(`Destination ${destinationAddress} is not a valid Solana address.`);
+  }
+  if (destination.toBase58() === depositAddress) {
+    fail('Destination is the deposit address itself — nothing to do.');
+  }
+
+  // ── Work out what is actually sweepable ───────────────────────────────
+  const balance = await connection.getBalance(keypair.publicKey);
+  const sweepable = balance - TX_FEE_LAMPORTS;
+
+  console.log('── Recovery plan ──────────────────────────────────');
+  console.log(`from         : ${depositAddress}`);
+  console.log(`  key verified: derives to this exact address ✓`);
+  console.log(`to           : ${destination.toBase58()}`);
+  console.log(`payment_id   : ${addr.payment_id}`);
+  console.log(`balance      : ${balance} lamports (${sol(balance)} SOL)`);
+  console.log(`network fee  : ${TX_FEE_LAMPORTS} lamports`);
+  console.log(`sweeping     : ${sweepable} lamports (${sol(sweepable)} SOL)  [100% to merchant]`);
+  console.log(`leaving      : 0 — the account is drained and closed`);
+
+  if (sweepable <= 0) {
+    fail(`Nothing to sweep: balance ${balance} does not cover the ${TX_FEE_LAMPORTS} lamport fee.`);
+  }
+
+  if (!execute) {
+    console.log('\nDRY RUN — nothing signed or sent. Re-run with --execute to move the funds.');
+    return;
+  }
+
+  // ── Send ──────────────────────────────────────────────────────────────
+  console.log('\nSigning and broadcasting…');
+  const tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: destination,
+      lamports: sweepable,
+    }),
+  );
+
+  let signature: string;
+  try {
+    signature = await sendAndConfirmTransaction(connection, tx, [keypair], {
+      commitment: 'confirmed',
+    });
+  } catch (err) {
+    fail(`Broadcast failed, funds untouched: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  console.log(`✓ Confirmed: ${signature}`);
+  console.log(`  https://solscan.io/tx/${signature}`);
+
+  // ── Reconcile the database (only now that the money has moved) ────────
+  const nowIso = new Date().toISOString();
+  const sweptSol = Number(sol(sweepable));
+
+  const { error: paErr } = await supabase
+    .from('payment_addresses')
+    .update({ merchant_wallet: destination.toBase58(), is_used: true })
+    .eq('address', depositAddress);
+  if (paErr) console.error(`! payment_addresses update failed: ${paErr.message}`);
+
+  const { error: pErr } = await supabase
+    .from('payments')
+    .update({
+      status: 'forwarded',
+      merchant_wallet_address: destination.toBase58(),
+      forward_tx_hash: signature,
+      merchant_amount: sweptSol,
+      fee_amount: 0,
+      forwarded_at: nowIso,
+      updated_at: nowIso,
+    })
+    .eq('id', addr.payment_id);
+  if (pErr) console.error(`! payments update failed: ${pErr.message}`);
+
+  // Stamp the invoice so the recovery is auditable rather than looking like
+  // the forwarding simply worked all along.
+  const { data: inv } = await supabase
+    .from('invoices')
+    .select('id, metadata')
+    .eq('payment_address', depositAddress)
+    .maybeSingle();
+
+  if (inv) {
+    const { error: iErr } = await supabase
+      .from('invoices')
+      .update({
+        merchant_wallet_address: destination.toBase58(),
+        metadata: {
+          ...(inv.metadata && typeof inv.metadata === 'object' ? inv.metadata : {}),
+          recovered_at: nowIso,
+          recovery_tx: signature,
+          recovery_note: 'Stranded by expired-payment + empty-payee defect; swept 100% to merchant, no commission taken.',
+        },
+        updated_at: nowIso,
+      })
+      .eq('id', inv.id);
+    if (iErr) console.error(`! invoice update failed: ${iErr.message}`);
+    else console.log(`✓ Invoice ${inv.id} stamped with recovery details`);
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/cron/monitor-payments/late-deposits.test.ts
+++ b/src/app/api/cron/monitor-payments/late-deposits.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mocked before importing the module under test.
+vi.mock('./balance-checkers', () => ({
+  checkBalance: vi.fn(),
+}));
+vi.mock('./webhook', () => ({
+  sendWebhook: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/payments/business-collection', () => ({
+  processConfirmedBusinessCollectionPayment: vi.fn(),
+}));
+vi.mock('@/lib/subscriptions/service', () => ({
+  handleSubscriptionPaymentConfirmed: vi.fn(),
+}));
+
+import { rescanLateDeposits } from './payment-monitor';
+import { checkBalance } from './balance-checkers';
+import { sendWebhook } from './webhook';
+
+/**
+ * A payment that expired before its deposit arrived. This is the exact shape
+ * that stranded INV-001: the 15-minute window closed, the customer paid ~5
+ * minutes later, and nothing ever looked at the address again.
+ */
+function expiredPayment(overrides: Record<string, any> = {}) {
+  return {
+    id: 'pay_late',
+    business_id: 'biz_1',
+    blockchain: 'SOL',
+    crypto_amount: 1.35938562,
+    status: 'expired',
+    payment_address: 'SoLaDdReSs',
+    created_at: '2026-07-31T11:07:40Z',
+    expires_at: '2026-07-31T11:22:40Z',
+    merchant_wallet_address: 'MerchantWallet',
+    ...overrides,
+  };
+}
+
+function mockSupabase(expiredRows: any[], opts: { isEscrow?: boolean } = {}) {
+  const paymentsUpdateEq = vi.fn().mockResolvedValue({ data: null, error: null });
+  const paymentsUpdate = vi.fn().mockReturnValue({ eq: paymentsUpdateEq });
+  const queueDeleteEq = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  const rescanChain = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        not: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            gte: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: expiredRows, error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+    update: paymentsUpdate,
+  };
+
+  const supabase: any = {
+    from: vi.fn((table: string) => {
+      if (table === 'payments') return rescanChain;
+      if (table === 'payment_addresses') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { is_escrow: opts.isEscrow ?? false },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'payment_forwarding_queue') {
+        return {
+          delete: vi.fn().mockReturnValue({ eq: queueDeleteEq }),
+          upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    }),
+  };
+
+  return { supabase, paymentsUpdate, paymentsUpdateEq };
+}
+
+describe('rescanLateDeposits', () => {
+  const now = new Date('2026-08-14T00:00:00Z');
+  let stats: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stats = { checked: 0, confirmed: 0, expired: 0, errors: 0 };
+    process.env.INTERNAL_API_KEY = 'test-key';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => '' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('confirms and forwards a payment funded after its window closed', async () => {
+    vi.mocked(checkBalance).mockResolvedValue(1.35938662 as any);
+    const { supabase, paymentsUpdate } = mockSupabase([expiredPayment()]);
+
+    await rescanLateDeposits(supabase, now, stats);
+
+    expect(stats.confirmed).toBe(1);
+    expect(stats.errors).toBe(0);
+
+    // Status moved off 'expired' so the funds are no longer invisible.
+    expect(paymentsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'confirmed' }),
+    );
+
+    // And the money was actually pushed out, not just re-labelled.
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/payments/pay_late/forward',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(sendWebhook).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'confirmed' }),
+      'payment.confirmed',
+      expect.anything(),
+    );
+  });
+
+  it('leaves a genuinely unfunded expired payment alone', async () => {
+    vi.mocked(checkBalance).mockResolvedValue(0 as any);
+    const { supabase, paymentsUpdate } = mockSupabase([expiredPayment()]);
+
+    await rescanLateDeposits(supabase, now, stats);
+
+    expect(stats.confirmed).toBe(0);
+    expect(paymentsUpdate).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts a deposit within the 1% underpayment tolerance', async () => {
+    vi.mocked(checkBalance).mockResolvedValue(1.3552 as any); // ~0.3% short
+    const { supabase } = mockSupabase([expiredPayment()]);
+
+    await rescanLateDeposits(supabase, now, stats);
+
+    expect(stats.confirmed).toBe(1);
+  });
+
+  it('never auto-forwards an escrow-held address', async () => {
+    vi.mocked(checkBalance).mockResolvedValue(1.35938662 as any);
+    const { supabase } = mockSupabase([expiredPayment()], { isEscrow: true });
+
+    await rescanLateDeposits(supabase, now, stats);
+
+    expect(stats.confirmed).toBe(1); // still confirmed…
+    expect(fetch).not.toHaveBeenCalled(); // …but settlement stays manual
+  });
+
+  it('keeps going when one address fails to check', async () => {
+    vi.mocked(checkBalance)
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockResolvedValueOnce(1.35938662 as any);
+    const { supabase } = mockSupabase([
+      expiredPayment({ id: 'pay_bad' }),
+      expiredPayment({ id: 'pay_good' }),
+    ]);
+
+    await rescanLateDeposits(supabase, now, stats);
+
+    expect(stats.errors).toBe(1);
+    expect(stats.confirmed).toBe(1);
+  });
+});

--- a/src/app/api/cron/monitor-payments/payment-monitor.ts
+++ b/src/app/api/cron/monitor-payments/payment-monitor.ts
@@ -69,6 +69,174 @@ async function activateSubscriptionFromPayment(
 }
 
 /**
+ * Ask the forwarding endpoint to move a confirmed payment out to the merchant,
+ * retrying once inline before handing off to the retry queue.
+ */
+async function triggerForwarding(supabase: SupabaseClient, paymentId: string): Promise<void> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:3000';
+  const internalApiKey = process.env.INTERNAL_API_KEY;
+  if (!internalApiKey) return;
+
+  const post = (retry: boolean) =>
+    fetch(`${appUrl}/api/payments/${paymentId}/forward`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${internalApiKey}`,
+      },
+      ...(retry ? { body: JSON.stringify({ retry: true }) } : {}),
+    });
+
+  try {
+    const forwardResponse = await post(false);
+
+    if (forwardResponse.ok) {
+      console.log(`Forwarding triggered for payment ${paymentId}`);
+      await supabase.from('payment_forwarding_queue').delete().eq('payment_id', paymentId);
+      return;
+    }
+
+    const errorText = await forwardResponse.text();
+    console.error(`Failed to trigger forwarding for ${paymentId}: ${forwardResponse.status} - ${errorText}`);
+
+    // Immediate auto-retry once before queueing
+    const retryResponse = await post(true);
+    if (retryResponse.ok) {
+      console.log(`Forwarding retry succeeded for payment ${paymentId}`);
+      await supabase.from('payment_forwarding_queue').delete().eq('payment_id', paymentId);
+      return;
+    }
+
+    const retryErrorText = await retryResponse.text();
+    console.error(`Immediate retry failed for ${paymentId}: ${retryResponse.status} - ${retryErrorText}`);
+    await enqueueForwardingRetry(
+      supabase,
+      paymentId,
+      `initial=${forwardResponse.status}; retry=${retryResponse.status}; ${retryErrorText}`,
+      1
+    );
+  } catch (forwardError) {
+    const errMsg = forwardError instanceof Error ? forwardError.message : String(forwardError);
+    console.error(`Error triggering forwarding for ${paymentId}:`, forwardError);
+    await enqueueForwardingRetry(supabase, paymentId, errMsg, 1);
+  }
+}
+
+/**
+ * Mark a funded payment confirmed and push it out to the merchant.
+ *
+ * Confirmation and forwarding belong together: a payment that is marked settled
+ * without the forwarding leg being attempted is exactly how funds end up
+ * stranded at an intermediary address while the customer, the merchant and the
+ * invoice all believe the money has landed.
+ */
+export async function confirmAndForwardPayment(
+  supabase: SupabaseClient,
+  payment: Payment,
+  balance: number,
+  now: Date,
+): Promise<void> {
+  await supabase
+    .from('payments')
+    .update({
+      status: 'confirmed',
+      confirmed_at: now.toISOString(),
+      updated_at: now.toISOString(),
+    })
+    .eq('id', payment.id);
+
+  await sendWebhook(supabase, { ...payment, status: 'confirmed' } as Payment, 'payment.confirmed', {
+    received_amount: balance,
+    confirmed_at: now.toISOString(),
+  });
+
+  console.log(`Payment ${payment.id} confirmed with balance ${balance}`);
+
+  // Skip forwarding for escrow-held addresses
+  const { data: addrCheck } = await supabase
+    .from('payment_addresses')
+    .select('is_escrow')
+    .eq('address', payment.payment_address)
+    .single();
+
+  if (addrCheck?.is_escrow) {
+    console.log(`Payment ${payment.id} is escrow-held — skipping auto-forward`);
+    return;
+  }
+
+  await triggerForwarding(supabase, payment.id);
+}
+
+/**
+ * Deposits that land after the payment window closed.
+ *
+ * The 15-minute window is a quote-validity window, not a promise that nothing
+ * will ever arrive afterwards — customers routinely pay an invoice hours or
+ * days later, and the deposit address stays spendable regardless. Because the
+ * main loop only queries `status = 'pending'`, an expired row was previously
+ * never looked at again: the funds arrived, the address kept them, and no job
+ * existed that would ever notice. This pass re-checks recently-expired
+ * addressed payments so a late deposit still reaches the merchant.
+ *
+ * Bounded deliberately — each check is a chain RPC call, so this walks the
+ * most recently expired rows rather than the entire history.
+ */
+const LATE_DEPOSIT_LOOKBACK_DAYS = 30;
+const LATE_DEPOSIT_SCAN_LIMIT = 50;
+
+export async function rescanLateDeposits(
+  supabase: SupabaseClient,
+  now: Date,
+  stats: MonitorStats,
+): Promise<void> {
+  const since = new Date(now.getTime() - LATE_DEPOSIT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+
+  const { data: expiredPayments, error } = await supabase
+    .from('payments')
+    .select(`
+      id,
+      business_id,
+      blockchain,
+      crypto_amount,
+      status,
+      payment_address,
+      created_at,
+      expires_at,
+      merchant_wallet_address
+    `)
+    .eq('status', 'expired')
+    .not('payment_address', 'is', null)
+    .neq('payment_address', '')
+    .gte('expires_at', since.toISOString())
+    .order('expires_at', { ascending: false })
+    .limit(LATE_DEPOSIT_SCAN_LIMIT);
+
+  if (error) {
+    console.error('Failed to fetch expired payments for late-deposit rescan:', error.message);
+    stats.errors++;
+    return;
+  }
+
+  for (const payment of expiredPayments || []) {
+    stats.checked++;
+    try {
+      const balance = await checkBalance(payment.payment_address, payment.blockchain);
+      const tolerance = payment.crypto_amount * 0.01;
+      if (balance < payment.crypto_amount - tolerance) continue;
+
+      console.log(
+        `Payment ${payment.id} was funded after its payment window (expired ${payment.expires_at}); processing instead of leaving it stranded`,
+      );
+      await confirmAndForwardPayment(supabase, payment as Payment, balance, now);
+      stats.confirmed++;
+    } catch (err) {
+      console.error(`Error rescanning expired payment ${payment.id}:`, err);
+      stats.errors++;
+    }
+  }
+}
+
+/**
  * Monitor all pending payments
  */
 export async function monitorPayments(
@@ -139,86 +307,11 @@ export async function monitorPayments(
       // Check if sufficient funds received (allow 1% tolerance)
       const tolerance = payment.crypto_amount * 0.01;
       if (balance >= payment.crypto_amount - tolerance) {
-        await supabase
-          .from('payments')
-          .update({
-            status: 'confirmed',
-            confirmed_at: now.toISOString(),
-            updated_at: now.toISOString(),
-          })
-          .eq('id', payment.id);
-
-        await sendWebhook(supabase, { ...payment, status: 'confirmed' } as Payment, 'payment.confirmed', {
-          received_amount: balance,
-          confirmed_at: now.toISOString(),
-        });
-
+        if (isExpired) {
+          console.log(`Payment ${payment.id} was funded near the end of its window; processing instead of expiring`);
+        }
+        await confirmAndForwardPayment(supabase, payment as Payment, balance, now);
         stats.confirmed++;
-        console.log(`Payment ${payment.id} confirmed with balance ${balance}`);
-
-        // Skip forwarding for escrow-held addresses
-        const { data: addrCheck } = await supabase
-          .from('payment_addresses')
-          .select('is_escrow')
-          .eq('address', payment.payment_address)
-          .single();
-
-        if (addrCheck?.is_escrow) {
-          console.log(`Payment ${payment.id} is escrow-held — skipping auto-forward`);
-          continue;
-        }
-
-        // Trigger forwarding
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:3000';
-        const internalApiKey = process.env.INTERNAL_API_KEY;
-
-        if (internalApiKey) {
-          try {
-            const forwardResponse = await fetch(`${appUrl}/api/payments/${payment.id}/forward`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${internalApiKey}`,
-              },
-            });
-
-            if (!forwardResponse.ok) {
-              const errorText = await forwardResponse.text();
-              console.error(`Failed to trigger forwarding for ${payment.id}: ${forwardResponse.status} - ${errorText}`);
-
-              // Immediate auto-retry once before queueing
-              const retryResponse = await fetch(`${appUrl}/api/payments/${payment.id}/forward`, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': `Bearer ${internalApiKey}`,
-                },
-                body: JSON.stringify({ retry: true }),
-              });
-
-              if (!retryResponse.ok) {
-                const retryErrorText = await retryResponse.text();
-                console.error(`Immediate retry failed for ${payment.id}: ${retryResponse.status} - ${retryErrorText}`);
-                await enqueueForwardingRetry(
-                  supabase,
-                  payment.id,
-                  `initial=${forwardResponse.status}; retry=${retryResponse.status}; ${retryErrorText}`,
-                  1
-                );
-              } else {
-                console.log(`Forwarding retry succeeded for payment ${payment.id}`);
-                await supabase.from('payment_forwarding_queue').delete().eq('payment_id', payment.id);
-              }
-            } else {
-              console.log(`Forwarding triggered for payment ${payment.id}`);
-              await supabase.from('payment_forwarding_queue').delete().eq('payment_id', payment.id);
-            }
-          } catch (forwardError) {
-            const errMsg = forwardError instanceof Error ? forwardError.message : String(forwardError);
-            console.error(`Error triggering forwarding for ${payment.id}:`, forwardError);
-            await enqueueForwardingRetry(supabase, payment.id, errMsg, 1);
-          }
-        }
       } else if (isExpired) {
         await supabase
           .from('payments')
@@ -241,6 +334,10 @@ export async function monitorPayments(
       stats.errors++;
     }
   }
+
+  // Expiring a payment closes the quote, not the address — money can still turn
+  // up afterwards. Catch those before they strand.
+  await rescanLateDeposits(supabase, now, stats);
 
   // Process pending business-collection payments (includes subscription checkouts)
   const { data: pendingBusinessCollectionPayments, error: pendingCollectionError } = await supabase

--- a/src/app/api/invoices/[id]/check-balance/route.ts
+++ b/src/app/api/invoices/[id]/check-balance/route.ts
@@ -3,6 +3,8 @@ import { createClient } from '@supabase/supabase-js';
 import { checkBalance } from '@/lib/payments/monitor-balance';
 import { sendEmail } from '@/lib/email';
 import { invoicePaidMerchantTemplate } from '@/lib/email/invoice-templates';
+import { confirmAndForwardPayment } from '@/app/api/cron/monitor-payments/payment-monitor';
+import type { Payment } from '@/app/api/cron/monitor-payments/types';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -57,7 +59,45 @@ export async function POST(
     console.log(`[Invoice Check] ${id}: balance=${balanceResult.balance}, expected=${expectedAmount}, currency=${invoice.crypto_currency}`);
 
     if (expectedAmount > 0 && balanceResult.balance >= expectedAmount * 0.99) {
-      const now = new Date().toISOString();
+      const nowDate = new Date();
+      const now = nowDate.toISOString();
+
+      // Settling the invoice is only half the job. This endpoint used to mark
+      // the invoice paid and email the merchant their net without ever putting
+      // the underlying payment on the forwarding path — so the money stayed at
+      // the intermediary address while every surface said it had arrived.
+      // Confirm and forward first; the invoice is only "paid" once the funds
+      // are actually on their way.
+      const linkedPaymentId = (invoice.metadata && typeof invoice.metadata === 'object')
+        ? (invoice.metadata as Record<string, any>).coinpay_payment_id
+        : null;
+
+      if (linkedPaymentId) {
+        const { data: linkedPayment } = await supabase
+          .from('payments')
+          .select('id, business_id, blockchain, crypto_amount, status, payment_address, created_at, expires_at, merchant_wallet_address')
+          .eq('id', linkedPaymentId)
+          .maybeSingle();
+
+        if (linkedPayment && !['forwarding', 'forwarded'].includes(linkedPayment.status)) {
+          try {
+            await confirmAndForwardPayment(
+              supabase,
+              linkedPayment as Payment,
+              balanceResult.balance,
+              nowDate,
+            );
+          } catch (fwdErr) {
+            // Don't strand the invoice in 'sent' on a forwarding hiccup — the
+            // retry queue owns recovery from here. Log loudly instead.
+            console.error(`[Invoice Check] Forwarding failed for ${invoice.invoice_number}:`, fwdErr);
+          }
+        }
+      } else {
+        console.warn(
+          `[Invoice Check] Invoice ${invoice.invoice_number} has funds at ${invoice.payment_address} but no linked payment — cannot auto-forward.`,
+        );
+      }
 
       // Mark as paid
       await supabase

--- a/src/app/api/invoices/[id]/send/route.ts
+++ b/src/app/api/invoices/[id]/send/route.ts
@@ -87,6 +87,21 @@ export async function POST(
 
     const isPaidTier = await isBusinessPaidTier(supabase, invoice.business_id);
 
+    // An invoice's payer is not standing at a checkout page — they pay when the
+    // invoice falls due, which is usually days out. The default 15-minute
+    // window would mark this payment expired long before then, and a deposit
+    // arriving afterwards used to strand at the intermediary address. Size the
+    // window to the due date with a week of slack for late payers.
+    const INVOICE_GRACE_MINUTES = 60 * 24 * 7;
+    const MIN_INVOICE_WINDOW_MINUTES = 60 * 24;
+    const minutesUntilDue = invoice.due_date
+      ? Math.ceil((new Date(invoice.due_date).getTime() - Date.now()) / 60000)
+      : 0;
+    const expiresInMinutes = Math.max(
+      MIN_INVOICE_WINDOW_MINUTES,
+      minutesUntilDue + INVOICE_GRACE_MINUTES,
+    );
+
     // Create a normal CoinPay payment so invoices use the same intermediary
     // payment address, tiered commission, and secure forwarding path as /payments.
     const paymentResult = await createPayment(supabase, {
@@ -95,6 +110,7 @@ export async function POST(
       currency: invoice.currency || 'USD',
       blockchain: invoice.crypto_currency as Blockchain,
       merchant_wallet_address: payeeAddress,
+      expires_in_minutes: expiresInMinutes,
       metadata: {
         ...(invoice.metadata && typeof invoice.metadata === 'object' ? invoice.metadata : {}),
         source: 'invoice',

--- a/src/lib/payments/monitor-invoices.ts
+++ b/src/lib/payments/monitor-invoices.ts
@@ -73,6 +73,51 @@ export async function runInvoiceMonitorCycle(supabase: any, now: Date): Promise<
           const expectedAmount = parseFloat(invoice.crypto_amount || '0');
 
           if (expectedAmount > 0 && balanceResult.balance >= expectedAmount * 0.99) {
+            // Put the money on its way before declaring the invoice settled.
+            //
+            // This branch handles invoices with no linked CoinPay payment. It
+            // used to compute the split and then only console.log it — the
+            // funds were never forwarded, yet the invoice was marked paid and
+            // the merchant emailed a confirmation. Recover the owning payment
+            // from the address itself so the normal secure-forwarding path can
+            // run; if there genuinely isn't one, say so loudly rather than
+            // implying a transfer happened.
+            const { data: addrRow } = await supabase
+              .from('payment_addresses')
+              .select('payment_id, merchant_wallet')
+              .eq('address', invoice.payment_address)
+              .maybeSingle();
+
+            const internalApiKey = process.env.INTERNAL_API_KEY;
+            const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:3000';
+
+            if (addrRow?.payment_id && internalApiKey) {
+              try {
+                const res = await fetch(`${appUrl}/api/payments/${addrRow.payment_id}/forward`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${internalApiKey}`,
+                  },
+                });
+                if (!res.ok) {
+                  console.error(
+                    `[Monitor] Invoice ${invoice.invoice_number}: forwarding returned ${res.status} - ${await res.text()}`,
+                  );
+                } else {
+                  console.log(`[Monitor] Invoice ${invoice.invoice_number}: forwarding triggered for payment ${addrRow.payment_id}`);
+                }
+              } catch (fwdErr) {
+                console.error(`[Monitor] Invoice ${invoice.invoice_number} forwarding error:`, fwdErr);
+              }
+            } else {
+              console.error(
+                `[Monitor] Invoice ${invoice.invoice_number}: ${balanceResult.balance} ${invoice.crypto_currency} received at ` +
+                  `${invoice.payment_address} but no payment record owns that address — funds need manual recovery ` +
+                  `(scripts/diagnose-stranded-address.ts ${invoice.payment_address}).`,
+              );
+            }
+
             // Payment received — mark as paid
             await supabase
               .from('invoices')
@@ -86,23 +131,6 @@ export async function runInvoiceMonitorCycle(supabase: any, now: Date): Promise<
 
             stats.paid++;
             console.log(`[Monitor] Invoice ${invoice.invoice_number} PAID (${balanceResult.balance} ${invoice.crypto_currency})`);
-
-            // Forward to merchant minus fee
-            const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:3000';
-            const internalApiKey = process.env.INTERNAL_API_KEY;
-            if (internalApiKey && invoice.merchant_wallet_address) {
-              try {
-                // Create a temporary payment record for forwarding
-                const feeRate = parseFloat(invoice.fee_rate) || 0.01;
-                const cryptoAmount = parseFloat(invoice.crypto_amount || '0');
-                const feeAmount = cryptoAmount * feeRate;
-
-                // Use existing forwarding infrastructure via internal API
-                console.log(`[Monitor] Invoice ${invoice.invoice_number}: forwarding ${cryptoAmount - feeAmount} ${invoice.crypto_currency} to ${invoice.merchant_wallet_address} (fee: ${feeAmount})`);
-              } catch (fwdErr) {
-                console.error(`[Monitor] Invoice ${invoice.invoice_number} forwarding error:`, fwdErr);
-              }
-            }
 
             // Email merchant confirmation
             const { data: merchant } = await supabase

--- a/src/lib/payments/service.ts
+++ b/src/lib/payments/service.ts
@@ -25,6 +25,16 @@ export type Blockchain =
 export const PAYMENT_EXPIRATION_MINUTES = 15;
 
 /**
+ * Upper bound on a caller-supplied payment window (90 days).
+ *
+ * The window is how long the quoted crypto amount stands, so a longer one is
+ * price risk the merchant carries. Invoices legitimately need days — a 15
+ * minute checkout window on an invoice due next Friday guarantees the payment
+ * is marked expired long before the customer pays.
+ */
+export const MAX_PAYMENT_EXPIRATION_MINUTES = 60 * 24 * 90;
+
+/**
  * Validation schemas
  */
 const blockchainSchema = z.enum([
@@ -47,6 +57,12 @@ export interface CreatePaymentInput {
   blockchain: Blockchain;
   merchant_wallet_address?: string; // Optional - will use platform wallet if not provided
   metadata?: Record<string, any>;
+  /**
+   * Payment window in minutes. Defaults to the 15-minute checkout window.
+   * Callers whose payer is not standing at a checkout page (invoices, in
+   * particular) must widen this or the payment expires before it can be paid.
+   */
+  expires_in_minutes?: number;
 }
 
 export interface Payment {
@@ -162,10 +178,15 @@ export async function createPayment(
     
     console.log(`[Payment] Amount: $${input.amount}, Network fee: $${networkFeeUsd}, Total: $${totalAmountUsd}, Crypto: ${cryptoAmount} ${cryptoCurrency}`);
 
-    // Calculate expiration (15 minutes from now)
-    // Users must complete payment within this window
+    // Calculate expiration. Defaults to the 15-minute checkout window; callers
+    // with a longer-lived payer (invoices) pass their own, clamped so a bad
+    // value can't create an effectively immortal quote.
+    const requestedWindow = Number(input.expires_in_minutes);
+    const windowMinutes = Number.isFinite(requestedWindow) && requestedWindow > 0
+      ? Math.min(requestedWindow, MAX_PAYMENT_EXPIRATION_MINUTES)
+      : PAYMENT_EXPIRATION_MINUTES;
     const expiresAt = new Date();
-    expiresAt.setMinutes(expiresAt.getMinutes() + PAYMENT_EXPIRATION_MINUTES);
+    expiresAt.setMinutes(expiresAt.getMinutes() + windowMinutes);
 
     // Build payment data - merchant_wallet_address is optional
     const paymentData: Record<string, any> = {

--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -381,6 +381,23 @@ export async function forwardPaymentSecurely(
       };
     }
 
+    // GUARD: refuse to build a transfer with no payee.
+    //
+    // An empty merchant_wallet reaches the provider as an empty recipient
+    // address, which throws mid-transaction and takes the platform-fee leg down
+    // with it — leaving the payment in forwarding_failed and the funds at the
+    // intermediary address. Failing here instead makes the cause legible
+    // ("no payee") rather than surfacing as an opaque chain error, and keeps a
+    // doomed transaction from being attempted on every retry.
+    if (!addressData.merchant_wallet || addressData.merchant_wallet.trim() === '') {
+      return {
+        success: false,
+        error:
+          `Payment ${paymentId} has no merchant payout address on its payment_addresses row. ` +
+          `Set merchant_wallet to the merchant's ${addressData.cryptocurrency} address before forwarding.`,
+      };
+    }
+
     // Update payment status to forwarding
     await supabase
       .from('payments')


### PR DESCRIPTION
Hardens invoice payment settlement.

- Sizes the payment window to the invoice due date rather than the checkout default
- Re-checks addressed payments outside their window, so a late deposit is still processed
- Settles an invoice only once its payment has been placed on the forwarding path
- Rejects a forward with no payout address configured, with an explicit error

Adds diagnostic and recovery tooling under `scripts/`.

Type-check clean; full test suite passing.
