### PR TITLE
feat(payments): pay gas for EVM token forwards via a permit relayer

### DIFF
--- a/src/lib/wallets/evm-gas.test.ts
+++ b/src/lib/wallets/evm-gas.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ethers } from 'ethers';
+
+vi.mock('./system-wallet', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./system-wallet')>();
+  const { randomBytes } = await import('crypto');
+  // Generated per run rather than written as a literal: a hardcoded 32-byte hex
+  // string here is a valid secp256k1 key, so it reads as a committed credential
+  // to secret scanners even though it is only a fixture. getGasRelayer just
+  // needs the key to be well-formed — the assertions are on the address and
+  // balance the mock returns.
+  const key = randomBytes(32).toString('hex');
+  return {
+    ...actual,
+    deriveGasRelayerWallet: vi.fn(() => ({
+      address: '0x1111111111111111111111111111111111111111',
+      privateKey: key,
+    })),
+  };
+});
+
+import { computeGasReserve, resolvePermitDomain, getGasRelayer } from './evm-gas';
+
+describe('computeGasReserve', () => {
+  it('withholds the surcharge share of the token amount', () => {
+    // $140 invoice + $0.038 network fee, quoted as 140.038 USDC.
+    const reserve = computeGasReserve(140.038, { network_fee_usd: 0.038, total_amount_usd: 140.038 });
+    expect(reserve).toBeCloseTo(0.038, 6);
+  });
+
+  it('leaves the merchant whole after the split', () => {
+    // The point of the reserve: merchant should net the original invoice
+    // amount, not 99% of invoice-plus-surcharge.
+    const cryptoAmount = 140.038;
+    const reserve = computeGasReserve(cryptoAmount, {
+      network_fee_usd: 0.038,
+      total_amount_usd: 140.038,
+    });
+    const merchant = (cryptoAmount - reserve) * 0.99;
+    expect(merchant).toBeCloseTo(138.6, 1);
+  });
+
+  it('returns 0 when the metadata has no surcharge, so old payments split unchanged', () => {
+    expect(computeGasReserve(100, {})).toBe(0);
+    expect(computeGasReserve(100, null)).toBe(0);
+    expect(computeGasReserve(100, { network_fee_usd: 0, total_amount_usd: 100 })).toBe(0);
+  });
+
+  it('ignores malformed metadata rather than eating the payment', () => {
+    expect(computeGasReserve(100, { network_fee_usd: 'abc', total_amount_usd: 100 })).toBe(0);
+    expect(computeGasReserve(100, { network_fee_usd: 5, total_amount_usd: 0 })).toBe(0);
+    expect(computeGasReserve(100, { network_fee_usd: -5, total_amount_usd: 100 })).toBe(0);
+  });
+
+  it('never withholds more than half, however wrong the metadata is', () => {
+    // A surcharge larger than the payment would otherwise leave the merchant
+    // with nothing; cap it well before that.
+    expect(computeGasReserve(100, { network_fee_usd: 900, total_amount_usd: 100 })).toBe(50);
+  });
+});
+
+describe('resolvePermitDomain', () => {
+  const chainId = 1n;
+  const verifyingContract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+  function tokenStub(overrides: Record<string, any>) {
+    return {
+      getAddress: async () => verifyingContract,
+      name: async () => 'USD Coin',
+      ...overrides,
+    } as any;
+  }
+
+  it('picks the version whose domain hash the contract confirms', async () => {
+    const expected = { name: 'USD Coin', version: '2', chainId, verifyingContract };
+    const token = tokenStub({
+      DOMAIN_SEPARATOR: async () => ethers.TypedDataEncoder.hashDomain(expected),
+      version: async () => { throw new Error('not exposed'); },
+    });
+
+    const domain = await resolvePermitDomain(token, chainId);
+    expect(domain).toMatchObject({ version: '2', name: 'USD Coin' });
+  });
+
+  it('matches version 1 tokens too', async () => {
+    const expected = { name: 'USD Coin', version: '1', chainId, verifyingContract };
+    const token = tokenStub({
+      DOMAIN_SEPARATOR: async () => ethers.TypedDataEncoder.hashDomain(expected),
+      version: async () => { throw new Error('not exposed'); },
+    });
+
+    expect(await resolvePermitDomain(token, chainId)).toMatchObject({ version: '1' });
+  });
+
+  it('returns null when no candidate matches, so the caller falls back', async () => {
+    const token = tokenStub({
+      DOMAIN_SEPARATOR: async () => ethers.keccak256(ethers.toUtf8Bytes('something else')),
+      version: async () => { throw new Error('not exposed'); },
+    });
+
+    expect(await resolvePermitDomain(token, chainId)).toBeNull();
+  });
+
+  it('returns null for a token with no DOMAIN_SEPARATOR at all (e.g. USDT)', async () => {
+    const token = tokenStub({
+      DOMAIN_SEPARATOR: async () => { throw new Error('no such method'); },
+    });
+
+    expect(await resolvePermitDomain(token, chainId)).toBeNull();
+  });
+});
+
+describe('getGasRelayer', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the relayer balance so callers can report a broke float', async () => {
+    const provider = {
+      getBalance: vi.fn().mockResolvedValue(5_000_000_000_000_000n),
+    } as any;
+
+    const relayer = await getGasRelayer('USDC_ETH' as any, provider);
+
+    expect(relayer.address).toBe('0x1111111111111111111111111111111111111111');
+    expect(relayer.balance).toBe(5_000_000_000_000_000n);
+    expect(provider.getBalance).toHaveBeenCalledWith('0x1111111111111111111111111111111111111111');
+  });
+});

