### PR TITLE
fix(admin): actually revoke the user-stats functions from browser roles

### DIFF
--- a/supabase/migrations/20260814140000_revoke_admin_user_stats_from_browser_roles.sql
+++ b/supabase/migrations/20260814140000_revoke_admin_user_stats_from_browser_roles.sql
@@ -1,0 +1,27 @@
+-- Close the browser-role grants on the admin user-stats functions.
+--
+-- `20260813120000_admin_user_stats.sql` revoked both functions from PUBLIC and
+-- granted them to `service_role`, which reads as locked down but is not:
+-- Supabase's default privileges grant EXECUTE on new public-schema functions
+-- directly to `anon` and `authenticated`, and a revoke from PUBLIC does not
+-- remove a grant held by a named role. Both roles could therefore still call
+-- them. `admin_escrow_stats()` was written with the explicit revoke from the
+-- start; this brings the older pair in line.
+--
+-- Not a leak in the meantime: both are `security invoker`, so an anon caller
+-- runs under anon's own privileges and RLS on `merchants`, `businesses`,
+-- `payments` and `escrows` returns nothing. The point of revoking as well is
+-- that the call fails outright instead of quietly returning an empty result
+-- that looks like real data — and that the next `security definer` function
+-- copied from this pattern does not inherit a hole.
+--
+-- Verify with:
+--   select has_function_privilege('anon', p.oid, 'execute')
+--   from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--   where n.nspname = 'public' and p.proname like 'admin_%stats';
+
+revoke all on function public.admin_user_stats(text, text, text, int, int) from public, anon, authenticated;
+revoke all on function public.admin_platform_stats() from public, anon, authenticated;
+
+grant execute on function public.admin_user_stats(text, text, text, int, int) to service_role;
+grant execute on function public.admin_platform_stats() to service_role;


### PR DESCRIPTION
Follow-up to #253, which flagged this.

`admin_user_stats()` and `admin_platform_stats()` shipped with `revoke all on function ... from public` plus a grant to `service_role`. That reads as locked down, but it isn't: Supabase's default privileges grant EXECUTE on new public-schema functions **directly to `anon` and `authenticated`**, and a revoke from `PUBLIC` does not remove a grant held by a named role. Both roles could still call them.

Confirmed before the fix:

| function | anon | authenticated |
|---|---|---|
| `admin_user_stats` | ✅ could execute | ✅ could execute |
| `admin_platform_stats` | ✅ could execute | ✅ could execute |
| `admin_escrow_stats` | ❌ | ❌ |

And after:

```
admin_escrow_stats     anon=false  authed=false  service=true
admin_escrow_summary   anon=false  authed=false  service=true
admin_platform_stats   anon=false  authed=false  service=true
admin_user_stats       anon=false  authed=false  service=true
```

**This was not a live leak.** Both functions are `security invoker`, so an anon caller runs under anon's own privileges and RLS on `merchants` / `businesses` / `payments` / `escrows` returns nothing. Revoking matters for two other reasons: the call now fails outright instead of quietly returning an empty result that looks like real data, and the next function copied from this pattern doesn't inherit the hole — which is a real risk, because a `security definer` function with these grants *would* leak.

## Blast radius

The only caller is `src/lib/stats/admin-user-stats.ts`, which goes through `getSupabaseAdmin()` and holds the service role. Verified on prod after applying: `/admin/users` still returns 200 and `/api/admin/users` still returns 401 to an unauthenticated caller.

## Migration

`supabase/migrations/20260814140000_revoke_admin_user_stats_from_browser_roles.sql` — **already applied to prod** via MCP, since no CI applies migrations on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)