### PR TITLE
feat(admin): see every escrow and what is actually in custody

### DIFF
--- a/src/app/admin/AdminContent.tsx
+++ b/src/app/admin/AdminContent.tsx
@@ -177,6 +177,12 @@ export default function AdminContent() {
             Businesses →
           </Link>
           <Link
+            href="/admin/escrows"
+            className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
+          >
+            Escrows →
+          </Link>
+          <Link
             href="/admin/email-broadcast"
             className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20"
           >

--- a/src/app/admin/escrows/EscrowsContent.test.tsx
+++ b/src/app/admin/escrows/EscrowsContent.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCsv } from './EscrowsContent';
+
+function escrow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'escrow-1',
+    chain: 'SOL',
+    status: 'settled',
+    escrowModel: 'custodial',
+    amount: '1.500000000000000000',
+    amountUsd: 42.5,
+    depositedAmount: null,
+    feeAmount: null,
+    escrowAddress: 'Esc111',
+    depositorAddress: 'Dep111',
+    beneficiaryAddress: 'Ben111',
+    arbiterAddress: null,
+    depositorEmail: null,
+    beneficiaryEmail: null,
+    depositTxHash: null,
+    settlementTxHash: null,
+    disputeStatus: null,
+    disputeReason: null,
+    inSeries: false,
+    allowAutoRelease: false,
+    settleAttempts: 0,
+    businessId: null,
+    businessName: null,
+    merchantEmail: null,
+    createdAt: '2026-08-12T00:00:00Z',
+    fundedAt: null,
+    releasedAt: null,
+    settledAt: null,
+    disputedAt: null,
+    refundedAt: null,
+    expiresAt: null,
+    hoursToFund: null,
+    hoursToSettle: null,
+    isHeld: false,
+    isStranded: false,
+    ...overrides,
+  };
+}
+
+describe('toCsv', () => {
+  it('neutralizes formula prefixes in counterparty-controlled cells', () => {
+    // Addresses, emails and dispute text all come from whoever created the
+    // escrow, so any of them can carry a spreadsheet formula.
+    const csv = toCsv([
+      escrow({ depositorAddress: '=cmd|/c calc', beneficiaryEmail: '+SUM(1)@example.com' }),
+      escrow({ depositorAddress: '\t@SUM(1)' }),
+    ] as never);
+
+    expect(csv).toContain("'=cmd|/c calc");
+    expect(csv).toContain("'+SUM(1)@example.com");
+    expect(csv).toContain("'\t@SUM(1)");
+    expect(csv).not.toContain(',=cmd|/c calc');
+  });
+
+  it('still quotes commas and doubles embedded quotes', () => {
+    const csv = toCsv([escrow({ businessName: 'Acme, "Inc"' })] as never);
+
+    expect(csv).toContain('"Acme, ""Inc"""');
+  });
+
+  it('keeps the full precision of a chain amount rather than a rounded number', () => {
+    // numeric(30,18) does not survive a round trip through a JS double, so the
+    // export has to carry the string it was given.
+    const csv = toCsv([escrow({ amount: '9859113112.123456789012345678' })] as never);
+
+    expect(csv).toContain('9859113112.123456789012345678');
+  });
+
+  it('emits a header row followed by one line per escrow', () => {
+    const csv = toCsv([escrow(), escrow({ id: 'escrow-2' })] as never);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toContain('id,chain,status');
+    expect(lines).toHaveLength(3);
+  });
+});

