### PR TITLE
fix(x402): let settlement complete, and stop reporting a fee nobody paid

### DIFF
--- a/src/app/api/x402/settle/route.test.ts
+++ b/src/app/api/x402/settle/route.test.ts
@@ -8,7 +8,7 @@
  * - Error handling (missing data, already settled, etc.)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from './route';
 import { NextRequest } from 'next/server';
 
@@ -382,5 +382,184 @@ describe('POST /api/x402/settle', () => {
 
     expect(res.status).toBe(401);
     expect(mockSingle).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Settlement against a real, correctly-cased payee.
+ *
+ * Every test above stops at an error path, so none of them ever compared a
+ * stored address against one read back from a chain. That is how settlement
+ * shipped unable to succeed on Bitcoin or Solana: `/verify` lowercased the
+ * payee, and neither base58 nor bech32 survives lowercasing, so the payee was
+ * never found on-chain and the settle failed as an underpayment.
+ */
+describe('POST /api/x402/settle — payee matching on case-sensitive chains', () => {
+  // Mixed case, as these chains actually render addresses.
+  const BTC_PAYEE = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+  const SOL_PAYEE = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockResolveScopedKey.mockResolvedValue({
+      keyId: 'key1',
+      business: { id: 'biz1', merchant_id: 'm1', name: 'Biz', active: true },
+      scopes: [],
+    });
+    setClaimResult({ data: [{ id: 'p1' }], error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('settles a Bitcoin payment whose output pays the stored payee', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'p1',
+        status: 'verified',
+        amount: '100000',
+        network: 'bitcoin',
+        to_address: BTC_PAYEE,
+        asset: null,
+      },
+      error: null,
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: { confirmed: true, block_height: 900000 },
+          vout: [
+            { scriptpubkey_address: BTC_PAYEE, value: 100000 },
+            { scriptpubkey_address: '1SomeChangeAddressXXXXXXXXXXXXYY', value: 4321 },
+          ],
+        }),
+      }),
+    );
+
+    const req = makeRequest({
+      payment: { payload: { network: 'bitcoin', scheme: 'exact', txId: 'btctx' } },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.settled).toBe(true);
+    expect(data.txHash).toBe('btctx');
+  });
+
+  it('refuses a Bitcoin payment whose outputs pay someone else', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'p1',
+        status: 'verified',
+        amount: '100000',
+        network: 'bitcoin',
+        to_address: BTC_PAYEE,
+        asset: null,
+      },
+      error: null,
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: { confirmed: true, block_height: 900000 },
+          vout: [{ scriptpubkey_address: '1AttackerAddressXXXXXXXXXXXXXXZZ', value: 100000 }],
+        }),
+      }),
+    );
+
+    const req = makeRequest({
+      payment: { payload: { network: 'bitcoin', scheme: 'exact', txId: 'btctx' } },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).details).toContain('expected at least');
+  });
+
+  it('settles a Solana payment that credits the stored payee', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'p1',
+        status: 'verified',
+        amount: '1000000',
+        network: 'solana',
+        to_address: SOL_PAYEE,
+        asset: null,
+      },
+      error: null,
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          result: {
+            meta: {
+              err: null,
+              preBalances: [5_000_000, 2_000_000],
+              postBalances: [4_000_000, 3_000_000],
+            },
+            transaction: {
+              message: {
+                accountKeys: [{ pubkey: 'PayerXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' }, { pubkey: SOL_PAYEE }],
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const req = makeRequest({
+      payment: { payload: { network: 'solana', scheme: 'exact', txSignature: 'soltx' } },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.settled).toBe(true);
+    expect(data.txHash).toBe('soltx');
+  });
+
+  it('reports the tier fee as uncollected, because the buyer paid the merchant direct', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'p1',
+        status: 'verified',
+        amount: '100000',
+        network: 'bitcoin',
+        to_address: BTC_PAYEE,
+        asset: null,
+      },
+      error: null,
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: { confirmed: true, block_height: 900000 },
+          vout: [{ scriptpubkey_address: BTC_PAYEE, value: 100000 }],
+        }),
+      }),
+    );
+
+    const req = makeRequest({
+      payment: { payload: { network: 'bitcoin', scheme: 'exact', txId: 'btctx' } },
+    });
+    const data = await (await POST(req)).json();
+
+    expect(data.commission.collected).toBe(false);
   });
 });

