### PR TITLE
fix(deps): unstick the four failing Dependabot security updates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   picomatch: '>=4.0.4'
   flatted: '>=3.4.2'
   h3: '>=1.15.11'
-  socket.io-parser: '>=4.2.6'
+  socket.io-parser: '>=4.2.7'
   minimatch: '>=9.0.9'
   rollup: '>=4.60.1'
   bn.js: '>=5.2.3'
@@ -23,12 +23,13 @@ overrides:
   postcss: '>=8.5.10'
   follow-redirects: '>=1.16.0'
   uuid: '>=14.0.0'
-  ip-address: '>=10.1.1'
+  ip-address: '>=10.3.1'
   ws@>=8.0.0: '>=8.20.1'
-  dompurify: '>=3.4.12'
+  dompurify: '>=3.4.13'
   js-yaml: '>=4.3.1'
   ws@>=7.0.0 <8.0.0: '>=7.5.10'
   ws@<7.0.0: '>=6.2.3'
+  nanoid@>=3.0.0 <4.0.0: '>=3.3.18 <4.0.0'
   tar: '>=7.5.22'
   form-data: '>=4.0.6'
   ua-parser-js: '>=2.0.10'
@@ -4510,8 +4511,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5309,8 +5310,8 @@ packages:
   iobuffer@5.4.0:
     resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   iron-webcrypto@1.2.1:
@@ -6034,8 +6035,8 @@ packages:
   nan@2.23.1:
     resolution: {integrity: sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6951,8 +6952,8 @@ packages:
     resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socks-proxy-agent@8.0.5:
@@ -13434,7 +13435,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -14498,7 +14499,7 @@ snapshots:
 
   iobuffer@5.4.0: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -14896,7 +14897,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       html2canvas: 1.4.1
 
   jsqr@1.4.0: {}
@@ -15357,7 +15358,7 @@ snapshots:
 
   nan@2.23.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -15731,13 +15732,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -15746,7 +15747,7 @@ snapshots:
       '@posthog/core': 1.30.9
       '@posthog/types': 1.381.0
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.29.1
       query-selector-shadow-dom: 1.0.1
@@ -16458,13 +16459,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.7(supports-color@8.1.1)
       engine.io-client: 6.6.3(bufferutil@4.0.9)(supports-color@8.1.1)(utf-8-validate@5.0.10)
-      socket.io-parser: 4.2.6(supports-color@8.1.1)
+      socket.io-parser: 4.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6(supports-color@8.1.1):
+  socket.io-parser@4.2.7(supports-color@8.1.1):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -16481,7 +16482,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   sodium-native@4.3.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   picomatch: '>=4.0.4'
   flatted: '>=3.4.2'
   h3: '>=1.15.11'
-  socket.io-parser: '>=4.2.6'
+  socket.io-parser: '>=4.2.7'
   minimatch: '>=9.0.9'
   rollup: '>=4.60.1'
   bn.js: '>=5.2.3'
@@ -35,12 +35,21 @@ overrides:
   postcss: '>=8.5.10'
   follow-redirects: '>=1.16.0'
   uuid: '>=14.0.0'
-  ip-address: '>=10.1.1'
+  ip-address: '>=10.3.1'
   'ws@>=8.0.0': '>=8.20.1'
   # Added while re-homing the block — these had open alerts but no prior pin.
   # Kept within the current major of each package so nothing has to change at
   # the call sites; the alerts are all fixed in patch releases.
-  dompurify: '>=3.4.12'
+  #
+  # NOTE ON FLOORS: a '>=X' override does not keep itself current. pnpm resolves
+  # it once, writes the result to pnpm-lock.yaml, and thereafter the lockfile is
+  # authoritative — so when a new advisory lands on the exact version that was
+  # locked, the tree stays vulnerable and Dependabot reports
+  # `security_update_not_possible` ("latest resolvable" equal to our floor)
+  # rather than opening a PR. socket.io-parser, ip-address and dompurify all
+  # failed that way. Raise the floor past the vulnerable range and re-run
+  # `pnpm install` to force a re-resolve; bumping the floor alone is not enough.
+  dompurify: '>=3.4.13'
   # All versions, not just 4.x. The remaining 3.15.0 copy came in via
   # @istanbuljs/load-nyc-config -> babel-plugin-istanbul, i.e. coverage tooling
   # that never runs in production. Forcing it to 4.x crosses a major, so the
@@ -48,6 +57,18 @@ overrides:
   js-yaml: '>=4.3.1'
   'ws@>=7.0.0 <8.0.0': '>=7.5.10'
   'ws@<7.0.0': '>=6.2.3'
+  # Both halves are bounded, and both bounds matter.
+  #
+  # The only consumer is postcss, which asks for '^3.3.11'. nanoid dropped CJS
+  # after v3, so pulling in 4+ makes postcss — and with it Next, Tailwind,
+  # autoprefixer and Vite — fail to require it.
+  #
+  # The selector on the left ('nanoid@>=3.0.0 <4.0.0') only chooses WHICH
+  # dependency ranges this rule applies to. It does not constrain the result:
+  # with a replacement of '>=3.3.18', pnpm still resolved to the highest match
+  # published, which is 6.0.1. The upper bound on the RIGHT is what keeps the
+  # resolution inside the 3.x line. Same trap as brace-expansion above.
+  'nanoid@>=3.0.0 <4.0.0': '>=3.3.18 <4.0.0'
   tar: '>=7.5.22'
   form-data: '>=4.0.6'
   ua-parser-js: '>=2.0.10'


### PR DESCRIPTION
Fixes the four failing **Dependabot Updates** jobs on the Actions tab.

## What was actually wrong

All four failed with `security_update_not_possible`, and in every case the "latest resolvable version" Dependabot reported was **exactly the floor in our own override**:

| package | locked | our floor | fix |
|---|---|---|---|
| `socket.io-parser` | 4.2.6 | `>=4.2.6` | 4.2.7 |
| `ip-address` | 10.2.0 | `>=10.1.1` | 10.3.1 (clears 3 overlapping alerts) |
| `dompurify` | 3.4.12 | `>=3.4.12` | 3.4.13 |
| `nanoid` | 3.3.16 | *(no pin)* | 3.3.18 |

A `>=X` override **does not keep itself current**. pnpm resolves it once, writes the result to `pnpm-lock.yaml`, and the lockfile is authoritative from then on. When an advisory later lands on the exact version that was locked, the tree stays vulnerable *and* Dependabot cannot fix it — it sees a manifest constraint it can't move and gives up instead of opening a PR. So the override that was supposed to protect us was the thing pinning us to the vulnerable version.

Raising the floor past the vulnerable range and re-running `pnpm install` forces the re-resolve. I've written that up in the file so the next person doesn't have to rediscover it.

## The nanoid trap

Pinned as `'nanoid@>=3.0.0 <4.0.0': '>=3.3.18 <4.0.0'`. **Both bounds are load-bearing**, and I got this wrong on the first attempt:

- the selector on the **left** only chooses which dependency ranges the rule applies to;
- it does **not** constrain the result. With a replacement of `>=3.3.18`, pnpm resolved to **6.0.1**.

nanoid dropped CJS after v3, and its only consumer here is postcss (`^3.3.11`) — so 6.x would break postcss and with it Next, Tailwind, autoprefixer and Vite. The upper bound on the **right** is what holds it to the 3.x line. This is the same trap already documented above for `brace-expansion`.

## Verification

- `pnpm type-check` clean
- `vitest run` — 4038 passing, 3 skipped, 0 failing
- `pnpm build` succeeds — this is the one that actually matters here, since it's what exercises postcss/Tailwind against the new nanoid

Resolved in the lockfile: `dompurify@3.4.13`, `ip-address@10.4.0`, `nanoid@3.3.18`, `socket.io-parser@4.2.7`.

## Still open, deliberately

`image-size` — no patched release exists upstream (both CVEs affect `<= 2.0.2`, the newest published). It stays documented in `pnpm-workspace.yaml` with its reachability analysis rather than pinned to a version that fixes nothing. Its Dependabot alert will remain open until upstream ships a fix, or until the four unused `@solana/wallet-adapter-*` packages that drag in the chain are dropped.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