--- a/src/lib/wallets/evm-gas.ts
+++ b/src/lib/wallets/evm-gas.ts
@@ -1,0 +1,309 @@
+/**
+ * Gas strategy for EVM token forwards.
+ *
+ * An ERC20 transfer is paid for in the chain's native currency by the *sending*
+ * address. CoinPay's derived payment addresses only ever receive the token, so
+ * a plain `token.transfer()` from one of them reverts on intrinsic gas cost —
+ * which is how token payments came to strand at intermediary addresses while
+ * every surface reported them received.
+ *
+ * Two ways out, tried in order:
+ *
+ *   1. RELAYER (preferred). EIP-2612 `permit` lets the address authorise a
+ *      spender with an off-chain signature — no gas, and we already hold its
+ *      key. The relayer then calls `transferFrom` and pays the gas itself. No
+ *      native currency ever touches the derived address, so nothing is
+ *      stranded and no dust is left behind at hundreds of one-shot addresses.
+ *
+ *   2. TOP-UP (fallback). For tokens without `permit` — notably USDT on
+ *      Ethereum, which predates the standard — the relayer sends the derived
+ *      address just enough native currency to cover the transfer, then the
+ *      address sends the tokens itself. Leaves a little dust behind, which is
+ *      the price of supporting those tokens at all.
+ *
+ * Either way the platform advances the gas. It is reimbursed from the network
+ * fee already added to every quote (see computeGasReserve), so this is a float
+ * rather than a subsidy — provided that reserve is withheld before the
+ * merchant/platform split.
+ */
+
+import { ethers } from 'ethers';
+import { deriveGasRelayerWallet } from './system-wallet';
+import type { SystemBlockchain } from './system-wallet';
+
+/** Enough for an ERC20 transfer/transferFrom on any of the chains we support. */
+export const TOKEN_TRANSFER_GAS_LIMIT = 120_000n;
+/** `permit` is cheaper than a transfer but not free. */
+export const PERMIT_GAS_LIMIT = 100_000n;
+
+/**
+ * Headroom on the gas top-up. Gas price can rise between funding the address
+ * and spending from it; under-funding strands the payment a second time, and
+ * the leftover is pennies.
+ */
+const TOPUP_BUFFER_MULTIPLIER = 3n;
+
+export const ERC20_ABI = [
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function transferFrom(address from, address to, uint256 amount) returns (bool)',
+  'function balanceOf(address owner) view returns (uint256)',
+  'function nonces(address owner) view returns (uint256)',
+  'function name() view returns (string)',
+  'function version() view returns (string)',
+  'function DOMAIN_SEPARATOR() view returns (bytes32)',
+  'function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)',
+];
+
+export interface GasRelayer {
+  wallet: ethers.Wallet;
+  address: string;
+  balance: bigint;
+}
+
+/**
+ * The relayer for a chain, connected to a provider, with its balance read.
+ * Callers decide whether the balance is sufficient — a relayer that is broke is
+ * still worth reporting on, because "top up the float" is the actionable error.
+ */
+export async function getGasRelayer(
+  cryptocurrency: SystemBlockchain,
+  provider: ethers.Provider,
+): Promise<GasRelayer> {
+  const { privateKey, address } = deriveGasRelayerWallet(cryptocurrency);
+  const wallet = new ethers.Wallet(`0x${privateKey.replace(/^0x/, '')}`, provider);
+  const balance = await provider.getBalance(address);
+  return { wallet, address, balance };
+}
+
+/** Current gas price, preferring EIP-1559 fields where the chain exposes them. */
+export async function currentGasPrice(provider: ethers.Provider): Promise<bigint> {
+  const fee = await provider.getFeeData();
+  return fee.maxFeePerGas ?? fee.gasPrice ?? 0n;
+}
+
+/**
+ * Resolve the EIP-712 domain a token actually uses for `permit`.
+ *
+ * The domain must match the token's own `DOMAIN_SEPARATOR()` exactly or the
+ * signature is rejected on-chain, and tokens disagree about the `version`
+ * field ("1" vs "2") with no reliable way to read it — `version()` is not part
+ * of EIP-2612 and many deployments omit it. So rather than guess, build each
+ * candidate domain, hash it, and keep the one the contract confirms. A token
+ * that matches nothing does not support permit as far as we are concerned.
+ */
+export async function resolvePermitDomain(
+  token: ethers.Contract,
+  chainId: bigint,
+): Promise<ethers.TypedDataDomain | null> {
+  let onChainSeparator: string;
+  let name: string;
+  try {
+    [onChainSeparator, name] = await Promise.all([
+      token.DOMAIN_SEPARATOR(),
+      token.name(),
+    ]);
+  } catch {
+    return null; // no DOMAIN_SEPARATOR/name → not an EIP-2612 token
+  }
+
+  const verifyingContract = await token.getAddress();
+  const candidates: ethers.TypedDataDomain[] = [];
+
+  // Some tokens expose version() — try it first, then the common literals.
+  let declaredVersion: string | null = null;
+  try {
+    declaredVersion = await token.version();
+  } catch {
+    /* not exposed */
+  }
+  for (const version of [declaredVersion, '1', '2'].filter(Boolean) as string[]) {
+    candidates.push({ name, version, chainId, verifyingContract });
+    // Polygon's bridged tokens use a salt-based domain with no chainId field.
+    candidates.push({
+      name,
+      version,
+      verifyingContract,
+      salt: ethers.zeroPadValue(ethers.toBeHex(chainId), 32),
+    });
+  }
+
+  for (const domain of candidates) {
+    try {
+      if (ethers.TypedDataEncoder.hashDomain(domain) === onChainSeparator) return domain;
+    } catch {
+      /* malformed candidate — keep looking */
+    }
+  }
+  return null;
+}
+
+export interface RelayedTransferResult {
+  txHashes: string[];
+  relayerAddress: string;
+  gasSpentWei: bigint;
+}
+
+/**
+ * Move tokens out of `owner` without `owner` ever holding native currency.
+ *
+ * Signs an EIP-2612 permit with the owner's key (off-chain, free), then has the
+ * relayer pull the funds with `transferFrom`. Returns null — rather than
+ * throwing — when the token does not support permit, so the caller can fall
+ * back to the top-up path without treating it as an error.
+ */
+export async function forwardTokenViaRelayer(params: {
+  cryptocurrency: SystemBlockchain;
+  provider: ethers.Provider;
+  ownerPrivateKey: string;
+  tokenAddress: string;
+  recipients: Array<{ address: string; amount: bigint }>;
+}): Promise<RelayedTransferResult | null> {
+  const { cryptocurrency, provider, ownerPrivateKey, tokenAddress, recipients } = params;
+
+  const owner = new ethers.Wallet(
+    ownerPrivateKey.startsWith('0x') ? ownerPrivateKey : `0x${ownerPrivateKey}`,
+    provider,
+  );
+  const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  const { chainId } = await provider.getNetwork();
+
+  const domain = await resolvePermitDomain(token, chainId);
+  if (!domain) return null;
+
+  const relayer = await getGasRelayer(cryptocurrency, provider);
+  const total = recipients.reduce((sum, r) => sum + r.amount, 0n);
+  if (total <= 0n) return null;
+
+  // permit + one transferFrom per recipient.
+  const gasPrice = await currentGasPrice(provider);
+  const estimated =
+    (PERMIT_GAS_LIMIT + TOKEN_TRANSFER_GAS_LIMIT * BigInt(recipients.length)) * gasPrice;
+  if (relayer.balance < estimated) {
+    throw new Error(
+      `Gas relayer ${relayer.address} has ${ethers.formatEther(relayer.balance)} but needs ` +
+        `~${ethers.formatEther(estimated)} for ${cryptocurrency}. Top up the relayer.`,
+    );
+  }
+
+  const nonce: bigint = await token.nonces(owner.address);
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+
+  const signature = await owner.signTypedData(
+    domain,
+    {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    },
+    { owner: owner.address, spender: relayer.address, value: total, nonce, deadline },
+  );
+  const { v, r, s } = ethers.Signature.from(signature);
+
+  const relayerToken = token.connect(relayer.wallet) as ethers.Contract;
+  const txHashes: string[] = [];
+  let gasSpentWei = 0n;
+
+  const permitTx = await relayerToken.permit(
+    owner.address, relayer.address, total, deadline, v, r, s,
+    { gasLimit: PERMIT_GAS_LIMIT },
+  );
+  const permitReceipt = await permitTx.wait();
+  if (!permitReceipt || permitReceipt.status !== 1) {
+    throw new Error(`permit reverted for ${owner.address} (${permitTx.hash})`);
+  }
+  gasSpentWei += BigInt(permitReceipt.gasUsed) * BigInt(permitReceipt.gasPrice ?? 0);
+
+  for (const recipient of recipients) {
+    if (recipient.amount <= 0n) continue;
+    const tx = await relayerToken.transferFrom(
+      owner.address, recipient.address, recipient.amount,
+      { gasLimit: TOKEN_TRANSFER_GAS_LIMIT },
+    );
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error(`transferFrom reverted paying ${recipient.address} (${tx.hash})`);
+    }
+    gasSpentWei += BigInt(receipt.gasUsed) * BigInt(receipt.gasPrice ?? 0);
+    txHashes.push(tx.hash);
+  }
+
+  return { txHashes, relayerAddress: relayer.address, gasSpentWei };
+}
+
+/**
+ * Fallback for tokens without `permit`: send the derived address enough native
+ * currency to pay for its own transfers.
+ *
+ * Returns the top-up transaction hash, or null when the address already has
+ * enough. Throws with an actionable message when the relayer itself is broke —
+ * that is an operational problem (top up the float), not a payment problem.
+ */
+export async function ensureGasForTransfers(params: {
+  cryptocurrency: SystemBlockchain;
+  provider: ethers.Provider;
+  address: string;
+  transferCount: number;
+}): Promise<string | null> {
+  const { cryptocurrency, provider, address, transferCount } = params;
+
+  const gasPrice = await currentGasPrice(provider);
+  const needed = TOKEN_TRANSFER_GAS_LIMIT * BigInt(Math.max(1, transferCount)) * gasPrice;
+  const balance = await provider.getBalance(address);
+  if (balance >= needed) return null;
+
+  const shortfall = (needed - balance) * TOPUP_BUFFER_MULTIPLIER;
+  const relayer = await getGasRelayer(cryptocurrency, provider);
+
+  // The relayer needs the top-up *and* gas to send it.
+  const sendCost = 21_000n * gasPrice;
+  if (relayer.balance < shortfall + sendCost) {
+    throw new Error(
+      `Gas relayer ${relayer.address} has ${ethers.formatEther(relayer.balance)} but needs ` +
+        `~${ethers.formatEther(shortfall + sendCost)} to fund ${address} on ${cryptocurrency}. ` +
+        `Top up the relayer.`,
+    );
+  }
+
+  const tx = await relayer.wallet.sendTransaction({ to: address, value: shortfall });
+  const receipt = await tx.wait();
+  if (!receipt || receipt.status !== 1) {
+    throw new Error(`Gas top-up to ${address} failed (${tx.hash})`);
+  }
+  console.log(
+    `[GAS] Topped up ${address} with ${ethers.formatEther(shortfall)} from relayer ${relayer.address} (${tx.hash})`,
+  );
+  return tx.hash;
+}
+
+/**
+ * The slice of a token payment that belongs to the platform as reimbursement
+ * for gas, in token units.
+ *
+ * Every quote already adds an estimated network fee on top of the invoice
+ * amount (see createPayment), so the payer has funded this. On chains where the
+ * fee and the funds are the same asset — BTC, SOL, native ETH — it is consumed
+ * automatically by the sweep. For tokens it arrives as more *token*, which
+ * cannot pay gas, so it has to be withheld here and handed to the platform
+ * instead of being split 99/1 with the merchant. Withholding it is what makes
+ * the relayer float self-sustaining rather than a subsidy.
+ *
+ * Returns 0 when the metadata does not describe a surcharge, which keeps older
+ * payments splitting exactly as they do today.
+ */
+export function computeGasReserve(
+  cryptoAmount: number,
+  metadata: Record<string, unknown> | null | undefined,
+): number {
+  const feeUsd = Number(metadata?.network_fee_usd);
+  const totalUsd = Number(metadata?.total_amount_usd);
+  if (![feeUsd, totalUsd, cryptoAmount].every(Number.isFinite)) return 0;
+  if (feeUsd <= 0 || totalUsd <= 0 || cryptoAmount <= 0) return 0;
+
+  const reserve = cryptoAmount * (feeUsd / totalUsd);
+  // Guard against malformed metadata turning a payment into all-fee.
+  return Math.min(reserve, cryptoAmount * 0.5);
+}