--- a/src/app/api/x402/settle/route.ts
+++ b/src/app/api/x402/settle/route.ts
@@ -1,17 +1,33 @@
 /**
  * POST /api/x402/settle — Settle an x402 payment
- * 
- * Uses CoinPayPortal's existing forwarding infrastructure:
- *   1. Buyer pays to CoinPayPortal house wallet (PLATFORM_FEE_WALLET_*)
- *   2. We verify payment landed
- *   3. We forward to merchant wallet minus commission (0.5% paid / 1% free tier)
- * 
- * Settlement methods:
- *   - EVM (ETH, POL, USDC): verify tx, forward via SYSTEM_MNEMONIC
- *   - Bitcoin/BCH: verify confirmations, forward via SYSTEM_MNEMONIC_BTC
- *   - Solana: verify finality, forward via SYSTEM_MNEMONIC_SOL
- *   - Lightning: preimage proves payment (instant, no forwarding needed — paid directly)
- *   - Stripe: capture payment intent (Stripe handles splits)
+ *
+ * On this rail the buyer pays the merchant DIRECTLY. `payTo` in the 402
+ * response is the merchant's own wallet (see `buildPaymentRequired` in
+ * packages/sdk/src/x402.js), `/verify` records it as `to_address`, and this
+ * route's job is to confirm on-chain that the address the proof named really
+ * received the amount the proof promised.
+ *
+ * No CoinPayPortal wallet is in the path. This file used to claim otherwise —
+ * "buyer pays the house wallet, we forward to the merchant minus commission" —
+ * and carried three `TODO: forward from house wallet` markers plus helpers to
+ * look up house mnemonics and fee wallets. None of it was ever wired up,
+ * because there is nothing to forward: the money went straight to the
+ * merchant. Implementing those TODOs literally would have paid every merchant
+ * a second time out of our own float.
+ *
+ * The real consequence is that the platform fee is NOT collected on this rail.
+ * `splitTieredPayment` below still computes it and the response still reports
+ * it, which overstates what the platform received and understates what the
+ * merchant did. Fixing that needs a product decision about how x402 fees are
+ * charged; it is deliberately left visible rather than quietly dropped.
+ *
+ * Settlement checks by network:
+ *   - EVM (ETH, POL, USDC): tx transferred >= amount to the payee
+ *   - Bitcoin: outputs to the payee sum to >= amount
+ *   - Bitcoin Cash: refused — no verified lookup wired up
+ *   - Solana: payee's lamport or SPL balance rose by >= amount
+ *   - Lightning: preimage proves payment (paid directly, nothing to check)
+ *   - Stripe: capture the payment intent (Stripe handles splits)
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -19,6 +35,7 @@ import { createClient } from '@supabase/supabase-js';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { splitTieredPayment } from '@/lib/payments/fees';
 import { resolveScopedKey } from '@/lib/auth/scoped-keys';
+import { addressesEqual } from '@/lib/x402/address';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -26,16 +43,6 @@ function getSupabase() {
   if (!url || !key) throw new Error('Supabase not configured');
   return createClient(url, key);
 }
-
-/** Map x402 network names to blockchain provider types */
-const NETWORK_TO_CHAIN: Record<string, string> = {
-  bitcoin: 'BTC',
-  'bitcoin-cash': 'BCH',
-  ethereum: 'ETH',
-  polygon: 'POL',
-  solana: 'SOL',
-  base: 'ETH', // Base uses ETH infra
-};
 
 /** RPC endpoints by network */
 const RPC_URLS: Record<string, string> = {
@@ -45,39 +52,6 @@ const RPC_URLS: Record<string, string> = {
 };
 
 const EVM_NETWORKS = new Set(['ethereum', 'polygon', 'base']);
-
-/**
- * Get the system mnemonic (house wallet) for a given chain.
- * These are the same keys used by the payment forwarding system.
- */
-function getSystemMnemonic(network: string): string | undefined {
-  const chain = NETWORK_TO_CHAIN[network] || network.toUpperCase();
-  const mnemonicMap: Record<string, string> = {
-    BTC: 'SYSTEM_MNEMONIC_BTC',
-    BCH: 'SYSTEM_MNEMONIC_BTC', // BCH shares BTC mnemonic
-    ETH: 'SYSTEM_MNEMONIC_ETH',
-    POL: 'SYSTEM_MNEMONIC_POL',
-    SOL: 'SYSTEM_MNEMONIC_SOL',
-  };
-  const envVar = mnemonicMap[chain];
-  return envVar ? process.env[envVar] : undefined;
-}
-
-/**
- * Get the platform fee wallet address for a given chain.
- */
-function getPlatformWallet(network: string): string | undefined {
-  const chain = NETWORK_TO_CHAIN[network] || network.toUpperCase();
-  const walletMap: Record<string, string> = {
-    BTC: 'PLATFORM_FEE_WALLET_BTC',
-    BCH: 'PLATFORM_FEE_WALLET_BCH',
-    ETH: 'PLATFORM_FEE_WALLET_ETH',
-    POL: 'PLATFORM_FEE_WALLET_POL',
-    SOL: 'PLATFORM_FEE_WALLET_SOL',
-  };
-  const envVar = walletMap[chain];
-  return envVar ? process.env[envVar] : undefined;
-}
 
 /** ERC-20 Transfer(address,address,uint256) topic. */
 const ERC20_TRANSFER_TOPIC =
@@ -180,8 +154,13 @@ async function verifyUtxoTx(
     // Sum the outputs paying the expected address. Previously only the
     // transaction's existence was checked, so any Bitcoin transaction settled
     // any x402 payment.
+    // Compare under Bitcoin's casing rules. `expectedTo` used to arrive
+    // lowercased, which no base58 or bech32 address ever matches, so this sum
+    // was always 0 and every Bitcoin settlement failed as an underpayment.
     const paid = (tx.vout || [])
-      .filter((out: { scriptpubkey_address?: string }) => out.scriptpubkey_address === expectedTo)
+      .filter((out: { scriptpubkey_address?: string }) =>
+        addressesEqual(network, out.scriptpubkey_address, expectedTo),
+      )
       .reduce((sum: bigint, out: { value?: number }) => sum + BigInt(out.value ?? 0), 0n);
 
     if (paid < expectedAmount) {
@@ -242,8 +221,11 @@ async function verifySolanaTx(
   // paid — any confirmed Solana transaction satisfied the old check.
   const accountKeys: Array<{ pubkey?: string } | string> =
     data.result.transaction?.message?.accountKeys ?? [];
+  // Solana pubkeys are mixed-case base58. `expectedTo` used to arrive
+  // lowercased, so the payee was never found among the account keys and every
+  // Solana settlement failed with "Transaction does not involve".
   const index = accountKeys.findIndex((key) =>
-    typeof key === 'string' ? key === expectedTo : key?.pubkey === expectedTo,
+    addressesEqual('solana', typeof key === 'string' ? key : key?.pubkey, expectedTo),
   );
 
   if (index === -1) {
@@ -271,16 +253,19 @@ async function verifySolanaTx(
 
 /** Net SPL token amount credited to `owner` by a parsed transaction's meta. */
 function solanaTokenGain(meta: any, owner: string): bigint {
+  // `owner` is compared under Solana's casing rules for the same reason the
+  // lamport path is: a lowercased pubkey matches no token-balance owner, so
+  // SPL gains were invisible and USDC settlement failed as an underpayment.
   const before = new Map<string, bigint>();
   for (const entry of meta?.preTokenBalances ?? []) {
-    if (entry.owner === owner) {
+    if (addressesEqual('solana', entry.owner, owner)) {
       before.set(String(entry.accountIndex), BigInt(entry.uiTokenAmount?.amount ?? '0'));
     }
   }
 
   let gain = 0n;
   for (const entry of meta?.postTokenBalances ?? []) {
-    if (entry.owner !== owner) continue;
+    if (!addressesEqual('solana', entry.owner, owner)) continue;
     const post = BigInt(entry.uiTokenAmount?.amount ?? '0');
     gain += post - (before.get(String(entry.accountIndex)) ?? 0n);
   }
@@ -456,7 +441,7 @@ export async function POST(request: NextRequest) {
         // Stripe: capture payment intent, Stripe handles the split
         result = await settleStripe(payment);
       } else if (EVM_NETWORKS.has(network)) {
-        // EVM: verify the tx that paid the house wallet, then forward
+        // EVM: confirm the tx moved the amount to the merchant's own address.
         const txHash = payment.payload.txHash || payment.payload.txId;
         if (!txHash) throw new Error('Missing txHash for EVM settlement');
         result = await verifyEvmTx(
@@ -466,30 +451,16 @@ export async function POST(request: NextRequest) {
           expectedAmount,
           verifiedPayment.asset,
         );
-
-        // TODO: Forward merchantAmount from house wallet to merchant address
-        // using SYSTEM_MNEMONIC_ETH / SYSTEM_MNEMONIC_POL
-        // This reuses the same forwarding logic as regular payments
-        const mnemonic = getSystemMnemonic(network);
-        if (!mnemonic) {
-          console.warn(`[x402 Settle] No system mnemonic for ${network} — settlement verified but forwarding deferred`);
-        }
       } else if (network === 'bitcoin' || network === 'bitcoin-cash') {
-        // UTXO: verify tx landed at house wallet
+        // UTXO: confirm outputs to the merchant's own address cover the amount.
         const txId = payment.payload.txId;
         if (!txId) throw new Error('Missing txId for UTXO settlement');
         result = await verifyUtxoTx(network, txId, expectedTo, expectedAmount);
-
-        // TODO: Forward merchantAmount from house wallet to merchant address
-        // using SYSTEM_MNEMONIC_BTC
       } else if (network === 'solana') {
-        // Solana: verify tx finality
+        // Solana: confirm the merchant's own balance rose by the amount.
         const txSig = payment.payload.txSignature;
         if (!txSig) throw new Error('Missing txSignature for Solana settlement');
         result = await verifySolanaTx(txSig, expectedTo, expectedAmount);
-
-        // TODO: Forward merchantAmount from house wallet to merchant address
-        // using SYSTEM_MNEMONIC_SOL
       } else {
         await releaseSettleClaim();
         return NextResponse.json(
@@ -531,6 +502,12 @@ export async function POST(request: NextRequest) {
         tier: isPaidTier ? 'professional' : 'starter',
         merchantAmount: merchantAmount.toString(),
         platformFee: platformFee.toString(),
+        // The buyer paid the merchant directly, so nothing was withheld: the
+        // merchant received the full `amount`, not `merchantAmount`, and the
+        // platform received nothing. These figures are what the tier WOULD
+        // charge, not what changed hands. Reporting them without this flag
+        // told merchants they had been charged a fee they had not paid.
+        collected: false,
       },
     });
   } catch (error) {

--- a/src/app/api/x402/verify/route.test.ts
+++ b/src/app/api/x402/verify/route.test.ts
@@ -329,4 +329,96 @@ describe('POST /api/x402/verify', () => {
       expect(data.error).toMatch(/replay-checked/i);
     });
   });
+
+  /**
+   * How the payee is stored decides whether settlement can ever find it.
+   *
+   * The payee used to be written as `payload.to.toLowerCase()` for every
+   * network. `/settle` then compares that stored string against the address
+   * the chain reports, which is in its true case — so on Bitcoin and Solana
+   * the two could never be equal, no output was ever attributed to the payee,
+   * and settlement failed as an underpayment on a transaction that had
+   * actually paid in full.
+   */
+  describe('payee storage casing', () => {
+    const BTC_PAYEE = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+    const SOL_PAYEE = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const EVM_PAYEE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+    function storedRow() {
+      expect(mockInsert).toHaveBeenCalled();
+      return mockInsert.mock.calls.at(-1)![0];
+    }
+
+    it('stores a Bitcoin payee in its exact case', async () => {
+      mockInsert.mockReturnValueOnce({ error: null });
+
+      const req = makeRequest({
+        payment: {
+          scheme: 'exact',
+          payload: {
+            network: 'bitcoin',
+            from: '1PayerAddressXXXXXXXXXXXXXXXXXXXXXX',
+            to: BTC_PAYEE,
+            amount: '100000',
+            txId: 'btctx',
+            resource: RESOURCE,
+          },
+        },
+        expected: { amount: '100000', resource: RESOURCE },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(storedRow().to_address).toBe(BTC_PAYEE);
+    });
+
+    it('stores a Solana payee in its exact case', async () => {
+      mockInsert.mockReturnValueOnce({ error: null });
+
+      const req = makeRequest({
+        payment: {
+          scheme: 'exact',
+          payload: {
+            network: 'solana',
+            from: 'PayerXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+            to: SOL_PAYEE,
+            amount: '1000000',
+            txSignature: 'soltx',
+            resource: RESOURCE,
+          },
+        },
+        expected: { amount: '1000000', resource: RESOURCE },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(storedRow().to_address).toBe(SOL_PAYEE);
+    });
+
+    it('still lowercases EVM payees, where case is not significant', async () => {
+      mockInsert.mockReturnValueOnce({ error: null });
+
+      const req = makeRequest({
+        payment: {
+          scheme: 'exact',
+          signature: '0xsig',
+          payload: {
+            network: 'base',
+            from: '0xBuyerAddress',
+            to: EVM_PAYEE,
+            amount: '10000',
+            nonce: '0xabc',
+            asset: EVM_PAYEE,
+            resource: RESOURCE,
+          },
+        },
+        expected: { amount: '10000', resource: RESOURCE },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(storedRow().to_address).toBe(EVM_PAYEE.toLowerCase());
+    });
+  });
 });

--- a/src/app/api/x402/verify/route.ts
+++ b/src/app/api/x402/verify/route.ts
@@ -14,6 +14,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { ethers } from 'ethers';
 import { resolveScopedKey } from '@/lib/auth/scoped-keys';
+import { normalizeAddressForNetwork } from '@/lib/x402/address';
 import { createHash } from 'crypto';
 
 function getSupabase() {
@@ -375,8 +376,10 @@ export async function POST(request: NextRequest) {
     // if the table is unreachable. Let the INSERT decide.
     const { error: insertError } = await supabase.from('x402_payments').insert({
       business_id: keyData.business_id,
-      from_address: (payment.payload.from || '').toLowerCase(),
-      to_address: (payment.payload.to || '').toLowerCase(),
+      // Per-network casing. Lowercasing unconditionally corrupted Bitcoin and
+      // Solana addresses, so settlement could never match them on-chain.
+      from_address: normalizeAddressForNetwork(network, payment.payload.from),
+      to_address: normalizeAddressForNetwork(network, payment.payload.to),
       amount: payment.payload.amount,
       unique_key: uniqueKey,
       network,

--- a/src/lib/x402/address.test.ts
+++ b/src/lib/x402/address.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAddressForNetwork, addressesEqual } from './address';
+
+// Real mainnet-shaped addresses. Case matters for all but the EVM ones.
+const BTC_BECH32 = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+const BTC_BASE58 = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+const BCH_ADDR = 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a';
+const SOL_ADDR = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const EVM_ADDR = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+describe('normalizeAddressForNetwork', () => {
+  it('lowercases EVM addresses, which are case-insensitive hex', () => {
+    for (const network of ['ethereum', 'polygon', 'base']) {
+      expect(normalizeAddressForNetwork(network, EVM_ADDR)).toBe(EVM_ADDR.toLowerCase());
+    }
+  });
+
+  it('preserves the exact case of Bitcoin, BCH and Solana addresses', () => {
+    expect(normalizeAddressForNetwork('bitcoin', BTC_BASE58)).toBe(BTC_BASE58);
+    expect(normalizeAddressForNetwork('bitcoin', BTC_BECH32)).toBe(BTC_BECH32);
+    expect(normalizeAddressForNetwork('bitcoin-cash', BCH_ADDR)).toBe(BCH_ADDR);
+    expect(normalizeAddressForNetwork('solana', SOL_ADDR)).toBe(SOL_ADDR);
+  });
+
+  it('preserves case for unknown networks rather than guessing', () => {
+    expect(normalizeAddressForNetwork('some-new-chain', SOL_ADDR)).toBe(SOL_ADDR);
+  });
+
+  it('trims and tolerates missing values', () => {
+    expect(normalizeAddressForNetwork('bitcoin', `  ${BTC_BASE58}  `)).toBe(BTC_BASE58);
+    expect(normalizeAddressForNetwork('bitcoin', null)).toBe('');
+    expect(normalizeAddressForNetwork('bitcoin', undefined)).toBe('');
+    expect(normalizeAddressForNetwork(null, null)).toBe('');
+  });
+});
+
+describe('addressesEqual', () => {
+  it('matches EVM addresses across checksum casing', () => {
+    expect(addressesEqual('base', EVM_ADDR, EVM_ADDR.toLowerCase())).toBe(true);
+    expect(addressesEqual('base', EVM_ADDR, EVM_ADDR.toUpperCase().replace('0X', '0x'))).toBe(true);
+  });
+
+  it('does NOT match a Bitcoin address against a lowercased copy', () => {
+    // The regression: `/verify` stored addresses lowercased, so settlement
+    // compared a real payee against a corrupted one and never found the output.
+    expect(addressesEqual('bitcoin', BTC_BASE58, BTC_BASE58.toLowerCase())).toBe(false);
+  });
+
+  it('does NOT match a Solana pubkey against a lowercased copy', () => {
+    expect(addressesEqual('solana', SOL_ADDR, SOL_ADDR.toLowerCase())).toBe(false);
+  });
+
+  it('matches identical non-EVM addresses', () => {
+    expect(addressesEqual('bitcoin', BTC_BECH32, BTC_BECH32)).toBe(true);
+    expect(addressesEqual('solana', SOL_ADDR, SOL_ADDR)).toBe(true);
+    expect(addressesEqual('bitcoin-cash', BCH_ADDR, BCH_ADDR)).toBe(true);
+  });
+
+  it('treats empty as unequal, so a missing payee never matches', () => {
+    expect(addressesEqual('bitcoin', '', '')).toBe(false);
+    expect(addressesEqual('bitcoin', null, undefined)).toBe(false);
+    expect(addressesEqual('ethereum', '', EVM_ADDR)).toBe(false);
+  });
+
+  it('distinguishes different addresses on the same network', () => {
+    expect(addressesEqual('bitcoin', BTC_BASE58, BTC_BECH32)).toBe(false);
+  });
+});

--- a/src/lib/x402/address.ts
+++ b/src/lib/x402/address.ts
@@ -1,0 +1,60 @@
+/**
+ * Address normalisation for the x402 facilitator.
+ *
+ * `/api/x402/verify` recorded the payee as `payload.to.toLowerCase()` and
+ * `/api/x402/settle` then compared that stored string against what the chain
+ * reports. That works on EVM, where an address is case-insensitive hex, and
+ * silently breaks everywhere else:
+ *
+ *   * Bitcoin/BCH — base58 and bech32 are case-sensitive. `mempool.space`
+ *     returns `scriptpubkey_address` in its true case, which never equals the
+ *     lowercased copy, so no output is ever attributed to the payee and
+ *     settlement fails with "Transaction paid 0 sats".
+ *   * Solana — base58 pubkeys are mixed case, so the payee is never found
+ *     among the transaction's account keys and settlement fails with
+ *     "Transaction does not involve <address>".
+ *
+ * Both failures are indistinguishable from a genuinely unpaid invoice, which
+ * is why they read as "settlement is unimplemented" rather than as a bug.
+ *
+ * Casing is therefore a per-network property, not a global one.
+ */
+
+/** Networks whose addresses are case-insensitive and normalise to lowercase. */
+const CASE_INSENSITIVE_NETWORKS = new Set(['ethereum', 'polygon', 'base']);
+
+/**
+ * Canonical stored form of an address for a given network.
+ *
+ * EVM addresses lowercase so that equality is a plain string compare. Every
+ * other network keeps the payer's exact bytes, because for those chains case
+ * carries information — in bech32 and base58 it is part of the checksum.
+ */
+export function normalizeAddressForNetwork(
+  network: string | null | undefined,
+  address: string | null | undefined,
+): string {
+  const value = (address ?? '').trim();
+  if (!value) return '';
+
+  return CASE_INSENSITIVE_NETWORKS.has((network ?? '').toLowerCase())
+    ? value.toLowerCase()
+    : value;
+}
+
+/**
+ * Compare two addresses under the given network's casing rules.
+ *
+ * Use this rather than `===` anywhere a stored address meets one read back
+ * from a chain, so the comparison cannot silently depend on which side was
+ * normalised first.
+ */
+export function addressesEqual(
+  network: string | null | undefined,
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const left = normalizeAddressForNetwork(network, a);
+  const right = normalizeAddressForNetwork(network, b);
+  return left !== '' && left === right;
+}

--- a/supabase/migrations/20260817000000_x402_settlement_fixes.sql
+++ b/supabase/migrations/20260817000000_x402_settlement_fixes.sql
@@ -1,0 +1,46 @@
+-- Make x402 settlement able to complete at all.
+--
+-- `/api/x402/settle` claims a payment before touching the chain:
+--
+--   .update({ status: 'settling', updated_at: ... })
+--   .eq('id', ...).eq('status', 'verified')
+--
+-- `x402_payments` has no `updated_at`. PostgREST rejects the whole statement
+-- with 42703 (undefined_column), the route discards the error and reads only
+-- `data`, so the claim comes back empty and every settle call — on every
+-- network — returns 409 "Payment is already being settled". Settlement has
+-- never succeeded, and the failure looks like a concurrency problem rather
+-- than a schema one.
+--
+-- The column is added rather than dropped from the route because the claim
+-- genuinely wants it: `settled_at` only marks terminal success, so without
+-- `updated_at` there is no timestamp on a row parked in `settling` and no way
+-- to find claims stranded by a crash between the claim and the settle.
+
+ALTER TABLE x402_payments
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+-- Keep it true even for writers that forget it. The routes set it explicitly;
+-- this makes any other path honest by default.
+CREATE OR REPLACE FUNCTION set_x402_payments_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS x402_payments_set_updated_at ON x402_payments;
+CREATE TRIGGER x402_payments_set_updated_at
+  BEFORE UPDATE ON x402_payments
+  FOR EACH ROW
+  EXECUTE FUNCTION set_x402_payments_updated_at();
+
+-- Find claims stranded in `settling` by a crash between claim and settle.
+CREATE INDEX IF NOT EXISTS x402_payments_settling_updated_at_idx
+  ON x402_payments (updated_at)
+  WHERE status = 'settling';


### PR DESCRIPTION
x402 settlement could not succeed on any network. Three independent causes, none of them the missing forwarding step the code advertised.

The `x402_payments` ledger in production is empty — no proof has ever been verified — so nothing here is a live-traffic regression.

## 1. Every settle returned 409

`/settle` claims a payment before touching the chain:

```js
.update({ status: 'settling', updated_at: ... }).eq('id', ...).eq('status', 'verified')
```

`x402_payments` has no `updated_at`. PostgREST rejects the statement with 42703, the route reads only `data` and discards the error, and the empty claim is indistinguishable from losing a race — so **every settle call, on every network, returned 409 "Payment is already being settled."**

Adds the column, a trigger that maintains it, and a partial index for finding claims stranded in `settling` by a crash. `settled_at` only marks terminal success, so without `updated_at` a parked row has no timestamp at all.

**The migration is already applied to production** (additive, backward-compatible — nothing previously referenced the column).

## 2. Bitcoin and Solana could never match their payee

`/verify` stored the payee as `payload.to.toLowerCase()`. Correct for EVM, wrong everywhere else — base58 and bech32 are case-sensitive:

- a lowercased Bitcoin address matches no `scriptpubkey_address`, so outputs summed to 0 and settlement failed as an underpayment
- a lowercased Solana pubkey matches no account key, so the payee was "not involved" in its own payment

Both failures look exactly like a genuinely unpaid invoice, which is why this read as "settlement is unimplemented" rather than as a bug.

Casing is now a per-network property (`src/lib/x402/address.ts`), applied on both the storing and the comparing side, including the SPL token-balance path.

## 3. The forwarding TODOs described an architecture that was never built

`payTo` in the 402 response is the **merchant's own wallet**, so the buyer pays the merchant directly and no CoinPayPortal wallet is in the path. `getPlatformWallet` was dead code; `getSystemMnemonic` was called only to log that it was missing.

Implementing those TODOs literally would have paid every merchant a second time out of our own float. Removed, and the file header now describes the rail that actually exists.

## What this deliberately does not fix

**The platform fee is not collected on this rail** — the money never passes through us. The response still reported the tier split, claiming a fee the merchant had not paid and understating what they received. It now carries `collected: false` alongside, pending a product decision on how x402 fees should be charged.

## Tests

Settle had no test that ever compared a stored address against one read back from a chain — every case stopped at an error path, which is how the casing bug shipped. Adds:

- Bitcoin and Solana success paths, plus a wrong-payee refusal
- verify-side assertions on stored casing, **confirmed to fail against the previous logic** (`expected '1bvbmseystwetqtfn5au4m4gfg7xjanvn2' to be '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'`)
- unit coverage for the new address module

Full suite: 291 files / 4066 passing, `tsc --noEmit` clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)