--- a/src/app/admin/escrows/EscrowsContent.tsx
+++ b/src/app/admin/escrows/EscrowsContent.tsx
@@ -1,0 +1,789 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+
+type SortKey =
+  | 'created_at'
+  | 'funded_at'
+  | 'settled_at'
+  | 'expires_at'
+  | 'amount_usd'
+  | 'chain'
+  | 'status'
+  | 'escrow_model'
+  | 'business_name'
+  | 'settle_attempts'
+  | 'hours_to_fund'
+  | 'hours_to_settle';
+
+type EscrowRow = {
+  id: string;
+  chain: string;
+  status: string;
+  escrowModel: string;
+  amount: string;
+  amountUsd: number;
+  depositedAmount: string | null;
+  feeAmount: string | null;
+  escrowAddress: string;
+  depositorAddress: string;
+  beneficiaryAddress: string;
+  arbiterAddress: string | null;
+  depositorEmail: string | null;
+  beneficiaryEmail: string | null;
+  depositTxHash: string | null;
+  settlementTxHash: string | null;
+  disputeStatus: string | null;
+  disputeReason: string | null;
+  inSeries: boolean;
+  allowAutoRelease: boolean;
+  settleAttempts: number;
+  businessId: string | null;
+  businessName: string | null;
+  merchantEmail: string | null;
+  createdAt: string;
+  fundedAt: string | null;
+  releasedAt: string | null;
+  settledAt: string | null;
+  disputedAt: string | null;
+  refundedAt: string | null;
+  expiresAt: string | null;
+  hoursToFund: number | null;
+  hoursToSettle: number | null;
+  isHeld: boolean;
+  isStranded: boolean;
+};
+
+type StatusBucket = { status: string; total: number; valueUsd: number };
+type ChainBucket = { chain: string; total: number; settled: number; settledUsd: number; heldUsd: number };
+type ModelBucket = { escrowModel: string; total: number; settled: number };
+type MonthBucket = { month: string; created: number; funded: number; settled: number; settledUsd: number };
+
+type Summary = {
+  escrowsTotal: number;
+  firstCreatedAt: string | null;
+  lastCreatedAt: string | null;
+  everFunded: number;
+  everDisbursed: number;
+  everReleased: number;
+  everDisputed: number;
+  statusSettled: number;
+  statusRefunded: number;
+  expired: number;
+  heldCount: number;
+  strandedCount: number;
+  disputesOpen: number;
+  inSeries: number;
+  autoRelease: number;
+  withBusiness: number;
+  businesses: number;
+  created30d: number;
+  settled30d: number;
+  createdValueUsd: number;
+  fundedValueUsd: number;
+  disbursedValueUsd: number;
+  releasedValueUsd: number;
+  refundedValueUsd: number;
+  heldValueUsd: number;
+  largestUsd: number;
+  medianUsd: number;
+  medianHoursToFund: number | null;
+  medianHoursToSettle: number | null;
+  byStatus: StatusBucket[];
+  byChain: ChainBucket[];
+  byModel: ModelBucket[];
+  months: MonthBucket[];
+};
+
+const PAGE_SIZE = 50;
+
+function authHeaders(extra?: HeadersInit): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+  const headers: Record<string, string> = { ...(extra as Record<string, string>) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+function usd(value: number): string {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/** Compact form for the tiles, where a 12-digit figure would break the layout. */
+function usdCompact(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return `$${value.toLocaleString('en-US', { notation: 'compact', maximumFractionDigits: 2 })}`;
+  }
+  return usd(value);
+}
+
+function count(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function pct(part: number, whole: number): string {
+  if (!whole) return '—';
+  return `${Math.round((part / whole) * 100)}%`;
+}
+
+/** Chain amounts are numeric(30,18); drop the trailing zeros but keep precision. */
+function chainAmount(value: string | null): string {
+  if (!value) return '—';
+  return value.includes('.') ? value.replace(/0+$/, '').replace(/\.$/, '') : value;
+}
+
+function shortDate(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** Escrows settle in minutes or sit for months, so the unit has to adapt. */
+function duration(hours: number | null): string {
+  if (hours === null || !Number.isFinite(hours)) return '—';
+  if (hours < 1 / 60) return '<1m';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours < 48) return `${hours.toFixed(1)}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  settled: 'bg-green-500/10 text-green-300',
+  released: 'bg-green-500/10 text-green-300',
+  refunded: 'bg-amber-500/10 text-amber-300',
+  disputed: 'bg-red-500/10 text-red-300',
+  settle_failed: 'bg-red-500/10 text-red-300',
+  expired: 'bg-slate-600/20 text-gray-400',
+  funded: 'bg-blue-500/10 text-blue-300',
+  pending: 'bg-blue-500/10 text-blue-300',
+  created: 'bg-blue-500/10 text-blue-300',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const style = STATUS_STYLES[status] ?? 'bg-slate-600/20 text-gray-300';
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${style}`}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  );
+}
+
+const COLUMNS: { key: SortKey; label: string; numeric: boolean; title?: string }[] = [
+  { key: 'created_at', label: 'Escrow', numeric: false, title: 'Escrow id and chain, newest first' },
+  { key: 'status', label: 'Status', numeric: false },
+  { key: 'amount_usd', label: 'Amount', numeric: true, title: 'USD at creation, with the chain amount beneath' },
+  { key: 'business_name', label: 'Business', numeric: false, title: 'Merchant the escrow belongs to, if any' },
+  { key: 'funded_at', label: 'Funded', numeric: false },
+  { key: 'hours_to_settle', label: 'To settle', numeric: true, title: 'Time from funding to the settlement transaction' },
+  { key: 'expires_at', label: 'Expires', numeric: false },
+];
+
+const CSV_COLUMNS: { header: string; value: (e: EscrowRow) => string | number }[] = [
+  { header: 'id', value: (e) => e.id },
+  { header: 'chain', value: (e) => e.chain },
+  { header: 'status', value: (e) => e.status },
+  { header: 'escrow_model', value: (e) => e.escrowModel },
+  { header: 'amount', value: (e) => e.amount },
+  { header: 'amount_usd', value: (e) => e.amountUsd },
+  { header: 'deposited_amount', value: (e) => e.depositedAmount ?? '' },
+  { header: 'fee_amount', value: (e) => e.feeAmount ?? '' },
+  { header: 'escrow_address', value: (e) => e.escrowAddress },
+  { header: 'depositor_address', value: (e) => e.depositorAddress },
+  { header: 'beneficiary_address', value: (e) => e.beneficiaryAddress },
+  { header: 'arbiter_address', value: (e) => e.arbiterAddress ?? '' },
+  { header: 'depositor_email', value: (e) => e.depositorEmail ?? '' },
+  { header: 'beneficiary_email', value: (e) => e.beneficiaryEmail ?? '' },
+  { header: 'deposit_tx_hash', value: (e) => e.depositTxHash ?? '' },
+  { header: 'settlement_tx_hash', value: (e) => e.settlementTxHash ?? '' },
+  { header: 'dispute_status', value: (e) => e.disputeStatus ?? '' },
+  { header: 'in_series', value: (e) => String(e.inSeries) },
+  { header: 'allow_auto_release', value: (e) => String(e.allowAutoRelease) },
+  { header: 'settle_attempts', value: (e) => e.settleAttempts },
+  { header: 'business_name', value: (e) => e.businessName ?? '' },
+  { header: 'merchant_email', value: (e) => e.merchantEmail ?? '' },
+  { header: 'created_at', value: (e) => e.createdAt },
+  { header: 'funded_at', value: (e) => e.fundedAt ?? '' },
+  { header: 'released_at', value: (e) => e.releasedAt ?? '' },
+  { header: 'settled_at', value: (e) => e.settledAt ?? '' },
+  { header: 'disputed_at', value: (e) => e.disputedAt ?? '' },
+  { header: 'refunded_at', value: (e) => e.refundedAt ?? '' },
+  { header: 'expires_at', value: (e) => e.expiresAt ?? '' },
+  { header: 'held', value: (e) => String(e.isHeld) },
+  { header: 'stranded', value: (e) => String(e.isStranded) },
+];
+
+export function toCsv(rows: EscrowRow[]): string {
+  const escape = (v: string | number): string => {
+    const raw = String(v);
+    // Neutralise spreadsheet formulas — addresses and dispute text are attacker-supplied.
+    const safe = typeof v === 'string' && /^[\u0000-\u0020]*[=+\-@]/.test(raw) ? `'${raw}` : raw;
+    return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+  };
+  const lines = [CSV_COLUMNS.map((c) => c.header).join(',')];
+  for (const row of rows) {
+    lines.push(CSV_COLUMNS.map((c) => escape(c.value(row))).join(','));
+  }
+  return lines.join('\n');
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+  tone,
+  title,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: 'default' | 'warn';
+  title?: string;
+}) {
+  const border = tone === 'warn' ? 'border-amber-500/40' : 'border-slate-700';
+  return (
+    <div className={`rounded-lg border ${border} bg-slate-900/50 p-4`} title={title}>
+      <div className="text-xs uppercase tracking-wide text-gray-400">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-white">{value}</div>
+      {sub && <div className="mt-1 text-xs text-gray-500">{sub}</div>}
+    </div>
+  );
+}
+
+export default function EscrowsContent() {
+  const [escrows, setEscrows] = useState<EscrowRow[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [sort, setSort] = useState<SortKey>('created_at');
+  const [dir, setDir] = useState<'asc' | 'desc'>('desc');
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+  const [chain, setChain] = useState('');
+  const [model, setModel] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [authState, setAuthState] = useState<'unknown' | 'unauthenticated' | 'forbidden' | 'ok'>('unknown');
+  const [error, setError] = useState<string | null>(null);
+
+  // Debounce the search box so typing an address is one request, not thirty.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearch(searchInput);
+      setOffset(0);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  const queryString = useCallback(
+    (over: Partial<{ limit: number; offset: number; summary: string }> = {}) => {
+      const params = new URLSearchParams({
+        sort,
+        dir,
+        limit: String(over.limit ?? PAGE_SIZE),
+        offset: String(over.offset ?? offset),
+      });
+      if (search.trim()) params.set('search', search.trim());
+      if (status) params.set('status', status);
+      if (chain) params.set('chain', chain);
+      if (model) params.set('model', model);
+      if (over.summary) params.set('summary', over.summary);
+      return params.toString();
+    },
+    [sort, dir, offset, search, status, chain, model],
+  );
+
+  // A slow request for an earlier filter must not overwrite a newer one.
+  const requestId = useRef(0);
+
+  const fetchEscrows = useCallback(async () => {
+    const id = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/escrows?${queryString()}`, { headers: authHeaders() });
+      if (id !== requestId.current) return;
+      if (res.status === 401) {
+        setAuthState('unauthenticated');
+        return;
+      }
+      if (res.status === 403) {
+        setAuthState('forbidden');
+        return;
+      }
+      if (!res.ok) {
+        setError('Failed to load escrows');
+        return;
+      }
+      const data = await res.json();
+      if (id !== requestId.current) return;
+      setEscrows(data.escrows ?? []);
+      setTotal(data.total ?? 0);
+      if (data.summary) setSummary(data.summary);
+      setAuthState('ok');
+    } catch {
+      if (id === requestId.current) setError('Network error');
+    } finally {
+      if (id === requestId.current) setLoading(false);
+    }
+  }, [queryString]);
+
+  useEffect(() => {
+    void fetchEscrows();
+  }, [fetchEscrows]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sort) {
+      setDir((d) => (d === 'desc' ? 'asc' : 'desc'));
+    } else {
+      setSort(key);
+      // Names and statuses read best A-Z; dates and amounts read best newest/biggest first.
+      setDir(key === 'business_name' || key === 'status' || key === 'chain' ? 'asc' : 'desc');
+    }
+    setOffset(0);
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    setError(null);
+    try {
+      // Exports everything matching the current filters, not just this page —
+      // 500 is the server's ceiling.
+      const res = await fetch(`/api/admin/escrows?${queryString({ limit: 500, offset: 0, summary: '0' })}`, {
+        headers: authHeaders(),
+      });
+      if (!res.ok) {
+        setError('Export failed');
+        return;
+      }
+      const data = await res.json();
+      const rows: EscrowRow[] = data.escrows ?? [];
+      const blob = new Blob([toCsv(rows)], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `coinpay-escrows-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      if (data.total > rows.length) {
+        setError(`Exported the first ${rows.length} of ${data.total} escrows — narrow the filters for the rest.`);
+      }
+    } catch {
+      setError('Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const resetFilters = () => {
+    setStatus('');
+    setChain('');
+    setModel('');
+    setSearchInput('');
+    setOffset(0);
+  };
+
+  const filtered = Boolean(search.trim() || status || chain || model);
+  const pageEnd = useMemo(() => Math.min(offset + escrows.length, total), [offset, escrows.length, total]);
+
+  if (authState === 'unauthenticated') {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-gray-300 mb-4">You need to log in.</p>
+        <Link href="/login" className="text-purple-400 hover:underline">Log in →</Link>
+      </div>
+    );
+  }
+
+  if (authState === 'forbidden') {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-red-400 mb-2">403 — Forbidden</p>
+        <p className="text-gray-400 mb-4">This area is restricted to administrators.</p>
+        <Link href="/dashboard" className="text-purple-400 hover:underline">Back to dashboard →</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="mb-2 flex items-baseline gap-3">
+        <Link href="/admin" className="text-sm text-gray-400 hover:text-purple-300">← Admin</Link>
+      </div>
+      <h1 className="text-3xl font-bold text-white mb-2">Escrows</h1>
+      <p className="text-gray-400 mb-8">
+        Every escrow ever created, where each one stopped in the lifecycle, and how much is in platform custody right
+        now.
+        {summary?.firstCreatedAt && (
+          <> All time, from {shortDate(summary.firstCreatedAt)} to {shortDate(summary.lastCreatedAt)}.</>
+        )}
+      </p>
+
+      {summary && (
+        <>
+          <section className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
+            <StatTile
+              label="Held now"
+              value={usdCompact(summary.heldValueUsd)}
+              sub={
+                summary.strandedCount > 0
+                  ? `${count(summary.heldCount)} escrows · ${count(summary.strandedCount)} past expiry`
+                  : `${count(summary.heldCount)} escrows in custody`
+              }
+              tone={summary.strandedCount > 0 ? 'warn' : 'default'}
+              title="Funded, and neither settled nor refunded — the money the platform is still holding"
+            />
+            <StatTile
+              label="Released"
+              value={usdCompact(summary.releasedValueUsd)}
+              sub={`${count(summary.statusSettled)} to beneficiaries`}
+              title="Escrows with status 'settled' — funds reached the beneficiary"
+            />
+            <StatTile
+              label="Refunded"
+              value={usdCompact(summary.refundedValueUsd)}
+              sub={`${count(summary.statusRefunded)} back to depositors`}
+            />
+            <StatTile
+              label="Disbursed"
+              value={usdCompact(summary.disbursedValueUsd)}
+              sub="released + refunded"
+              title="Every escrow that sent a settlement transaction, in either direction"
+            />
+            <StatTile
+              label="Escrows"
+              value={count(summary.escrowsTotal)}
+              sub={`${count(summary.created30d)} in the last 30d`}
+            />
+            <StatTile
+              label="Funded"
+              value={`${count(summary.everFunded)} / ${count(summary.escrowsTotal)}`}
+              sub={`${pct(summary.everFunded, summary.escrowsTotal)} of escrows ever funded`}
+            />
+          </section>
+
+          <section className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
+            <StatTile
+              label="Quoted"
+              value={usdCompact(summary.createdValueUsd)}
+              sub="incl. never funded"
+              title="Total value quoted at creation. Most escrows expire unfunded, so this is demand, not money moved — never add it to the disbursed figure."
+            />
+            <StatTile label="Median escrow" value={usdCompact(summary.medianUsd)} sub={`largest ${usdCompact(summary.largestUsd)}`} />
+            <StatTile label="Time to fund" value={duration(summary.medianHoursToFund)} sub="median, create → fund" />
+            <StatTile label="Time to settle" value={duration(summary.medianHoursToSettle)} sub="median, fund → settle" />
+            <StatTile
+              label="Disputes"
+              value={count(summary.everDisputed)}
+              sub={summary.disputesOpen > 0 ? `${count(summary.disputesOpen)} open` : 'none open'}
+              tone={summary.disputesOpen > 0 ? 'warn' : 'default'}
+            />
+            <StatTile
+              label="Merchant-linked"
+              value={`${count(summary.withBusiness)} / ${count(summary.escrowsTotal)}`}
+              sub={`${count(summary.businesses)} businesses · ${count(summary.inSeries)} in a series`}
+            />
+          </section>
+
+          <div className="mb-8 grid gap-4 lg:grid-cols-3">
+            <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+              <h2 className="mb-3 text-xs uppercase tracking-wide text-gray-400">By status</h2>
+              <table className="w-full text-sm">
+                <tbody>
+                  {summary.byStatus.map((s) => (
+                    <tr key={s.status} className="border-b border-slate-800 last:border-0">
+                      <td className="py-1.5">
+                        <button onClick={() => { setStatus(s.status); setOffset(0); }} className="hover:opacity-80">
+                          <StatusBadge status={s.status} />
+                        </button>
+                      </td>
+                      <td className="py-1.5 text-right text-gray-300">{count(s.total)}</td>
+                      <td className="py-1.5 text-right text-gray-500">{usdCompact(s.valueUsd)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+              <h2 className="mb-3 text-xs uppercase tracking-wide text-gray-400">By chain</h2>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-[10px] uppercase tracking-wide text-gray-500">
+                    <th className="pb-1 text-left font-medium">Chain</th>
+                    <th className="pb-1 text-right font-medium">All</th>
+                    <th className="pb-1 text-right font-medium">Settled</th>
+                    <th className="pb-1 text-right font-medium">Held</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.byChain.map((c) => (
+                    <tr key={c.chain} className="border-b border-slate-800 last:border-0">
+                      <td className="py-1.5">
+                        <button
+                          onClick={() => { setChain(c.chain); setOffset(0); }}
+                          className="text-gray-300 hover:text-purple-300"
+                        >
+                          {c.chain}
+                        </button>
+                      </td>
+                      <td className="py-1.5 text-right text-gray-300">{count(c.total)}</td>
+                      <td className="py-1.5 text-right text-gray-500">{usdCompact(c.settledUsd)}</td>
+                      <td className="py-1.5 text-right text-gray-500">{c.heldUsd ? usdCompact(c.heldUsd) : '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+              <h2 className="mb-3 text-xs uppercase tracking-wide text-gray-400">Monthly history</h2>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-[10px] uppercase tracking-wide text-gray-500">
+                    <th className="pb-1 text-left font-medium">Month</th>
+                    <th className="pb-1 text-right font-medium">Created</th>
+                    <th className="pb-1 text-right font-medium">Funded</th>
+                    <th className="pb-1 text-right font-medium">Settled</th>
+                    <th className="pb-1 text-right font-medium">USD</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.months.map((m) => (
+                    <tr key={m.month} className="border-b border-slate-800 last:border-0">
+                      <td className="py-1.5 text-gray-300">{m.month}</td>
+                      <td className="py-1.5 text-right text-gray-300">{m.created || '—'}</td>
+                      <td className="py-1.5 text-right text-gray-500">{m.funded || '—'}</td>
+                      <td className="py-1.5 text-right text-gray-500">{m.settled || '—'}</td>
+                      <td className="py-1.5 text-right text-gray-500">
+                        {m.settledUsd ? usdCompact(m.settledUsd) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          </div>
+        </>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded border border-red-500/50 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <input
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search id, address, email, tx hash or business…"
+          className="min-w-[18rem] flex-1 rounded bg-slate-950 px-3 py-2 text-sm text-white border border-slate-700 focus:border-purple-500 focus:outline-none"
+        />
+        <select
+          value={status}
+          onChange={(e) => { setStatus(e.target.value); setOffset(0); }}
+          className="rounded bg-slate-950 px-3 py-2 text-sm text-white border border-slate-700 focus:border-purple-500 focus:outline-none"
+        >
+          <option value="">All statuses</option>
+          {summary?.byStatus.map((s) => (
+            <option key={s.status} value={s.status}>{s.status} ({s.total})</option>
+          ))}
+        </select>
+        <select
+          value={chain}
+          onChange={(e) => { setChain(e.target.value); setOffset(0); }}
+          className="rounded bg-slate-950 px-3 py-2 text-sm text-white border border-slate-700 focus:border-purple-500 focus:outline-none"
+        >
+          <option value="">All chains</option>
+          {summary?.byChain.map((c) => (
+            <option key={c.chain} value={c.chain}>{c.chain} ({c.total})</option>
+          ))}
+        </select>
+        {summary && summary.byModel.length > 1 && (
+          <select
+            value={model}
+            onChange={(e) => { setModel(e.target.value); setOffset(0); }}
+            className="rounded bg-slate-950 px-3 py-2 text-sm text-white border border-slate-700 focus:border-purple-500 focus:outline-none"
+          >
+            <option value="">All models</option>
+            {summary.byModel.map((m) => (
+              <option key={m.escrowModel} value={m.escrowModel}>{m.escrowModel} ({m.total})</option>
+            ))}
+          </select>
+        )}
+        {filtered && (
+          <button onClick={resetFilters} className="text-sm text-gray-400 hover:text-purple-300">
+            Clear
+          </button>
+        )}
+        <button
+          onClick={handleExport}
+          disabled={exporting}
+          className="rounded bg-purple-600/20 px-4 py-2 text-sm text-purple-300 hover:bg-purple-600/30 border border-purple-500/20 disabled:opacity-50"
+        >
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
+        <button
+          onClick={() => void fetchEscrows()}
+          disabled={loading}
+          className="text-sm text-gray-400 hover:text-purple-300 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-slate-900/50">
+        <table className="w-full min-w-[60rem] text-sm">
+          <thead>
+            <tr className="border-b border-slate-700 text-xs uppercase tracking-wide text-gray-400">
+              {COLUMNS.map((col) => (
+                <th
+                  key={col.key}
+                  title={col.title}
+                  className={`px-3 py-3 font-medium ${col.numeric ? 'text-right' : 'text-left'}`}
+                >
+                  <button
+                    onClick={() => toggleSort(col.key)}
+                    className={`hover:text-purple-300 ${sort === col.key ? 'text-purple-300' : ''}`}
+                  >
+                    {col.label}
+                    {sort === col.key && <span className="ml-1">{dir === 'desc' ? '↓' : '↑'}</span>}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {escrows.length === 0 && !loading && (
+              <tr>
+                <td colSpan={COLUMNS.length} className="px-3 py-8 text-center text-gray-400">
+                  {filtered ? 'No escrows match these filters.' : 'No escrows yet.'}
+                </td>
+              </tr>
+            )}
+            {escrows.map((e) => {
+              const isOpen = expanded === e.id;
+              return (
+                <tr
+                  key={e.id}
+                  onClick={() => setExpanded(isOpen ? null : e.id)}
+                  className="cursor-pointer border-b border-slate-800 last:border-0 hover:bg-slate-800/40"
+                >
+                  <td className="px-3 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-white">{e.id.slice(0, 8)}</span>
+                      <span className="rounded bg-slate-700/40 px-1.5 py-0.5 text-[10px] text-gray-300">{e.chain}</span>
+                      {e.escrowModel !== 'custodial' && (
+                        <span className="rounded bg-purple-500/10 px-1.5 py-0.5 text-[10px] uppercase text-purple-300">
+                          {e.escrowModel}
+                        </span>
+                      )}
+                      {e.isStranded && (
+                        <span
+                          className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] uppercase text-amber-300"
+                          title="Funded, unsettled and past its expiry"
+                        >
+                          stranded
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-400">{shortDate(e.createdAt)}</div>
+                    {isOpen && (
+                      <div className="mt-2 space-y-0.5 text-xs text-gray-400">
+                        <div className="font-mono text-[10px] text-gray-600">{e.id}</div>
+                        <div>Escrow address: <span className="font-mono">{e.escrowAddress}</span></div>
+                        <div>Depositor: <span className="font-mono">{e.depositorAddress}</span>{e.depositorEmail && ` · ${e.depositorEmail}`}</div>
+                        <div>Beneficiary: <span className="font-mono">{e.beneficiaryAddress}</span>{e.beneficiaryEmail && ` · ${e.beneficiaryEmail}`}</div>
+                        {e.arbiterAddress && <div>Arbiter: <span className="font-mono">{e.arbiterAddress}</span></div>}
+                        <div>
+                          Amount: {chainAmount(e.amount)} {e.chain}
+                          {e.depositedAmount && ` · deposited ${chainAmount(e.depositedAmount)}`}
+                          {e.feeAmount && ` · fee ${chainAmount(e.feeAmount)}`}
+                        </div>
+                        {e.depositTxHash && <div>Deposit tx: <span className="font-mono">{e.depositTxHash}</span></div>}
+                        {e.settlementTxHash && <div>Settlement tx: <span className="font-mono">{e.settlementTxHash}</span></div>}
+                        <div>
+                          Funded {e.fundedAt ? new Date(e.fundedAt).toLocaleString() : '—'} · released{' '}
+                          {e.releasedAt ? new Date(e.releasedAt).toLocaleString() : '—'} · settled{' '}
+                          {e.settledAt ? new Date(e.settledAt).toLocaleString() : '—'}
+                        </div>
+                        {(e.disputedAt || e.disputeReason) && (
+                          <div className="text-amber-300/80">
+                            Disputed {e.disputedAt ? new Date(e.disputedAt).toLocaleString() : ''}
+                            {e.disputeStatus && ` (${e.disputeStatus})`}
+                            {e.disputeReason && `: ${e.disputeReason}`}
+                          </div>
+                        )}
+                        <div>
+                          {e.inSeries ? 'Part of a recurring series · ' : ''}
+                          {e.allowAutoRelease ? 'auto-release on · ' : ''}
+                          {e.settleAttempts > 0 ? `${count(e.settleAttempts)} settle attempts` : ''}
+                        </div>
+                        {e.merchantEmail && <div>Merchant: {e.merchantEmail}</div>}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-3">
+                    <StatusBadge status={e.status} />
+                    {e.isHeld && !e.isStranded && (
+                      <div className="mt-1 text-[10px] uppercase tracking-wide text-blue-300">held</div>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    <div className="text-gray-200">{usd(e.amountUsd)}</div>
+                    <div className="text-xs text-gray-500">{chainAmount(e.amount)} {e.chain}</div>
+                  </td>
+                  <td className="px-3 py-3 text-gray-300">
+                    {e.businessName ?? <span className="text-gray-600">—</span>}
+                    {e.merchantEmail && <div className="text-xs text-gray-500">{e.merchantEmail}</div>}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-gray-300" title={e.fundedAt ?? ''}>
+                    {e.fundedAt ? shortDate(e.fundedAt) : <span className="text-gray-600">never</span>}
+                  </td>
+                  <td className="px-3 py-3 text-right text-gray-300">{duration(e.hoursToSettle)}</td>
+                  <td className="whitespace-nowrap px-3 py-3 text-gray-300" title={e.expiresAt ?? ''}>
+                    {shortDate(e.expiresAt)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-gray-400">
+        <span>
+          {total === 0 ? 'No escrows' : `${count(offset + 1)}–${count(pageEnd)} of ${count(total)}`}
+          {filtered && ' (filtered)'}
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setOffset((o) => Math.max(o - PAGE_SIZE, 0))}
+            disabled={offset === 0 || loading}
+            className="rounded border border-slate-700 px-3 py-1 hover:text-purple-300 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            onClick={() => setOffset((o) => o + PAGE_SIZE)}
+            disabled={pageEnd >= total || loading}
+            className="rounded border border-slate-700 px-3 py-1 hover:text-purple-300 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-6 text-xs text-gray-500">
+        USD figures come from the amount priced at creation. “Quoted” covers every escrow including those that never
+        funded, so it is demand rather than money moved and is never added to “Disbursed”. Chain amounts are shown
+        per-escrow and never summed across chains. “Held” is funded and neither settled nor refunded; “stranded”
+        narrows that to escrows already past their expiry. Release tokens are deliberately not exposed here.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/escrows/page.tsx
+++ b/src/app/admin/escrows/page.tsx
@@ -1,0 +1,14 @@
+import { requireAdminPage } from '@/lib/auth/admin-guard';
+import EscrowsContent from './EscrowsContent';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Escrows · Admin · CoinPay',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminEscrowsPage() {
+  await requireAdminPage('/admin/escrows');
+  return <EscrowsContent />;
+}

--- a/src/app/api/admin/escrows/route.test.ts
+++ b/src/app/api/admin/escrows/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth/admin-guard', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/stats/admin-escrow-stats', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/stats/admin-escrow-stats')>(
+    '@/lib/stats/admin-escrow-stats',
+  );
+  return {
+    ...actual,
+    getAdminEscrowStats: vi.fn(),
+    getAdminEscrowSummary: vi.fn(),
+  };
+});
+
+import { GET } from './route';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getAdminEscrowStats, getAdminEscrowSummary } from '@/lib/stats/admin-escrow-stats';
+
+const admin = { id: 'admin-1', email: 'admin@example.com', is_admin: true as const };
+
+const emptyPage = { rows: [], total: 0, limit: 50, offset: 0 };
+
+function req(query = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/admin/escrows${query}`);
+}
+
+describe('GET /api/admin/escrows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue(admin);
+    vi.mocked(getAdminEscrowStats).mockResolvedValue(emptyPage);
+    vi.mocked(getAdminEscrowSummary).mockResolvedValue({ escrowsTotal: 7 } as never);
+  });
+
+  describe('authorization', () => {
+    it('propagates the guard response for a non-admin and never reads any stats', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue(
+        NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+      );
+
+      const res = await GET(req());
+
+      expect(res.status).toBe(403);
+      expect(getAdminEscrowStats).not.toHaveBeenCalled();
+      expect(getAdminEscrowSummary).not.toHaveBeenCalled();
+    });
+
+    it('propagates a 401 for an unauthenticated caller', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue(
+        NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+      );
+
+      const res = await GET(req());
+
+      expect(res.status).toBe(401);
+      expect(getAdminEscrowStats).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('query parameters', () => {
+    it('defaults to newest first, no filters, first page', async () => {
+      await GET(req());
+
+      expect(getAdminEscrowStats).toHaveBeenCalledWith({
+        search: null,
+        status: null,
+        chain: null,
+        model: null,
+        sort: 'created_at',
+        direction: 'desc',
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    it('passes through the filters, a recognised sort key and the direction', async () => {
+      await GET(req('?sort=amount_usd&dir=asc&search=abc&status=settled&chain=SOL&model=custodial&limit=10&offset=20'));
+
+      expect(getAdminEscrowStats).toHaveBeenCalledWith({
+        search: 'abc',
+        status: 'settled',
+        chain: 'SOL',
+        model: 'custodial',
+        sort: 'amount_usd',
+        direction: 'asc',
+        limit: 10,
+        offset: 20,
+      });
+    });
+
+    it('falls back to the default sort when the key is not recognised', async () => {
+      await GET(req('?sort=release_token&dir=sideways'));
+
+      expect(getAdminEscrowStats).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'created_at', direction: 'desc' }),
+      );
+    });
+
+    it('clamps an oversized limit and a negative offset', async () => {
+      await GET(req('?limit=100000&offset=-5'));
+
+      expect(getAdminEscrowStats).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 500, offset: 0 }),
+      );
+    });
+
+    it('uses defaults when limit and offset are not numbers', async () => {
+      await GET(req('?limit=abc&offset=xyz'));
+
+      expect(getAdminEscrowStats).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, offset: 0 }),
+      );
+    });
+  });
+
+  describe('summary', () => {
+    it('includes all-time totals by default', async () => {
+      const res = await GET(req());
+      const body = await res.json();
+
+      expect(getAdminEscrowSummary).toHaveBeenCalled();
+      expect(body.summary).toEqual({ escrowsTotal: 7 });
+    });
+
+    it('skips the totals when summary=0', async () => {
+      const res = await GET(req('?summary=0'));
+      const body = await res.json();
+
+      expect(getAdminEscrowSummary).not.toHaveBeenCalled();
+      expect(body.summary).toBeNull();
+    });
+  });
+
+  it('never caches — the response is custody data for every escrow', async () => {
+    const res = await GET(req());
+
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns 500 rather than an empty page when the query fails', async () => {
+    // A silent empty page would read as "no escrows exist", which for a
+    // custodial service is the opposite of the truth an admin is checking.
+    vi.mocked(getAdminEscrowStats).mockRejectedValue(new Error('boom'));
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await GET(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.escrows).toBeUndefined();
+    spy.mockRestore();
+  });
+});

--- a/src/app/api/admin/escrows/route.ts
+++ b/src/app/api/admin/escrows/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import {
+  getAdminEscrowStats,
+  getAdminEscrowSummary,
+  parseSortDirection,
+  parseSortKey,
+} from '@/lib/stats/admin-escrow-stats';
+
+/**
+ * GET /api/admin/escrows — every escrow on the platform, plus all-time totals.
+ *
+ * Each row carries both counterparties' addresses and emails and any dispute
+ * text, so the admin check is the whole security boundary: the underlying
+ * Postgres functions are granted to `service_role` only and are unreachable
+ * from a browser session.
+ *
+ * `?summary=0` skips the all-time totals. The table refetches on every sort,
+ * filter, page and search change, and the totals do not vary with any of them.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const params = req.nextUrl.searchParams;
+  const search = params.get('search');
+  const status = params.get('status');
+  const chain = params.get('chain');
+  const model = params.get('model');
+  const sort = parseSortKey(params.get('sort'));
+  const direction = parseSortDirection(params.get('dir'));
+
+  // Clamped again in SQL; parsed here so a non-numeric ?limit=abc becomes the
+  // default rather than NaN.
+  const parsedLimit = Number.parseInt(params.get('limit') ?? '', 10);
+  const parsedOffset = Number.parseInt(params.get('offset') ?? '', 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), 500) : 50;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  const wantsSummary = params.get('summary') !== '0';
+
+  try {
+    const [page, summary] = await Promise.all([
+      getAdminEscrowStats({ search, status, chain, model, sort, direction, limit, offset }),
+      wantsSummary ? getAdminEscrowSummary() : Promise.resolve(null),
+    ]);
+
+    return NextResponse.json(
+      {
+        escrows: page.rows,
+        total: page.total,
+        limit: page.limit,
+        offset: page.offset,
+        sort,
+        dir: direction,
+        summary,
+      },
+      // Never cache: this is custody data about every escrow on the platform.
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (err) {
+    console.error('[admin/escrows] failed to load stats', err);
+    return NextResponse.json({ error: 'Failed to load escrow stats' }, { status: 500 });
+  }
+}

--- a/src/lib/stats/admin-escrow-stats.ts
+++ b/src/lib/stats/admin-escrow-stats.ts
@@ -1,0 +1,362 @@
+/**
+ * Escrow statistics for the admin console.
+ *
+ * Thin typed wrapper over the `admin_escrow_stats()` and
+ * `admin_escrow_summary()` Postgres functions. Both are granted to
+ * `service_role` only and are reached through `/api/admin/escrows`, behind
+ * `requireAdmin()` — this module does no authorization of its own, so nothing
+ * outside an admin-guarded route should import it.
+ *
+ * Postgres returns `numeric` as a string over the wire (it does not fit a JS
+ * number safely in general), so every figure is normalised through `toNumber`
+ * here rather than in the component.
+ *
+ * The one exception is `amount`: chain amounts are `numeric(30, 18)` and a
+ * value like 9859113112.000000000000000000 loses precision as a double, so the
+ * raw string is kept for display and only the USD figure is a number. USD is
+ * `numeric(20, 2)` and safe.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+
+/** Sort keys the Postgres function accepts. Anything else falls back server-side. */
+export const ESCROW_SORT_KEYS = [
+  'created_at',
+  'funded_at',
+  'settled_at',
+  'expires_at',
+  'amount_usd',
+  'chain',
+  'status',
+  'escrow_model',
+  'business_name',
+  'settle_attempts',
+  'hours_to_fund',
+  'hours_to_settle',
+] as const;
+
+export type EscrowSortKey = (typeof ESCROW_SORT_KEYS)[number];
+export type SortDirection = 'asc' | 'desc';
+
+export interface AdminEscrowRow {
+  id: string;
+  chain: string;
+  status: string;
+  escrowModel: string;
+  /** Chain units, as a string — see the precision note above. */
+  amount: string;
+  amountUsd: number;
+  depositedAmount: string | null;
+  feeAmount: string | null;
+  escrowAddress: string;
+  depositorAddress: string;
+  beneficiaryAddress: string;
+  arbiterAddress: string | null;
+  depositorEmail: string | null;
+  beneficiaryEmail: string | null;
+  depositTxHash: string | null;
+  settlementTxHash: string | null;
+  disputeStatus: string | null;
+  disputeReason: string | null;
+  inSeries: boolean;
+  allowAutoRelease: boolean;
+  settleAttempts: number;
+  businessId: string | null;
+  businessName: string | null;
+  merchantEmail: string | null;
+  createdAt: string;
+  fundedAt: string | null;
+  releasedAt: string | null;
+  settledAt: string | null;
+  disputedAt: string | null;
+  refundedAt: string | null;
+  expiresAt: string | null;
+  hoursToFund: number | null;
+  hoursToSettle: number | null;
+  /** Funded, and neither settled nor refunded — money the platform still holds. */
+  isHeld: boolean;
+  /** Held past its own expiry: needs a rescan or a human. */
+  isStranded: boolean;
+}
+
+export interface AdminEscrowPage {
+  rows: AdminEscrowRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface EscrowStatusBucket {
+  status: string;
+  total: number;
+  valueUsd: number;
+}
+
+export interface EscrowChainBucket {
+  chain: string;
+  total: number;
+  settled: number;
+  settledUsd: number;
+  heldUsd: number;
+}
+
+export interface EscrowModelBucket {
+  escrowModel: string;
+  total: number;
+  settled: number;
+}
+
+export interface EscrowMonthBucket {
+  month: string;
+  created: number;
+  funded: number;
+  settled: number;
+  settledUsd: number;
+}
+
+export interface AdminEscrowSummary {
+  escrowsTotal: number;
+  firstCreatedAt: string | null;
+  lastCreatedAt: string | null;
+  everFunded: number;
+  /** A settlement transaction was sent — on a release *or* a refund. */
+  everDisbursed: number;
+  everReleased: number;
+  everDisputed: number;
+  statusSettled: number;
+  statusRefunded: number;
+  expired: number;
+  heldCount: number;
+  strandedCount: number;
+  disputesOpen: number;
+  inSeries: number;
+  autoRelease: number;
+  withBusiness: number;
+  businesses: number;
+  created30d: number;
+  settled30d: number;
+  /** Quoted at creation, including escrows that never funded. Not money moved. */
+  createdValueUsd: number;
+  fundedValueUsd: number;
+  /** releasedValueUsd + refundedValueUsd, by construction. */
+  disbursedValueUsd: number;
+  releasedValueUsd: number;
+  refundedValueUsd: number;
+  heldValueUsd: number;
+  largestUsd: number;
+  medianUsd: number;
+  medianHoursToFund: number | null;
+  medianHoursToSettle: number | null;
+  byStatus: EscrowStatusBucket[];
+  byChain: EscrowChainBucket[];
+  byModel: EscrowModelBucket[];
+  months: EscrowMonthBucket[];
+}
+
+type Numeric = number | string | null | undefined;
+
+function toNumber(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Like `toNumber`, but keeps "not measured yet" distinct from zero. */
+function toNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value ? value : null;
+}
+
+/** Narrow an arbitrary string to a sort key, falling back to newest first. */
+export function parseSortKey(value: string | null | undefined): EscrowSortKey {
+  return (ESCROW_SORT_KEYS as readonly string[]).includes(value ?? '')
+    ? (value as EscrowSortKey)
+    : 'created_at';
+}
+
+export function parseSortDirection(value: string | null | undefined): SortDirection {
+  return value?.toLowerCase() === 'asc' ? 'asc' : 'desc';
+}
+
+type RawRow = Record<string, unknown>;
+
+function mapRow(raw: unknown): AdminEscrowRow {
+  const row = (raw ?? {}) as RawRow;
+  return {
+    id: String(row.id ?? ''),
+    chain: String(row.chain ?? ''),
+    status: String(row.status ?? ''),
+    escrowModel: String(row.escrow_model ?? ''),
+    amount: row.amount === null || row.amount === undefined ? '0' : String(row.amount),
+    amountUsd: toNumber(row.amount_usd),
+    depositedAmount: row.deposited_amount == null ? null : String(row.deposited_amount),
+    feeAmount: row.fee_amount == null ? null : String(row.fee_amount),
+    escrowAddress: String(row.escrow_address ?? ''),
+    depositorAddress: String(row.depositor_address ?? ''),
+    beneficiaryAddress: String(row.beneficiary_address ?? ''),
+    arbiterAddress: str(row.arbiter_address),
+    depositorEmail: str(row.depositor_email),
+    beneficiaryEmail: str(row.beneficiary_email),
+    depositTxHash: str(row.deposit_tx_hash),
+    settlementTxHash: str(row.settlement_tx_hash),
+    disputeStatus: str(row.dispute_status),
+    disputeReason: str(row.dispute_reason),
+    inSeries: Boolean(row.in_series),
+    allowAutoRelease: Boolean(row.allow_auto_release),
+    settleAttempts: toNumber(row.settle_attempts),
+    businessId: str(row.business_id),
+    businessName: str(row.business_name),
+    merchantEmail: str(row.merchant_email),
+    createdAt: String(row.created_at ?? ''),
+    fundedAt: str(row.funded_at),
+    releasedAt: str(row.released_at),
+    settledAt: str(row.settled_at),
+    disputedAt: str(row.disputed_at),
+    refundedAt: str(row.refunded_at),
+    expiresAt: str(row.expires_at),
+    hoursToFund: toNullableNumber(row.hours_to_fund),
+    hoursToSettle: toNullableNumber(row.hours_to_settle),
+    isHeld: Boolean(row.is_held),
+    isStranded: Boolean(row.is_stranded),
+  };
+}
+
+export interface GetAdminEscrowStatsOptions {
+  search?: string | null;
+  status?: string | null;
+  chain?: string | null;
+  model?: string | null;
+  sort?: EscrowSortKey;
+  direction?: SortDirection;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * One page of escrows.
+ *
+ * Throws on failure rather than returning an empty page: a silent zero here
+ * would be indistinguishable from "there are no escrows", and for a custodial
+ * service that is exactly the difference an admin is checking for.
+ */
+export async function getAdminEscrowStats(
+  options: GetAdminEscrowStatsOptions = {},
+): Promise<AdminEscrowPage> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase.rpc('admin_escrow_stats', {
+    p_search: options.search?.trim() || null,
+    p_status: options.status?.trim() || null,
+    p_chain: options.chain?.trim() || null,
+    p_model: options.model?.trim() || null,
+    p_sort: options.sort ?? 'created_at',
+    p_dir: options.direction ?? 'desc',
+    p_limit: options.limit ?? 50,
+    p_offset: options.offset ?? 0,
+  });
+
+  if (error || !data) {
+    throw new Error(`admin_escrow_stats failed: ${error?.message ?? 'no data'}`);
+  }
+
+  const payload = data as { rows?: unknown[]; total?: Numeric; limit?: Numeric; offset?: Numeric };
+  return {
+    rows: (payload.rows ?? []).map(mapRow),
+    total: toNumber(payload.total),
+    limit: toNumber(payload.limit),
+    offset: toNumber(payload.offset),
+  };
+}
+
+function mapStatusBucket(raw: unknown): EscrowStatusBucket {
+  const row = (raw ?? {}) as RawRow;
+  return {
+    status: String(row.status ?? ''),
+    total: toNumber(row.total),
+    valueUsd: toNumber(row.value_usd),
+  };
+}
+
+function mapChainBucket(raw: unknown): EscrowChainBucket {
+  const row = (raw ?? {}) as RawRow;
+  return {
+    chain: String(row.chain ?? ''),
+    total: toNumber(row.total),
+    settled: toNumber(row.settled),
+    settledUsd: toNumber(row.settled_usd),
+    heldUsd: toNumber(row.held_usd),
+  };
+}
+
+function mapModelBucket(raw: unknown): EscrowModelBucket {
+  const row = (raw ?? {}) as RawRow;
+  return {
+    escrowModel: String(row.escrow_model ?? ''),
+    total: toNumber(row.total),
+    settled: toNumber(row.settled),
+  };
+}
+
+function mapMonthBucket(raw: unknown): EscrowMonthBucket {
+  const row = (raw ?? {}) as RawRow;
+  return {
+    month: String(row.month ?? ''),
+    created: toNumber(row.created),
+    funded: toNumber(row.funded),
+    settled: toNumber(row.settled),
+    settledUsd: toNumber(row.settled_usd),
+  };
+}
+
+/** All-time totals, breakdowns and monthly history. Unaffected by the filters. */
+export async function getAdminEscrowSummary(): Promise<AdminEscrowSummary> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase.rpc('admin_escrow_summary');
+
+  if (error || !data) {
+    throw new Error(`admin_escrow_summary failed: ${error?.message ?? 'no data'}`);
+  }
+
+  const raw = data as Record<string, unknown>;
+  const list = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+  return {
+    escrowsTotal: toNumber(raw.escrows_total),
+    firstCreatedAt: str(raw.first_created_at),
+    lastCreatedAt: str(raw.last_created_at),
+    everFunded: toNumber(raw.ever_funded),
+    everDisbursed: toNumber(raw.ever_disbursed),
+    everReleased: toNumber(raw.ever_released),
+    everDisputed: toNumber(raw.ever_disputed),
+    statusSettled: toNumber(raw.status_settled),
+    statusRefunded: toNumber(raw.status_refunded),
+    expired: toNumber(raw.expired),
+    heldCount: toNumber(raw.held_count),
+    strandedCount: toNumber(raw.stranded_count),
+    disputesOpen: toNumber(raw.disputes_open),
+    inSeries: toNumber(raw.in_series),
+    autoRelease: toNumber(raw.auto_release),
+    withBusiness: toNumber(raw.with_business),
+    businesses: toNumber(raw.businesses),
+    created30d: toNumber(raw.created_30d),
+    settled30d: toNumber(raw.settled_30d),
+    createdValueUsd: toNumber(raw.created_value_usd),
+    fundedValueUsd: toNumber(raw.funded_value_usd),
+    disbursedValueUsd: toNumber(raw.disbursed_value_usd),
+    releasedValueUsd: toNumber(raw.released_value_usd),
+    refundedValueUsd: toNumber(raw.refunded_value_usd),
+    heldValueUsd: toNumber(raw.held_value_usd),
+    largestUsd: toNumber(raw.largest_usd),
+    medianUsd: toNumber(raw.median_usd),
+    medianHoursToFund: toNullableNumber(raw.median_hours_to_fund),
+    medianHoursToSettle: toNullableNumber(raw.median_hours_to_settle),
+    byStatus: list(raw.by_status).map(mapStatusBucket),
+    byChain: list(raw.by_chain).map(mapChainBucket),
+    byModel: list(raw.by_model).map(mapModelBucket),
+    months: list(raw.months).map(mapMonthBucket),
+  };
+}

--- a/supabase/migrations/20260814120000_admin_escrow_stats.sql
+++ b/supabase/migrations/20260814120000_admin_escrow_stats.sql
@@ -1,0 +1,347 @@
+-- Escrow statistics for the admin console.
+--
+-- Answers "what has this escrow service actually done, all time" in one place:
+-- every escrow ever created, where each one stopped in the lifecycle, and how
+-- much money is sitting in platform custody right now.
+--
+-- Three deliberate choices about money:
+--
+-- 1. `amount`, `deposited_amount` and `fee_amount` are denominated in each
+--    chain's own units. Summing them across BTC, SOL and USDC_POL would give a
+--    number with no meaning, so every USD figure here comes from `amount_usd`
+--    and the chain-unit columns are only ever reported per-row.
+-- 2. Created value and settled value are reported separately and never added.
+--    An escrow that was quoted but never funded moved no money, and the two
+--    figures differ by orders of magnitude on real data: most escrows expire
+--    unfunded. A single "escrow volume" number would be dominated by escrows
+--    that never existed economically.
+-- 3. "Held" is the number an operator of a custodial escrow actually needs:
+--    funded, and neither settled nor refunded. `stranded` narrows that to the
+--    ones whose window has already closed, which is the set that needs a human
+--    or a rescan.
+--
+-- Status is read from the data rather than assumed. The `escrows_status_check`
+-- constraint is NOT VALID and rows exist with statuses outside it (e.g.
+-- `settle_failed`), so the per-status breakdown groups over whatever is
+-- actually stored and the UI builds its filter from that.
+
+-- One page of escrows for the admin table.
+create or replace function public.admin_escrow_stats(
+  p_search text default null,
+  p_status text default null,
+  p_chain text default null,
+  p_model text default null,
+  p_sort text default 'created_at',
+  p_dir text default 'desc',
+  p_limit int default 50,
+  p_offset int default 0
+)
+returns json
+language plpgsql
+stable
+security invoker
+set search_path = public
+as $fn$
+declare
+  -- Inlined rather than kept as a view so this function stays the single
+  -- object to grant, revoke and reason about, matching admin_user_stats().
+  c_base constant text := $base$
+    select
+      e.id,
+      e.chain,
+      e.status,
+      e.escrow_model,
+      e.amount,
+      e.amount_usd,
+      e.deposited_amount,
+      e.fee_amount,
+      e.escrow_address,
+      e.depositor_address,
+      e.beneficiary_address,
+      e.arbiter_address,
+      e.depositor_email,
+      e.beneficiary_email,
+      e.deposit_tx_hash,
+      e.settlement_tx_hash,
+      e.dispute_status,
+      e.dispute_reason,
+      (e.series_id is not null) as in_series,
+      e.allow_auto_release,
+      coalesce(e.settle_attempts, 0) as settle_attempts,
+      e.business_id,
+      b.name as business_name,
+      m.email as merchant_email,
+      e.created_at,
+      e.funded_at,
+      e.released_at,
+      e.settled_at,
+      e.disputed_at,
+      e.refunded_at,
+      e.expires_at,
+      -- Lifecycle timings, in hours, null until the milestone happens.
+      extract(epoch from (e.funded_at - e.created_at)) / 3600.0  as hours_to_fund,
+      extract(epoch from (e.settled_at - e.funded_at)) / 3600.0  as hours_to_settle,
+      -- Money the platform is custodying: funded, not yet settled or refunded.
+      (e.funded_at is not null and e.settled_at is null and e.refunded_at is null) as is_held,
+      -- Held past its own expiry — the set that needs a rescan or a human.
+      (e.funded_at is not null and e.settled_at is null and e.refunded_at is null
+        and e.expires_at is not null and e.expires_at < now()) as is_stranded
+    from escrows e
+    left join businesses b on b.id = e.business_id
+    left join merchants m on m.id = b.merchant_id
+  $base$;
+
+  v_sort_col text;
+  v_dir text;
+  v_limit int;
+  v_offset int;
+  v_search text;
+  v_status text;
+  v_chain text;
+  v_model text;
+  -- Always the same shape, with null meaning "no filter", so the four
+  -- parameters can be bound unconditionally instead of assembled per call.
+  c_where constant text :=
+    ' where ($2 is null or s.status = $2)'
+    || ' and ($3 is null or s.chain = $3)'
+    || ' and ($4 is null or s.escrow_model = $4)'
+    || ' and ($1 is null or ('
+    || '      s.id::text ilike ''%'' || $1 || ''%'''
+    || '   or s.escrow_address ilike ''%'' || $1 || ''%'''
+    || '   or s.depositor_address ilike ''%'' || $1 || ''%'''
+    || '   or s.beneficiary_address ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.depositor_email, '''') ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.beneficiary_email, '''') ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.deposit_tx_hash, '''') ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.settlement_tx_hash, '''') ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.business_name, '''') ilike ''%'' || $1 || ''%'''
+    || '   or coalesce(s.merchant_email, '''') ilike ''%'' || $1 || ''%'''
+    || ' ))';
+  v_total bigint;
+  v_rows json;
+begin
+  -- Whitelist, not quote_ident: the caller supplies a sort *key*, never a
+  -- column name, so an unrecognised value falls back rather than reaching the
+  -- statement text.
+  v_sort_col := case p_sort
+    when 'created_at'      then 'created_at'
+    when 'funded_at'       then 'funded_at'
+    when 'settled_at'      then 'settled_at'
+    when 'expires_at'      then 'expires_at'
+    when 'amount_usd'      then 'amount_usd'
+    when 'chain'           then 'chain'
+    when 'status'          then 'status'
+    when 'escrow_model'    then 'escrow_model'
+    when 'business_name'   then 'business_name'
+    when 'settle_attempts' then 'settle_attempts'
+    when 'hours_to_fund'   then 'hours_to_fund'
+    when 'hours_to_settle' then 'hours_to_settle'
+    else 'created_at'
+  end;
+
+  v_dir    := case when lower(coalesce(p_dir, '')) = 'asc' then 'asc' else 'desc' end;
+  v_limit  := least(greatest(coalesce(p_limit, 50), 1), 500);
+  v_offset := greatest(coalesce(p_offset, 0), 0);
+  v_search := nullif(btrim(coalesce(p_search, '')), '');
+  v_status := nullif(btrim(coalesce(p_status, '')), '');
+  v_chain  := nullif(btrim(coalesce(p_chain, '')), '');
+  v_model  := nullif(btrim(coalesce(p_model, '')), '');
+
+  execute format('select count(*) from (%s) s %s', c_base, c_where)
+    into v_total
+    using v_search, v_status, v_chain, v_model;
+
+  -- The id tiebreak keeps pagination stable when the sort column ties, which
+  -- it does constantly: most escrows share a status and never funded.
+  execute format(
+    'select coalesce(json_agg(row_to_json(t)), ''[]''::json) from ('
+      || 'select * from (%s) s %s order by s.%I %s nulls last, s.id asc limit %s offset %s'
+    || ') t',
+    c_base, c_where, v_sort_col, v_dir, v_limit, v_offset
+  )
+    into v_rows
+    using v_search, v_status, v_chain, v_model;
+
+  return json_build_object('total', v_total, 'limit', v_limit, 'offset', v_offset, 'rows', v_rows);
+end;
+$fn$;
+
+comment on function public.admin_escrow_stats(text, text, text, text, text, text, int, int) is
+  'One page of escrows for the admin console, with lifecycle timings and custody '
+  'flags. Admin-gated in the application layer (src/lib/auth/admin-guard.ts); '
+  'service_role only here. Chain-unit amounts are per-row and never summed.';
+
+-- All-time totals and breakdowns for the header of the same page. Deliberately
+-- a separate function: none of it varies with the table's search or filters, so
+-- folding it in would recompute a constant on every keystroke.
+create or replace function public.admin_escrow_summary()
+returns json
+language sql
+stable
+security invoker
+set search_path = public
+as $fn$
+  with e as (
+    select
+      *,
+      (funded_at is not null and settled_at is null and refunded_at is null) as is_held
+    from escrows
+  ),
+  totals as (
+    select
+      count(*)                                                as escrows_total,
+      min(created_at)                                         as first_created_at,
+      max(created_at)                                         as last_created_at,
+      count(*) filter (where funded_at is not null)           as ever_funded,
+      -- `settled_at` means a settlement transaction was sent, which happens on
+      -- a refund as well as a release — 'disbursed' is the honest name for it.
+      -- Where the money went is a question for `status`, below.
+      count(*) filter (where settled_at is not null)          as ever_disbursed,
+      count(*) filter (where released_at is not null)         as ever_released,
+      count(*) filter (where disputed_at is not null)         as ever_disputed,
+      count(*) filter (where status = 'settled')              as status_settled,
+      count(*) filter (where status = 'refunded')             as status_refunded,
+      count(*) filter (where status = 'expired')              as expired,
+      count(*) filter (where is_held)                         as held_count,
+      count(*) filter (where is_held and expires_at is not null and expires_at < now())
+                                                              as stranded_count,
+      count(*) filter (where dispute_status in ('open', 'under_review'))
+                                                              as disputes_open,
+      count(*) filter (where series_id is not null)           as in_series,
+      count(*) filter (where allow_auto_release)              as auto_release,
+      count(*) filter (where business_id is not null)         as with_business,
+      count(distinct business_id)                             as businesses,
+      count(*) filter (where created_at >= now() - interval '30 days')  as created_30d,
+      count(*) filter (where settled_at >= now() - interval '30 days')  as settled_30d,
+      -- Value quoted at creation. Includes escrows that never funded, so this
+      -- is demand, not money, and is never added to the settled figure.
+      coalesce(sum(amount_usd), 0)                                      as created_value_usd,
+      coalesce(sum(amount_usd) filter (where funded_at is not null), 0) as funded_value_usd,
+      -- Everything that left escrow, and where it went. The split is by status
+      -- rather than by timestamp so the two halves reconcile exactly:
+      -- released_value_usd + refunded_value_usd = disbursed_value_usd.
+      coalesce(sum(amount_usd) filter (where settled_at is not null), 0)   as disbursed_value_usd,
+      coalesce(sum(amount_usd) filter (where status = 'settled'), 0)       as released_value_usd,
+      coalesce(sum(amount_usd) filter (where status = 'refunded'), 0)      as refunded_value_usd,
+      coalesce(sum(amount_usd) filter (where is_held), 0)               as held_value_usd,
+      coalesce(max(amount_usd), 0)                                      as largest_usd,
+      coalesce(percentile_cont(0.5) within group (order by amount_usd), 0) as median_usd,
+      percentile_cont(0.5) within group (
+        order by extract(epoch from (funded_at - created_at)) / 3600.0
+      )                                                                 as median_hours_to_fund,
+      percentile_cont(0.5) within group (
+        order by extract(epoch from (settled_at - funded_at)) / 3600.0
+      )                                                                 as median_hours_to_settle
+    from e
+  ),
+  by_status as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.status), '[]'::json) as j
+    from (
+      select status, count(*) as total, coalesce(sum(amount_usd), 0) as value_usd
+      from e group by status
+    ) r
+  ),
+  by_chain as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.chain), '[]'::json) as j
+    from (
+      select chain,
+             count(*) as total,
+             count(*) filter (where settled_at is not null) as settled,
+             coalesce(sum(amount_usd) filter (where settled_at is not null), 0) as settled_usd,
+             coalesce(sum(amount_usd) filter (where funded_at is not null
+               and settled_at is null and refunded_at is null), 0) as held_usd
+      from e group by chain
+    ) r
+  ),
+  by_model as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.escrow_model), '[]'::json) as j
+    from (
+      select escrow_model,
+             count(*) as total,
+             count(*) filter (where settled_at is not null) as settled
+      from e group by escrow_model
+    ) r
+  ),
+  -- Zero-filled so a month with no escrows is a gap in the chart rather than a
+  -- missing point that silently compresses the timeline.
+  months as (
+    select coalesce(json_agg(row_to_json(r) order by r.month), '[]'::json) as j
+    from (
+      select to_char(g.m, 'YYYY-MM') as month,
+             count(e.id) filter (where date_trunc('month', e.created_at) = g.m) as created,
+             count(e.id) filter (where date_trunc('month', e.funded_at)  = g.m) as funded,
+             count(e.id) filter (where date_trunc('month', e.settled_at) = g.m) as settled,
+             coalesce(sum(e.amount_usd) filter (where date_trunc('month', e.settled_at) = g.m), 0)
+               as settled_usd
+      from generate_series(
+             (select date_trunc('month', min(created_at)) from e),
+             date_trunc('month', now()),
+             interval '1 month'
+           ) g(m)
+      left join e on date_trunc('month', e.created_at) = g.m
+                  or date_trunc('month', e.funded_at)  = g.m
+                  or date_trunc('month', e.settled_at) = g.m
+      group by g.m
+    ) r
+  )
+  select json_build_object(
+    'escrows_total',           t.escrows_total,
+    'first_created_at',        t.first_created_at,
+    'last_created_at',         t.last_created_at,
+    'ever_funded',             t.ever_funded,
+    'ever_disbursed',          t.ever_disbursed,
+    'ever_released',           t.ever_released,
+    'ever_disputed',           t.ever_disputed,
+    'status_settled',          t.status_settled,
+    'status_refunded',         t.status_refunded,
+    'expired',                 t.expired,
+    'held_count',              t.held_count,
+    'stranded_count',          t.stranded_count,
+    'disputes_open',           t.disputes_open,
+    'in_series',               t.in_series,
+    'auto_release',            t.auto_release,
+    'with_business',           t.with_business,
+    'businesses',              t.businesses,
+    'created_30d',             t.created_30d,
+    'settled_30d',             t.settled_30d,
+    'created_value_usd',       t.created_value_usd,
+    'funded_value_usd',        t.funded_value_usd,
+    'disbursed_value_usd',     t.disbursed_value_usd,
+    'released_value_usd',      t.released_value_usd,
+    'refunded_value_usd',      t.refunded_value_usd,
+    'held_value_usd',          t.held_value_usd,
+    'largest_usd',             t.largest_usd,
+    'median_usd',              t.median_usd,
+    'median_hours_to_fund',    t.median_hours_to_fund,
+    'median_hours_to_settle',  t.median_hours_to_settle,
+    'by_status',               (select j from by_status),
+    'by_chain',                (select j from by_chain),
+    'by_model',                (select j from by_model),
+    'months',                  (select j from months)
+  )
+  from totals t;
+$fn$;
+
+comment on function public.admin_escrow_summary() is
+  'All-time escrow totals, lifecycle funnel, per-chain and per-status breakdowns '
+  'and a monthly history for the admin console header. service_role only. '
+  'Created value and settled value are separate figures and must not be added.';
+
+-- Both functions read every escrow on the platform — counterparty addresses,
+-- emails and dispute text included — so neither is reachable from a browser.
+-- They are called server-side with the service role, behind requireAdmin().
+--
+-- `revoke ... from public` alone is not enough here: Supabase's default
+-- privileges grant EXECUTE on new public-schema functions directly to `anon`
+-- and `authenticated`, and a revoke from PUBLIC does not remove a grant held
+-- by a named role. Both roles are therefore revoked explicitly, the same way
+-- public_landing_stats() is locked down.
+--
+-- Being `security invoker` is the backstop rather than the lock: an anon
+-- caller would run under anon's own privileges and RLS on `escrows` would
+-- return nothing. Revoking as well means the call fails outright instead of
+-- quietly returning an empty page that looks like real data.
+revoke all on function public.admin_escrow_stats(text, text, text, text, text, text, int, int) from public, anon, authenticated;
+revoke all on function public.admin_escrow_summary() from public, anon, authenticated;
+grant execute on function public.admin_escrow_stats(text, text, text, text, text, text, int, int) to service_role;
+grant execute on function public.admin_escrow_summary() to service_role;


### PR DESCRIPTION
Adds `/admin/escrows`, alongside the existing `/admin/users` console.

Escrow was the one product with no admin view. The per-user page counts escrows per merchant, but nothing showed the escrows themselves — and for a custodial service the number that matters most is how much the platform is holding right now.

## What it shows

- **Custody first** — held value (funded, neither settled nor refunded) and *stranded* (held past its own expiry), which is the set that needs a rescan or a human.
- **All-time history** — every escrow since the first one, a zero-filled monthly series (created / funded / settled / USD), and per-status and per-chain breakdowns that double as one-click filters.
- **The table** — every escrow, searchable by id, address, email, tx hash or business; filterable by status, chain and model; sortable on 12 keys; expandable to full detail; CSV export.

## Three things the data forced

1. **`settled_at` is set on a refund as well as a release**, so it means "a settlement transaction was sent", not "the beneficiary was paid". The page reports *disbursed* value and splits it by status into *released* and *refunded*. They reconcile exactly — on current prod data, $102.98 + $132.97 = $235.95.
2. **Most escrows expire unfunded**, and value quoted at creation is dominated by escrows that never moved a coin. Quoted and disbursed are reported separately and never added. (Today quoted is ~$76B against $235.95 actually disbursed — see the note below.)
3. **Chain amounts are `numeric(30,18)`** and lose precision as a JS double, so they stay strings, render per-escrow, and are never summed across chains. Only `amount_usd` is treated as money — the same rule `admin_user_stats()` follows for fees.

## Security

- Both functions are `security invoker` and granted to `service_role` only, reached through `/api/admin/escrows` behind `requireAdmin()`. Response is `no-store`.
- The revokes name `anon` and `authenticated` explicitly: Supabase's default privileges grant EXECUTE on new public-schema functions directly to both, and a revoke from `PUBLIC` does not remove a grant held by a named role. Verified after applying — both roles now report `false`.
- `release_token` and `beneficiary_token` are deliberately not selected. They are bearer credentials that let anyone holding one release the escrow.
- Sort keys are whitelisted, not `quote_ident`ed; an unrecognised key falls back rather than reaching the statement text.

## Worth a look separately

- `admin_user_stats()` and `admin_platform_stats()` are still executable by `anon` and `authenticated` for the same default-privileges reason. Not a leak today — they are `security invoker`, so RLS returns nothing to anon — but they should get the same explicit revoke. Left out of this PR to keep it to one feature.
- Prod has 12 escrows carrying ~$9.8B each (expired, unfunded, no business, Feb 2026) that account for essentially all of the quoted-value figure. They look like load-test rows. The page reports them honestly rather than filtering them silently, but they may be worth deleting.
- One escrow is genuinely stranded: a DOGE escrow funded 2026-02-05, status `settle_failed`, past expiry, $0.10.
- `settle_failed` is stored in `escrows.status` but is not in the `escrows_status_check` constraint (which is `NOT VALID`). The page reads statuses from the data rather than a hardcoded list, so it displays correctly either way.

## Migration

`supabase/migrations/20260814120000_admin_escrow_stats.sql`. **Already applied to prod** via MCP (no CI applies migrations on this repo), so the functions exist ahead of this merge.

## Checks

`vitest run` — 286 files, 3959 passed / 3 skipped. `tsc --noEmit` clean, `eslint` clean on changed files, `next build` succeeds with `/admin/escrows` and `/api/admin/escrows` registered. 15 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)