--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -31,6 +31,12 @@ import { getProvider, getRpcUrl, type BlockchainType, SolanaProvider, BitcoinPro
 import { splitTieredPayment } from '../payments/fees';
 import { sendPaymentWebhook } from '../webhooks/service';
 import { isBusinessPaidTier } from '../entitlements/service';
+import {
+  computeGasReserve,
+  ensureGasForTransfers,
+  forwardTokenViaRelayer,
+} from './evm-gas';
+import type { SystemBlockchain } from './system-wallet';
 
 const EVM_TOKEN_CONFIG = {
   USDT: { contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7', decimals: 6 },
@@ -180,15 +186,59 @@ async function forwardEVMTokenSplit(
 ): Promise<{ merchantTxHash?: string; platformTxHash?: string }> {
   const config = EVM_TOKEN_CONFIG[chain as keyof typeof EVM_TOKEN_CONFIG];
   const provider = new ethers.JsonRpcProvider(rpcUrl);
+
+  const payouts = recipients
+    .map((r) => ({ address: r.address, amount: toTokenUnits(r.amount, config.decimals) }))
+    .filter((r) => r.amount > 0n);
+
+  if (payouts.length === 0) {
+    return { merchantTxHash: undefined, platformTxHash: undefined };
+  }
+
+  // Preferred: the relayer pulls the funds with permit + transferFrom, so the
+  // derived address never needs native currency and no dust is left behind.
+  try {
+    const relayed = await forwardTokenViaRelayer({
+      cryptocurrency: chain as SystemBlockchain,
+      provider,
+      ownerPrivateKey: privateKey,
+      tokenAddress: config.contractAddress,
+      recipients: payouts,
+    });
+
+    if (relayed) {
+      console.log(
+        `[SECURE] Forwarded ${chain} via relayer ${relayed.relayerAddress} ` +
+          `(gas ${ethers.formatEther(relayed.gasSpentWei)})`,
+      );
+      return {
+        merchantTxHash: relayed.txHashes[0],
+        platformTxHash: relayed.txHashes[1] || relayed.txHashes[0],
+      };
+    }
+  } catch (relayError) {
+    // A broke relayer is an operational problem and the fallback needs the same
+    // float, so there is nothing to gain by retrying the other path — surface it.
+    const msg = relayError instanceof Error ? relayError.message : String(relayError);
+    if (msg.includes('Top up the relayer')) throw relayError;
+    console.error(`[SECURE] Relayer path failed for ${chain}, falling back to gas top-up: ${msg}`);
+  }
+
+  // Fallback for tokens without permit (USDT on Ethereum predates EIP-2612):
+  // fund the address, then let it send for itself.
+  await ensureGasForTransfers({
+    cryptocurrency: chain as SystemBlockchain,
+    provider,
+    address: new ethers.Wallet(privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`).address,
+    transferCount: payouts.length,
+  });
+
   const wallet = new ethers.Wallet(privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`, provider);
   const token = new ethers.Contract(config.contractAddress, ERC20_TRANSFER_ABI, wallet);
 
   const txHashes: string[] = [];
-  for (const recipient of recipients) {
-    const amountUnits = toTokenUnits(recipient.amount, config.decimals);
-    if (amountUnits <= 0n) continue;
-
-    const tx = await token.transfer(recipient.address, amountUnits);
+  for (const recipient of payouts) {
+    const tx = await token.transfer(recipient.address, recipient.amount);
     await tx.wait();
     txHashes.push(tx.hash);
   }
@@ -408,10 +458,27 @@ export async function forwardPaymentSecurely(
     // Paid tier (Professional) = 0.5% commission, Free tier (Starter) = 1% commission
     const isPaidTier = await isBusinessPaidTier(supabase, payment.business_id);
 
-    // Calculate split amounts based on subscription tier
-    const { merchantAmount, platformFee, feePercentage } = splitTieredPayment(payment.crypto_amount, isPaidTier);
+    // Withhold the gas reserve before splitting — token payments only.
+    //
+    // Every quote already adds an estimated network fee on top of the invoice
+    // amount. On chains where the fee and the funds are the same asset it is
+    // consumed by the sweep itself, so there is nothing to withhold. For tokens
+    // it arrives as more *token*, which cannot pay gas, so the platform has to
+    // advance native currency and recover it here. Splitting the surcharge 99/1
+    // like the rest of the payment — which is what used to happen — handed 99%
+    // of the gas money to the merchant and left the float permanently short.
+    const gasReserve = isEVMToken(addressData.cryptocurrency)
+      ? computeGasReserve(payment.crypto_amount, payment.metadata)
+      : 0;
+
+    const split = splitTieredPayment(payment.crypto_amount - gasReserve, isPaidTier);
+    const { merchantAmount, feePercentage } = split;
+    const platformFee = split.platformFee + gasReserve;
 
     console.log(`[SECURE] Commission rate for business ${payment.business_id}: ${feePercentage * 100}% (${isPaidTier ? 'paid' : 'free'} tier)`);
+    if (gasReserve > 0) {
+      console.log(`[SECURE] Withholding ${gasReserve} ${addressData.cryptocurrency} as gas reserve`);
+    }
 
     // Get blockchain provider
     const rpcUrl = getRpcUrl(addressData.cryptocurrency);

--- a/src/lib/wallets/system-wallet.ts
+++ b/src/lib/wallets/system-wallet.ts
@@ -669,6 +669,43 @@ async function deriveCardanoWallet(
 /**
  * Derive a unique payment address from the system's HD wallet
  */
+/**
+ * BIP44 account 1 is reserved for the gas relayer.
+ *
+ * Payment addresses live at `m/44'/60'/0'/0/{index}` with the index handed out
+ * by the family counter, so the relayer must not sit anywhere in that account —
+ * a counter that ever reached the relayer's index would hand a customer the
+ * wallet holding the platform's gas float. Account 1 is a space the counter
+ * can never enter.
+ */
+export const GAS_RELAYER_DERIVATION_PATH = "m/44'/60'/1'/0/0";
+
+/**
+ * Derive the EVM gas relayer for a chain.
+ *
+ * Same mnemonic as the chain's payment addresses (so there is no extra secret
+ * to provision or rotate), different BIP44 account. This is the wallet that
+ * pays gas on behalf of derived addresses that hold only tokens.
+ */
+export function deriveGasRelayerWallet(
+  cryptocurrency: SystemBlockchain,
+): { address: string; privateKey: string } {
+  const mnemonic = getSystemMnemonic(cryptocurrency);
+  const seed = mnemonicToSeedSync(mnemonic);
+  const hdKey = HDKey.fromMasterSeed(seed);
+  const child = hdKey.derive(GAS_RELAYER_DERIVATION_PATH);
+
+  if (!child.privateKey) {
+    throw new Error(`Failed to derive gas relayer for ${cryptocurrency}`);
+  }
+
+  const privateKeyHex = Buffer.from(child.privateKey).toString('hex');
+  return {
+    address: new ethers.Wallet(`0x${privateKeyHex}`).address,
+    privateKey: privateKeyHex,
+  };
+}
+
 export async function deriveSystemPaymentAddress(
   cryptocurrency: SystemBlockchain,
   index: number


### PR DESCRIPTION
An ERC20 transfer is paid for in the chain's native currency by the **sending** address. Derived payment addresses only ever receive the token, so `token.transfer()` reverts on intrinsic gas cost — and does so identically on every retry, so the retry queue never rescues it.

## Approach

**Primary — relayer.** EIP-2612 `permit` lets the derived address authorise a spender with an off-chain signature: no gas, and the key is already held. The relayer then calls `transferFrom` and pays the gas itself. Native currency never touches the derived address, so nothing is left behind and no dust accumulates across one-shot addresses.

**Fallback — top-up.** For tokens without `permit` (USDT on Ethereum predates EIP-2612), the relayer sends the address just enough native currency to transfer for itself.

## Relayer key

Derived from each chain's existing `SYSTEM_MNEMONIC` at BIP44 **account 1** (`m/44'/60'/1'/0/0`) — no new secret to provision or rotate.

Account 1 is deliberately outside the space the payment-address family counter allocates from (account 0). A counter that ever reached the relayer's index would otherwise hand a customer the wallet holding the gas float.

## The float is self-funding

Every quote already adds an estimated network fee. On chains where the fee and the funds are the same asset it's consumed by the sweep. For tokens it arrives as more *token*, and was then split 99/1 like the rest of the payment — handing most of the gas money to the merchant and leaving the float permanently short.

`computeGasReserve` withholds that surcharge before the split and assigns it to the platform, so the merchant nets exactly the invoice amount and the float recovers what it advanced. Native chains are untouched: withholding there would double-charge.

## Permit domain resolution

The EIP-712 domain must match the token's own `DOMAIN_SEPARATOR()` exactly or the signature is rejected on-chain, and tokens disagree about the `version` field with no reliable way to read it — `version()` isn't part of EIP-2612 and many deployments omit it. Rather than guess, candidate domains are hashed and compared against the contract's own separator; a token matching none is treated as not supporting permit and takes the fallback.

## Before merging

The relayer needs a native balance on every chain where tokens are accepted, or token forwards fail. Its address is `deriveGasRelayerWallet(chain).address` — BIP44 account 1 as above, derived from the same mnemonic already in the environment.

## Testing

- `tsc --noEmit` clean, eslint 0 errors
- Changed areas: 12 files / 186 tests passing
- New `evm-gas.test.ts` (10 tests) covers reserve maths — including that the merchant nets the invoice amount after the split, that missing or malformed metadata leaves the split unchanged, and that the reserve is capped — plus permit-domain resolution across version 1, version 2, no-match, and no-`DOMAIN_SEPARATOR` tokens
