### PR TITLE
x402 v2 end-to-end: pay with CoinPay Wallet or MetaMask/Phantom, verify and settle EIP-3009

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,15 @@
     "./swap": {
       "import": "./src/swap.js",
       "types": "./src/swap.d.ts"
+    },
+    "./x402": {
+      "import": "./src/x402.js"
+    },
+    "./x402-v2": {
+      "import": "./src/x402-v2.js"
+    },
+    "./x402-browser": {
+      "import": "./src/x402-browser.js"
     }
   },
   "files": [

--- a/packages/sdk/src/x402-browser.js
+++ b/packages/sdk/src/x402-browser.js
@@ -1,0 +1,318 @@
+/**
+ * Browser-side x402 payer.
+ *
+ * Turns a 402 response into a paid retry, using whatever wallet the visitor
+ * actually has. CoinPay Wallet is preferred when present; otherwise any
+ * injected EIP-1193 wallet — MetaMask, Phantom's EVM provider, Rabby, Coinbase
+ * Wallet — can pay, because what gets signed is the standard EIP-3009
+ * authorization rather than anything CoinPay-specific.
+ *
+ * That interoperability is the whole point of signing the real structure. A
+ * bespoke payload would still be signable by MetaMask, but the resulting
+ * signature would authorise no transfer on-chain and only CoinPayPortal could
+ * interpret it — which is not a wallet integration, it is a lock-in.
+ *
+ * Usage:
+ *   const res = await fetchWithX402('https://api.example.com/premium');
+ *
+ * @module x402-browser
+ */
+
+import {
+  buildAuthorization,
+  buildEip3009Domain,
+  buildExactEvmPayment,
+  encodePaymentHeader,
+  evmChainId,
+  requiredAmount,
+  selectAcceptEntry,
+  toCaip2,
+  TRANSFER_WITH_AUTHORIZATION_TYPES,
+} from './x402-v2.js';
+
+/** How long a discovery sweep waits for EIP-6963 wallets to announce. */
+const EIP6963_ANNOUNCE_MS = 100;
+
+/**
+ * Enumerate injected EVM wallets via EIP-6963.
+ *
+ * Before EIP-6963 every wallet raced to own `window.ethereum`, so with two
+ * installed you got whichever won — the user could not choose, and a site
+ * could not tell which it had. EIP-6963 has each wallet announce itself with
+ * its own provider object instead.
+ *
+ * `window.ethereum` is still included as a last resort, for wallets that have
+ * not adopted the standard.
+ */
+export async function discoverEvmWallets({ timeoutMs = EIP6963_ANNOUNCE_MS } = {}) {
+  const found = new Map();
+
+  if (typeof window === 'undefined') return [];
+
+  const onAnnounce = (event) => {
+    const detail = event.detail;
+    if (!detail?.info?.uuid || !detail.provider) return;
+    found.set(detail.info.uuid, { info: detail.info, provider: detail.provider });
+  };
+
+  window.addEventListener('eip6963:announceProvider', onAnnounce);
+  window.dispatchEvent(new Event('eip6963:requestProvider'));
+  await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+  window.removeEventListener('eip6963:announceProvider', onAnnounce);
+
+  const wallets = [...found.values()].map(({ info, provider }) => ({
+    id: info.rdns || info.uuid,
+    name: info.name,
+    icon: info.icon,
+    provider,
+  }));
+
+  // Legacy fallback: only if nothing announced, so a 6963-aware wallet is not
+  // listed twice under two different identities.
+  if (wallets.length === 0 && window.ethereum) {
+    wallets.push({ id: 'injected', name: detectLegacyName(window.ethereum), provider: window.ethereum });
+  }
+
+  return wallets;
+}
+
+function detectLegacyName(provider) {
+  if (provider.isMetaMask) return 'MetaMask';
+  if (provider.isPhantom) return 'Phantom';
+  if (provider.isCoinbaseWallet) return 'Coinbase Wallet';
+  if (provider.isRabby) return 'Rabby';
+  return 'Injected Wallet';
+}
+
+/**
+ * True when a CoinPay Wallet that can actually pay an x402 invoice is present.
+ *
+ * Checks for the method, not merely for the wallet. `payX402` shipped after
+ * the provider itself, so an installed-but-older extension has `isCoinPay`
+ * and no way to pay — treating that as "CoinPay is here" would hand the
+ * payment to a wallet that cannot take it and throw a TypeError, when the
+ * visitor may well have MetaMask sitting right there.
+ */
+export function hasCoinPayWallet() {
+  return (
+    typeof window !== 'undefined' &&
+    window.coinpay?.isCoinPay === true &&
+    typeof window.coinpay.payX402 === 'function'
+  );
+}
+
+/** True when CoinPay Wallet is installed but predates x402 support. */
+export function hasOutdatedCoinPayWallet() {
+  return (
+    typeof window !== 'undefined' &&
+    window.coinpay?.isCoinPay === true &&
+    typeof window.coinpay.payX402 !== 'function'
+  );
+}
+
+/**
+ * Choose a wallet to pay with.
+ *
+ * CoinPay Wallet first when installed — it is the only one that can pay on
+ * every rail CoinPayPortal accepts, including Bitcoin and Lightning, which no
+ * EVM wallet can touch. Otherwise the first injected EVM wallet, or one named
+ * explicitly by `preferWalletId`.
+ */
+export async function selectWallet({ preferWalletId, allowCoinPay = true } = {}) {
+  if (allowCoinPay && hasCoinPayWallet() && !preferWalletId) {
+    return { kind: 'coinpay', id: 'coinpay', name: 'CoinPay Wallet', provider: window.coinpay };
+  }
+
+  const evm = await discoverEvmWallets();
+  if (evm.length === 0) {
+    if (allowCoinPay && hasCoinPayWallet()) {
+      return { kind: 'coinpay', id: 'coinpay', name: 'CoinPay Wallet', provider: window.coinpay };
+    }
+    return null;
+  }
+
+  const chosen = preferWalletId ? evm.find((w) => w.id === preferWalletId) : evm[0];
+  if (!chosen) return null;
+  return { kind: 'evm', ...chosen };
+}
+
+/** Ask an EIP-1193 provider for the active account, prompting if needed. */
+async function requireEvmAccount(provider) {
+  const accounts = await provider.request({ method: 'eth_requestAccounts' });
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    throw new Error('Wallet returned no accounts');
+  }
+  return accounts[0];
+}
+
+/**
+ * Put an EIP-1193 wallet on the chain an `accepts` entry requires.
+ *
+ * Signing an EIP-712 payload whose domain names chain X while the wallet is on
+ * chain Y produces a signature that verifies against neither — wallets bind
+ * the domain's chainId to their active chain. So the switch is mandatory, not
+ * a nicety.
+ */
+async function ensureEvmChain(provider, network) {
+  const chainId = evmChainId(network);
+  if (chainId === null) throw new Error(`Not an EVM network: ${network}`);
+  const hexChainId = `0x${chainId.toString(16)}`;
+
+  const current = await provider.request({ method: 'eth_chainId' });
+  if (typeof current === 'string' && current.toLowerCase() === hexChainId) return;
+
+  try {
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: hexChainId }],
+    });
+  } catch (err) {
+    // 4902 = chain unknown to the wallet. Adding it needs RPC details we do
+    // not have here, so surface it rather than guessing an RPC URL.
+    if (err?.code === 4902) {
+      throw new Error(
+        `Your wallet does not have chain ${chainId} configured. Add it, then try again.`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Sign an EIP-3009 authorization with an EIP-1193 wallet.
+ *
+ * @returns {{signature: string, authorization: object, from: string}}
+ */
+export async function signExactEvm(provider, entry, { from } = {}) {
+  const payer = from ?? (await requireEvmAccount(provider));
+  await ensureEvmChain(provider, entry.network);
+
+  const domain = buildEip3009Domain({
+    network: entry.network,
+    asset: entry.asset,
+    name: entry.extra?.name,
+    version: entry.extra?.version,
+  });
+
+  const authorization = buildAuthorization({
+    from: payer,
+    to: entry.payTo,
+    value: requiredAmount(entry),
+    validForSeconds: entry.maxTimeoutSeconds ?? 600,
+  });
+
+  const typedData = {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
+      ...TRANSFER_WITH_AUTHORIZATION_TYPES,
+    },
+    primaryType: 'TransferWithAuthorization',
+    domain,
+    message: authorization,
+  };
+
+  const signature = await provider.request({
+    method: 'eth_signTypedData_v4',
+    params: [payer, JSON.stringify(typedData)],
+  });
+
+  return { signature, authorization, from: payer };
+}
+
+/**
+ * Produce the `X-PAYMENT` header value for a 402 body.
+ *
+ * @param {object} paymentRequired  the parsed 402 JSON (`{x402Version, accepts}`)
+ * @param {object} [options]
+ * @param {string} [options.preferWalletId]
+ * @param {string[]} [options.capabilities] override which networks to consider
+ */
+export async function createPaymentHeader(paymentRequired, options = {}) {
+  const accepts = paymentRequired?.accepts;
+  if (!Array.isArray(accepts) || accepts.length === 0) {
+    throw new Error('402 response carried no `accepts` options');
+  }
+
+  const wallet = await selectWallet(options);
+  if (!wallet) {
+    if (hasOutdatedCoinPayWallet()) {
+      throw new Error(
+        'Your CoinPay Wallet is too old to pay x402 invoices and no other wallet is ' +
+          'available. Update it, or install MetaMask.',
+      );
+    }
+    throw new Error(
+      'No wallet available to pay. Install CoinPay Wallet, MetaMask, or another EVM wallet.',
+    );
+  }
+
+  if (wallet.kind === 'coinpay') {
+    // The extension picks among the offered options itself — it knows which
+    // chains the user actually holds funds on, which this page does not.
+    const header = await wallet.provider.payX402(paymentRequired);
+    return { header, wallet };
+  }
+
+  // An injected EVM wallet can only pay the EVM entries.
+  const evmCapable = accepts
+    .map((entry) => entry.network)
+    .filter((network) => evmChainId(network) !== null);
+
+  const entry = selectAcceptEntry(accepts, options.capabilities ?? evmCapable);
+  if (!entry) {
+    throw new Error(
+      `${wallet.name} cannot pay any of the offered options ` +
+        `(${accepts.map((a) => toCaip2(a.network)).join(', ')}). ` +
+        'CoinPay Wallet supports Bitcoin, Lightning and card rails as well.',
+    );
+  }
+
+  const { signature, authorization } = await signExactEvm(wallet.provider, entry);
+  const payment = buildExactEvmPayment({
+    network: entry.network,
+    signature,
+    authorization,
+    scheme: entry.scheme ?? 'exact',
+  });
+
+  return { header: encodePaymentHeader(payment), wallet, entry };
+}
+
+/**
+ * `fetch` that pays once if the resource asks for payment.
+ *
+ * Retries exactly one time. A second 402 after paying means the payment was
+ * rejected rather than missing, and retrying again would sign a fresh
+ * authorization for a resource that just refused one — at the user's expense.
+ *
+ * @param {string|URL|Request} input
+ * @param {RequestInit} [init]
+ * @param {object} [options] forwarded to {@link createPaymentHeader}
+ */
+export async function fetchWithX402(input, init = {}, options = {}) {
+  const first = await fetch(input, init);
+  if (first.status !== 402) return first;
+
+  let paymentRequired;
+  try {
+    paymentRequired = await first.clone().json();
+  } catch {
+    throw new Error('Resource returned 402 but its body was not valid x402 JSON');
+  }
+
+  const { header } = await createPaymentHeader(paymentRequired, options);
+
+  const headers = new Headers(init.headers ?? {});
+  headers.set('X-PAYMENT', header);
+
+  const paid = await fetch(input, { ...init, headers });
+  if (paid.status === 402) {
+    throw new Error('Payment was rejected by the resource; not retrying to avoid double-paying');
+  }
+  return paid;
+}

--- a/packages/sdk/src/x402-v2.js
+++ b/packages/sdk/src/x402-v2.js
@@ -1,0 +1,264 @@
+/**
+ * x402 v2 protocol primitives.
+ *
+ * `x402.js` speaks a dialect only CoinPayPortal understands: `x402Version: 1`,
+ * bare network names like `"base"`, `maxAmountRequired` instead of `amount`,
+ * and an EIP-712 domain of our own invention (`name: 'x402'`). Nothing else in
+ * the ecosystem can read a 402 we emit, and no proof from a standard client
+ * verifies against us.
+ *
+ * That is survivable while CoinPay Wallet is the only payer. It stops being
+ * survivable the moment MetaMask or Phantom is expected to pay, because those
+ * wallets sign standard structures and nothing else: MetaMask will happily
+ * sign our bespoke domain, but the resulting signature authorises nothing
+ * on-chain and only we could ever interpret it.
+ *
+ * This module is the real thing, and is shared by the browser payer and the
+ * facilitator so the two cannot drift.
+ *
+ * Field shapes here were taken from live `/supported` and
+ * `/discovery/resources` responses on facilitator.goplausible.xyz and
+ * Coinbase's facilitator, not from memory of the spec.
+ *
+ * @module x402-v2
+ */
+
+/** The protocol version the ecosystem is actually on. */
+export const X402_VERSION = 2;
+
+/**
+ * CAIP-2 chain identifiers.
+ *
+ * The ecosystem addresses chains as `namespace:reference`, never as a bare
+ * name — `"base"` is meaningless to another facilitator, `eip155:8453` is not.
+ *
+ * `eip155:*` and `solana:*` are verified against live facilitator responses.
+ * Solana's reference is the first 32 characters of the genesis hash, per
+ * CAIP-30.
+ */
+export const CAIP2 = {
+  ethereum: 'eip155:1',
+  polygon: 'eip155:137',
+  base: 'eip155:8453',
+  'base-sepolia': 'eip155:84532',
+  solana: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  // CAIP-2 namespace for Bitcoin-family chains is `bip122`, referenced by the
+  // genesis block hash. Bitcoin Cash shares Bitcoin's genesis block, so the two
+  // are not distinguishable by CAIP-2 alone; BCH is left out rather than given
+  // an identifier that collides with Bitcoin's.
+  bitcoin: 'bip122:000000000019d6689c085ae165831e93',
+};
+
+/**
+ * Rails CoinPayPortal supports that have no CAIP-2 identity.
+ *
+ * Nobody else's facilitator accepts these, so there is no interoperable name
+ * to use. They keep their legacy identifiers and are flagged here so callers
+ * can tell "not yet mapped" from "deliberately outside CAIP-2".
+ */
+export const NON_CAIP2_NETWORKS = new Set(['bitcoin-cash', 'lightning', 'stripe']);
+
+/** Legacy bare name -> CAIP-2, for translating our own v1 records. */
+export function toCaip2(network) {
+  if (!network) return '';
+  if (network.includes(':')) return network; // already CAIP-2
+  return CAIP2[network] ?? network;
+}
+
+/** CAIP-2 -> legacy bare name, for code that still keys on the old names. */
+export function fromCaip2(caip2) {
+  if (!caip2) return '';
+  if (!caip2.includes(':')) return caip2; // already a bare name
+  const match = Object.entries(CAIP2).find(([, id]) => id === caip2);
+  return match ? match[0] : caip2;
+}
+
+/** Numeric EVM chain id from a CAIP-2 id, or null if it is not an eip155 chain. */
+export function evmChainId(network) {
+  const caip2 = toCaip2(network);
+  const match = /^eip155:(\d+)$/.exec(caip2);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * EIP-3009 `TransferWithAuthorization` type.
+ *
+ * This — not a bespoke `Payment` struct — is what x402's `exact` scheme signs
+ * on EVM. The signature IS the payment: whoever holds it can call
+ * `transferWithAuthorization` on the token and move the funds, which is why
+ * the facilitator can broadcast and pay the gas while the payer needs no
+ * native currency at all.
+ */
+export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+};
+
+/**
+ * Build the EIP-712 domain for an EIP-3009 authorization.
+ *
+ * The domain belongs to the TOKEN, not to x402: `verifyingContract` is the
+ * token's own address, and `name`/`version` are the values that token returns
+ * from its own EIP-712 domain. Tokens disagree about `version` ("1" vs "2")
+ * and it is not derivable, which is why a v2 `accepts` entry carries it in
+ * `extra` — that is what `extra: { name: 'USD Coin', version: '2' }` in live
+ * discovery data is for.
+ *
+ * Getting this wrong is not a soft failure: the recovered signer is simply
+ * some other address, so the authorization is void.
+ *
+ * @param {object} args
+ * @param {string} args.network   CAIP-2 id or legacy name
+ * @param {string} args.asset     token contract address
+ * @param {string} args.name      token's EIP-712 domain name
+ * @param {string} args.version   token's EIP-712 domain version
+ */
+export function buildEip3009Domain({ network, asset, name, version }) {
+  const chainId = evmChainId(network);
+  if (chainId === null) {
+    throw new Error(`Not an EVM network, cannot build an EIP-3009 domain: ${network}`);
+  }
+  if (!asset) {
+    throw new Error('EIP-3009 requires the token contract address as verifyingContract');
+  }
+  if (!name || !version) {
+    throw new Error(
+      'EIP-3009 requires the token EIP-712 domain name and version; ' +
+        'a v2 `accepts` entry supplies them in `extra.name` / `extra.version`',
+    );
+  }
+
+  return { name, version, chainId, verifyingContract: asset };
+}
+
+/**
+ * A random 32-byte nonce, hex encoded.
+ *
+ * EIP-3009 nonces are arbitrary bytes32 rather than a sequence — the token
+ * tracks used ones per authorizer, so they need only be unpredictable and not
+ * repeated. Uses WebCrypto, which is present in browsers, Workers and Node 18+.
+ */
+export function randomNonce() {
+  const bytes = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(bytes);
+  return `0x${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/**
+ * Build the authorization message to be signed.
+ *
+ * `validAfter` is 0 rather than "now": clocks differ between the payer and the
+ * chain, and a validAfter in the payer's near future makes the authorization
+ * briefly unusable for no benefit.
+ *
+ * @param {object} args
+ * @param {string} args.from            payer address
+ * @param {string} args.to              payee address (`payTo` from `accepts`)
+ * @param {string|bigint} args.value    amount in the token's smallest unit
+ * @param {number} [args.validForSeconds=600]
+ * @param {string} [args.nonce]         defaults to a fresh random nonce
+ */
+export function buildAuthorization({ from, to, value, validForSeconds = 600, nonce }) {
+  if (!from) throw new Error('buildAuthorization requires `from`');
+  if (!to) throw new Error('buildAuthorization requires `to`');
+  if (value === undefined || value === null || value === '') {
+    throw new Error('buildAuthorization requires `value`');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  return {
+    from,
+    to,
+    value: String(value),
+    validAfter: '0',
+    validBefore: String(now + validForSeconds),
+    nonce: nonce ?? randomNonce(),
+  };
+}
+
+/**
+ * Assemble the payment payload that goes in the `X-PAYMENT` header.
+ *
+ * @param {object} args
+ * @param {string} args.network        CAIP-2 id
+ * @param {string} args.signature      65-byte EIP-712 signature, hex
+ * @param {object} args.authorization  from `buildAuthorization`
+ * @param {string} [args.scheme='exact']
+ */
+export function buildExactEvmPayment({ network, signature, authorization, scheme = 'exact' }) {
+  return {
+    x402Version: X402_VERSION,
+    scheme,
+    network: toCaip2(network),
+    payload: { signature, authorization },
+  };
+}
+
+/**
+ * base64 encoding of a payment payload, as the `X-PAYMENT` header carries it.
+ *
+ * Uses base64url-safe output only where the runtime gives it; the header is
+ * standard base64 in the spec, so plain base64 is what is produced.
+ */
+export function encodePaymentHeader(payment) {
+  const json = JSON.stringify(payment);
+  if (typeof globalThis.btoa === 'function') {
+    // Browsers: btoa is latin1-only, so UTF-8 must be widened first.
+    const bytes = new TextEncoder().encode(json);
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return globalThis.btoa(binary);
+  }
+  return Buffer.from(json, 'utf-8').toString('base64');
+}
+
+/** Inverse of {@link encodePaymentHeader}. */
+export function decodePaymentHeader(header) {
+  let json;
+  if (typeof globalThis.atob === 'function') {
+    const binary = globalThis.atob(header);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    json = new TextDecoder().decode(bytes);
+  } else {
+    json = Buffer.from(header, 'base64').toString('utf-8');
+  }
+  return JSON.parse(json);
+}
+
+/**
+ * Pick the best `accepts` entry a given set of wallets can actually pay.
+ *
+ * A 402 lists several options and the payer must choose one it can sign. The
+ * order of `accepts` is the merchant's preference, so it is honoured rather
+ * than re-ranked — the first entry whose network is supported wins.
+ *
+ * @param {object[]} accepts       the 402's `accepts` array
+ * @param {string[]} capabilities  CAIP-2 ids (or bare names) the payer can sign
+ * @returns {object|null}
+ */
+export function selectAcceptEntry(accepts, capabilities) {
+  if (!Array.isArray(accepts) || accepts.length === 0) return null;
+  const supported = new Set(capabilities.map(toCaip2));
+  return accepts.find((entry) => supported.has(toCaip2(entry?.network))) ?? null;
+}
+
+/**
+ * The amount an `accepts` entry asks for, in the asset's smallest unit.
+ *
+ * v2 names this `amount`; our own v1 emitted `maxAmountRequired`. Both are
+ * read so a payer can pay a CoinPayPortal 402 that has not been migrated yet.
+ */
+export function requiredAmount(entry) {
+  const raw = entry?.amount ?? entry?.maxAmountRequired;
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('`accepts` entry has neither `amount` nor `maxAmountRequired`');
+  }
+  return String(raw);
+}

--- a/packages/sdk/src/x402-v2.js
+++ b/packages/sdk/src/x402-v2.js
@@ -81,6 +81,73 @@ export function evmChainId(network) {
 }
 
 /**
+ * EIP-712 domains for the tokens we quote, keyed by `chainId:address`.
+ *
+ * A payer cannot sign without `name` and `version`, and they are not derivable:
+ * `version()` is not part of ERC-20 and tokens disagree about the value. So a
+ * v2 `accepts` entry has to carry them, which means the quoting side has to
+ * know them.
+ *
+ * Every entry below was read from the deployed contract — `name()`,
+ * `version()` and `DOMAIN_SEPARATOR()` over JSON-RPC — not copied from
+ * documentation. The Base values additionally match what GoPlausible's
+ * discovery index publishes for the same token.
+ *
+ * A token that is not in this table cannot be quoted for v2, because guessing
+ * its domain produces signatures that recover to the wrong address and fail
+ * verification with no useful diagnostic.
+ */
+export const TOKEN_DOMAINS = {
+  // USDC. All three deployments report the same domain.
+  'eip155:1:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': { name: 'USD Coin', version: '2' },
+  'eip155:137:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': { name: 'USD Coin', version: '2' },
+  'eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': { name: 'USD Coin', version: '2' },
+};
+
+/** The published EIP-712 domain for a token, or null if we do not know it. */
+export function tokenDomain(network, asset) {
+  if (!asset) return null;
+  const caip2 = toCaip2(network);
+  const exact = TOKEN_DOMAINS[`${caip2}:${asset}`];
+  if (exact) return exact;
+
+  // Addresses are case-insensitive, so a caller passing a differently-cased
+  // address must not silently miss.
+  const wanted = `${caip2}:${asset}`.toLowerCase();
+  const match = Object.entries(TOKEN_DOMAINS).find(([key]) => key.toLowerCase() === wanted);
+  return match ? match[1] : null;
+}
+
+/**
+ * The v2-quotable tokens, as `{ methodKey: {network, asset, decimals} }`.
+ *
+ * Only tokens: EIP-3009 is an ERC-20 extension, so native ETH or POL cannot be
+ * paid under the `exact` scheme at all — there is no contract to authorise
+ * against. Quoting native currency as `exact` would advertise something no
+ * wallet can sign.
+ */
+export const V2_METHODS = {
+  usdc_eth: {
+    network: 'eip155:1',
+    asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    decimals: 6,
+    label: 'USDC on Ethereum',
+  },
+  usdc_polygon: {
+    network: 'eip155:137',
+    asset: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+    decimals: 6,
+    label: 'USDC on Polygon',
+  },
+  usdc_base: {
+    network: 'eip155:8453',
+    asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    decimals: 6,
+    label: 'USDC on Base',
+  },
+};
+
+/**
  * EIP-3009 `TransferWithAuthorization` type.
  *
  * This — not a bespoke `Payment` struct — is what x402's `exact` scheme signs
@@ -247,6 +314,91 @@ export function selectAcceptEntry(accepts, capabilities) {
   if (!Array.isArray(accepts) || accepts.length === 0) return null;
   const supported = new Set(capabilities.map(toCaip2));
   return accepts.find((entry) => supported.has(toCaip2(entry?.network))) ?? null;
+}
+
+/**
+ * Build a v2 `402 Payment Required` body.
+ *
+ * `buildPaymentRequired` in x402.js emits our v1 dialect — `x402Version: 1`,
+ * bare network names, `maxAmountRequired` — which no standard payer can read.
+ * A facilitator that verifies v2 but only ever quotes v1 still cannot be paid
+ * by anyone, so this is the other half of speaking the protocol.
+ *
+ * Only tokens with a known EIP-712 domain are quoted. An entry a payer cannot
+ * sign is worse than an absent one: it looks payable, fails at signing time,
+ * and the failure surfaces as an opaque signature error.
+ *
+ * @param {object} options
+ * @param {string|Record<string,string>} options.payTo  merchant address, or per-network map
+ * @param {number} [options.amountUsd]  price in USD (USDC is quoted 1:1)
+ * @param {string} [options.amount]     explicit smallest-unit amount, overrides amountUsd
+ * @param {string[]} [options.methods]  keys from V2_METHODS; defaults to all
+ * @param {string} options.resource     the URL being sold
+ * @param {string} [options.description]
+ * @param {string} [options.mimeType='application/json']
+ * @param {number} [options.maxTimeoutSeconds=300]
+ */
+export function buildPaymentRequiredV2({
+  payTo,
+  amountUsd,
+  amount,
+  methods,
+  resource,
+  description = 'Payment required',
+  mimeType = 'application/json',
+  maxTimeoutSeconds = 300,
+} = {}) {
+  if (!payTo) throw new Error('buildPaymentRequiredV2 requires `payTo`');
+  if (!resource) throw new Error('buildPaymentRequiredV2 requires `resource`');
+  if (amount === undefined && amountUsd === undefined) {
+    throw new Error('buildPaymentRequiredV2 requires `amount` or `amountUsd`');
+  }
+
+  const keys = methods ?? Object.keys(V2_METHODS);
+  const accepts = [];
+
+  for (const key of keys) {
+    const method = V2_METHODS[key];
+    if (!method) continue;
+
+    const domain = tokenDomain(method.network, method.asset);
+    if (!domain) continue; // unsignable — leave it out rather than advertise it
+
+    const address =
+      typeof payTo === 'object' ? (payTo[method.network] ?? payTo[fromCaip2(method.network)] ?? payTo[key]) : payTo;
+    if (!address) continue; // merchant has no address on this chain
+
+    // USDC is a dollar stablecoin with 6 decimals, so a USD price converts
+    // exactly. Rounding up rather than down: rounding a fraction of a cent
+    // down would quote less than the asking price and verify as underpayment.
+    const smallestUnit =
+      amount !== undefined
+        ? String(amount)
+        : String(Math.ceil(amountUsd * 10 ** method.decimals));
+
+    accepts.push({
+      scheme: 'exact',
+      network: method.network,
+      amount: smallestUnit,
+      asset: method.asset,
+      payTo: address,
+      resource,
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      // The token's EIP-712 domain. Without this the payer cannot construct a
+      // signature at all — it is the whole reason `extra` exists on a v2 entry.
+      extra: { name: domain.name, version: domain.version },
+    });
+  }
+
+  if (accepts.length === 0) {
+    throw new Error(
+      'No payable options could be built. Check `payTo` covers at least one supported chain.',
+    );
+  }
+
+  return { x402Version: X402_VERSION, accepts };
 }
 
 /**

--- a/packages/sdk/src/x402.js
+++ b/packages/sdk/src/x402.js
@@ -8,6 +8,8 @@
  * @module x402
  */
 
+import { buildPaymentRequiredV2 } from './x402-v2.js';
+
 /**
  * All supported payment methods with their network/asset metadata.
  * 
@@ -352,12 +354,37 @@ function decodePaymentHeader(paymentHeader) {
  * The price comes from the offer the server just built — never from the proof
  * itself, which is the payer's word for what they owe.
  *
- * @returns {{amount: string, resource: string}|null} null if the proof matches
- *   no advertised method, in which case there is no price to hold it to.
+ * @returns {{amount: string, resource: string, payTo?: string, asset?: string}|null}
+ *   null if the proof matches no advertised method, in which case there is no
+ *   price to hold it to.
  */
 export function expectedForProof(paymentHeader, offer, resource) {
   const payment = decodePaymentHeader(paymentHeader);
   if (!payment?.payload) return null;
+
+  // A v2 proof describes itself differently: the network sits at the top level
+  // and the payload holds a signed authorization rather than loose fields.
+  // Matching it against the offer the same way as v1 would find nothing and
+  // report "no price to check against" for a perfectly good payment.
+  const authorization = payment.payload.authorization;
+  if (authorization) {
+    const entries = offer?.accepts || [];
+    const match =
+      entries.find((e) => e.network === payment.network && e.payTo === authorization.to) ||
+      entries.find((e) => e.network === payment.network);
+
+    if (!match) return null;
+
+    return {
+      amount: match.amount ?? match.maxAmountRequired,
+      resource,
+      // v2 verification needs both: an EIP-3009 signature says nothing about
+      // which token it is denominated in, so without the asset there is no
+      // domain to check it against.
+      payTo: match.payTo,
+      asset: match.asset,
+    };
+  }
 
   const { network, asset } = payment.payload;
   const methodKey = payment.payload.methodKey || payment.payload.extra?.methodKey;
@@ -425,9 +452,22 @@ export function createX402Middleware(globalOptions) {
     facilitatorUrl = DEFAULT_FACILITATOR_URL,
     apiBaseUrl = 'https://coinpayportal.com',
     allowPendingConfirmation: globalAllowPendingConfirmation = false,
+    /**
+     * Which protocol version to quote in the 402.
+     *
+     * Defaults to 1 so existing integrations keep the offer they have today —
+     * their payers only understand our dialect, and switching the quote out
+     * from under them would break every one at once. Set to 2 to advertise the
+     * real protocol, which is what any standard wallet (MetaMask, Phantom) can
+     * actually pay.
+     */
+    x402Version: protocolVersion = 1,
   } = globalOptions;
 
   if (!apiKey) throw new Error('x402 middleware requires an apiKey');
+  if (protocolVersion !== 1 && protocolVersion !== 2) {
+    throw new Error(`Unsupported x402Version: ${protocolVersion} (expected 1 or 2)`);
+  }
   if (!payTo) throw new Error('x402 middleware requires a payTo address');
 
   // Mutable rates cache — can be updated externally or via ratesEndpoint
@@ -475,17 +515,27 @@ export function createX402Middleware(globalOptions) {
       // and on a paid request it is the price the proof has to actually cover.
       let offer;
       try {
-        offer = buildPaymentRequired({
-          payTo,
-          amountUsd: routeAmountUsd,
-          amount: routeAmount,
-          network: routeOptions.network,
-          rates: currentRates,
-          methods: routeMethods,
-          resource,
-          description: routeDescription,
-          facilitatorUrl,
-        });
+        offer =
+          protocolVersion === 2
+            ? buildPaymentRequiredV2({
+                payTo,
+                amountUsd: routeAmountUsd,
+                amount: routeAmount,
+                methods: routeMethods,
+                resource,
+                description: routeDescription,
+              })
+            : buildPaymentRequired({
+                payTo,
+                amountUsd: routeAmountUsd,
+                amount: routeAmount,
+                network: routeOptions.network,
+                rates: currentRates,
+                methods: routeMethods,
+                resource,
+                description: routeDescription,
+                facilitatorUrl,
+              });
       } catch (err) {
         return res.status(500).json({ error: 'Failed to build payment options', details: err.message });
       }

--- a/packages/sdk/test/x402-browser.test.js
+++ b/packages/sdk/test/x402-browser.test.js
@@ -1,0 +1,367 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  discoverEvmWallets,
+  hasCoinPayWallet,
+  hasOutdatedCoinPayWallet,
+  selectWallet,
+  signExactEvm,
+  createPaymentHeader,
+  fetchWithX402,
+} from '../src/x402-browser.js';
+import { decodePaymentHeader } from '../src/x402-v2.js';
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const PAYER = '0x9dBA414637c611a16BEa6f0796BFcbcBdc410df8';
+const PAYEE = '0x1111111111111111111111111111111111111111';
+
+/** An `accepts` entry shaped exactly like live discovery data. */
+function baseEntry(overrides = {}) {
+  return {
+    scheme: 'exact',
+    network: 'eip155:8453',
+    amount: '6000',
+    asset: USDC_BASE,
+    payTo: PAYEE,
+    maxTimeoutSeconds: 300,
+    extra: { name: 'USD Coin', version: '2' },
+    ...overrides,
+  };
+}
+
+/** A minimal EIP-1193 provider that records what it was asked to do. */
+function fakeEvmProvider({ chainId = '0x2105', accounts = [PAYER] } = {}) {
+  const calls = [];
+  return {
+    calls,
+    isMetaMask: true,
+    async request({ method, params }) {
+      calls.push({ method, params });
+      switch (method) {
+        case 'eth_requestAccounts':
+          return accounts;
+        case 'eth_chainId':
+          return chainId;
+        case 'wallet_switchEthereumChain':
+          chainId = params[0].chainId;
+          return null;
+        case 'eth_signTypedData_v4':
+          return '0xsignature';
+        default:
+          throw new Error(`unexpected method ${method}`);
+      }
+    },
+  };
+}
+
+function announceWallet({ uuid, name, rdns, provider }) {
+  const handler = () => {
+    window.dispatchEvent(
+      new CustomEvent('eip6963:announceProvider', {
+        detail: { info: { uuid, name, rdns, icon: 'data:,' }, provider },
+      }),
+    );
+  };
+  window.addEventListener('eip6963:requestProvider', handler);
+  return () => window.removeEventListener('eip6963:requestProvider', handler);
+}
+
+beforeEach(() => {
+  delete window.coinpay;
+  delete window.ethereum;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('wallet discovery', () => {
+  it('enumerates EIP-6963 wallets', async () => {
+    const cleanup = announceWallet({
+      uuid: 'u1',
+      name: 'MetaMask',
+      rdns: 'io.metamask',
+      provider: fakeEvmProvider(),
+    });
+
+    const wallets = await discoverEvmWallets({ timeoutMs: 10 });
+    cleanup();
+
+    expect(wallets).toHaveLength(1);
+    expect(wallets[0]).toMatchObject({ id: 'io.metamask', name: 'MetaMask' });
+  });
+
+  it('enumerates several wallets rather than whichever won window.ethereum', async () => {
+    const a = announceWallet({ uuid: 'u1', name: 'MetaMask', rdns: 'io.metamask', provider: fakeEvmProvider() });
+    const b = announceWallet({ uuid: 'u2', name: 'Phantom', rdns: 'app.phantom', provider: fakeEvmProvider() });
+
+    const wallets = await discoverEvmWallets({ timeoutMs: 10 });
+    a();
+    b();
+
+    expect(wallets.map((w) => w.id).sort()).toEqual(['app.phantom', 'io.metamask']);
+  });
+
+  it('falls back to window.ethereum when nothing announces', async () => {
+    window.ethereum = fakeEvmProvider();
+    const wallets = await discoverEvmWallets({ timeoutMs: 10 });
+
+    expect(wallets).toHaveLength(1);
+    expect(wallets[0].name).toBe('MetaMask');
+  });
+
+  it('does not double-list a wallet that announced AND set window.ethereum', async () => {
+    const provider = fakeEvmProvider();
+    window.ethereum = provider;
+    const cleanup = announceWallet({ uuid: 'u1', name: 'MetaMask', rdns: 'io.metamask', provider });
+
+    const wallets = await discoverEvmWallets({ timeoutMs: 10 });
+    cleanup();
+
+    expect(wallets).toHaveLength(1);
+  });
+
+  it('reports no wallets when the page has none', async () => {
+    expect(await discoverEvmWallets({ timeoutMs: 10 })).toEqual([]);
+  });
+});
+
+describe('wallet selection', () => {
+  it('detects CoinPay Wallet', () => {
+    expect(hasCoinPayWallet()).toBe(false);
+    window.coinpay = { isCoinPay: true, payX402: () => {} };
+    expect(hasCoinPayWallet()).toBe(true);
+  });
+
+  it('does not count a CoinPay Wallet too old to pay x402', () => {
+    window.coinpay = { isCoinPay: true }; // no payX402
+    expect(hasCoinPayWallet()).toBe(false);
+    expect(hasOutdatedCoinPayWallet()).toBe(true);
+  });
+
+  it('prefers CoinPay Wallet when installed', async () => {
+    window.coinpay = { isCoinPay: true, payX402: () => {} };
+    window.ethereum = fakeEvmProvider();
+
+    expect(await selectWallet()).toMatchObject({ kind: 'coinpay', name: 'CoinPay Wallet' });
+  });
+
+  it('falls back to MetaMask when CoinPay Wallet is too old to pay', async () => {
+    window.coinpay = { isCoinPay: true }; // no payX402
+    window.ethereum = fakeEvmProvider();
+
+    expect(await selectWallet()).toMatchObject({ kind: 'evm', name: 'MetaMask' });
+  });
+
+  it('falls back to an injected EVM wallet when CoinPay is absent', async () => {
+    window.ethereum = fakeEvmProvider();
+    expect(await selectWallet()).toMatchObject({ kind: 'evm', name: 'MetaMask' });
+  });
+
+  it('honours an explicit wallet choice over the CoinPay default', async () => {
+    window.coinpay = { isCoinPay: true };
+    const cleanup = announceWallet({ uuid: 'u1', name: 'Phantom', rdns: 'app.phantom', provider: fakeEvmProvider() });
+
+    const wallet = await selectWallet({ preferWalletId: 'app.phantom' });
+    cleanup();
+
+    expect(wallet).toMatchObject({ kind: 'evm', name: 'Phantom' });
+  });
+
+  it('returns null when the page has no wallet at all', async () => {
+    expect(await selectWallet()).toBeNull();
+  });
+});
+
+describe('signing an EIP-3009 authorization', () => {
+  it('signs the token domain, not a bespoke x402 domain', async () => {
+    const provider = fakeEvmProvider();
+    await signExactEvm(provider, baseEntry());
+
+    const sign = provider.calls.find((c) => c.method === 'eth_signTypedData_v4');
+    const typedData = JSON.parse(sign.params[1]);
+
+    expect(typedData.primaryType).toBe('TransferWithAuthorization');
+    expect(typedData.domain).toEqual({
+      name: 'USD Coin',
+      version: '2',
+      chainId: 8453,
+      verifyingContract: USDC_BASE,
+    });
+    expect(typedData.domain.name).not.toBe('x402');
+  });
+
+  it('signs the amount and payee the entry asks for', async () => {
+    const provider = fakeEvmProvider();
+    const { authorization } = await signExactEvm(provider, baseEntry());
+
+    expect(authorization.to).toBe(PAYEE);
+    expect(authorization.value).toBe('6000');
+    expect(authorization.from).toBe(PAYER);
+  });
+
+  it('switches the wallet to the required chain before signing', async () => {
+    // Wallet starts on Ethereum mainnet; entry wants Base.
+    const provider = fakeEvmProvider({ chainId: '0x1' });
+    await signExactEvm(provider, baseEntry());
+
+    const methods = provider.calls.map((c) => c.method);
+    expect(methods).toContain('wallet_switchEthereumChain');
+    // The switch must precede the signature, or the domain's chainId and the
+    // wallet's active chain disagree and the signature verifies against neither.
+    expect(methods.indexOf('wallet_switchEthereumChain')).toBeLessThan(
+      methods.indexOf('eth_signTypedData_v4'),
+    );
+  });
+
+  it('does not switch when already on the right chain', async () => {
+    const provider = fakeEvmProvider({ chainId: '0x2105' });
+    await signExactEvm(provider, baseEntry());
+
+    expect(provider.calls.map((c) => c.method)).not.toContain('wallet_switchEthereumChain');
+  });
+
+  it('explains an unconfigured chain rather than guessing an RPC URL', async () => {
+    const provider = fakeEvmProvider({ chainId: '0x1' });
+    provider.request = async ({ method }) => {
+      if (method === 'eth_requestAccounts') return [PAYER];
+      if (method === 'eth_chainId') return '0x1';
+      if (method === 'wallet_switchEthereumChain') throw Object.assign(new Error('nope'), { code: 4902 });
+      throw new Error('unexpected');
+    };
+
+    await expect(signExactEvm(provider, baseEntry())).rejects.toThrow(/does not have chain 8453/i);
+  });
+
+  it('refuses an entry missing the token domain metadata', async () => {
+    const provider = fakeEvmProvider();
+    await expect(signExactEvm(provider, baseEntry({ extra: {} }))).rejects.toThrow(/name and version/i);
+  });
+});
+
+describe('createPaymentHeader', () => {
+  it('produces a decodable v2 payment for an EVM wallet', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    const { header, wallet } = await createPaymentHeader({ x402Version: 2, accepts: [baseEntry()] });
+    const payment = decodePaymentHeader(header);
+
+    expect(wallet.name).toBe('MetaMask');
+    expect(payment.x402Version).toBe(2);
+    expect(payment.network).toBe('eip155:8453');
+    expect(payment.scheme).toBe('exact');
+    expect(payment.payload.signature).toBe('0xsignature');
+    expect(payment.payload.authorization.value).toBe('6000');
+  });
+
+  it('delegates to CoinPay Wallet when it is installed', async () => {
+    const payX402 = vi.fn().mockResolvedValue('coinpay-header');
+    window.coinpay = { isCoinPay: true, payX402 };
+
+    const paymentRequired = { x402Version: 2, accepts: [baseEntry()] };
+    const { header } = await createPaymentHeader(paymentRequired);
+
+    expect(header).toBe('coinpay-header');
+    // The extension chooses among the options itself — it knows which chains
+    // hold funds, which the page does not.
+    expect(payX402).toHaveBeenCalledWith(paymentRequired);
+  });
+
+  it('skips options an EVM wallet cannot pay', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    const { header } = await createPaymentHeader({
+      x402Version: 2,
+      accepts: [baseEntry({ network: 'bitcoin', asset: 'BTC' }), baseEntry()],
+    });
+
+    expect(decodePaymentHeader(header).network).toBe('eip155:8453');
+  });
+
+  it('names CoinPay Wallet when no offered option is EVM-payable', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    await expect(
+      createPaymentHeader({ x402Version: 2, accepts: [baseEntry({ network: 'bitcoin', asset: 'BTC' })] }),
+    ).rejects.toThrow(/CoinPay Wallet supports Bitcoin/i);
+  });
+
+  it('tells the visitor to install a wallet when there is none', async () => {
+    await expect(createPaymentHeader({ x402Version: 2, accepts: [baseEntry()] })).rejects.toThrow(
+      /Install CoinPay Wallet, MetaMask/i,
+    );
+  });
+
+  it('rejects a 402 body with no options', async () => {
+    await expect(createPaymentHeader({ x402Version: 2, accepts: [] })).rejects.toThrow(/no `accepts`/i);
+  });
+});
+
+describe('fetchWithX402', () => {
+  it('passes a non-402 response straight through without touching a wallet', async () => {
+    const ok = new Response('hi', { status: 200 });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok));
+
+    expect(await fetchWithX402('https://api.example.com/x')).toBe(ok);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('pays and retries once with the X-PAYMENT header', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ x402Version: 2, accepts: [baseEntry()] }), { status: 402 }),
+      )
+      .mockResolvedValueOnce(new Response('paid', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithX402('https://api.example.com/premium');
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const retryHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(decodePaymentHeader(retryHeaders.get('X-PAYMENT')).network).toBe('eip155:8453');
+  });
+
+  it('preserves the caller\'s own headers on the paid retry', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ x402Version: 2, accepts: [baseEntry()] }), { status: 402 }),
+      )
+      .mockResolvedValueOnce(new Response('paid', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithX402('https://api.example.com/premium', {
+      headers: { Accept: 'application/json' },
+    });
+
+    const retryHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(retryHeaders.get('Accept')).toBe('application/json');
+  });
+
+  it('does NOT pay a second time when the paid retry is refused', async () => {
+    window.ethereum = fakeEvmProvider();
+
+    const body = JSON.stringify({ x402Version: 2, accepts: [baseEntry()] });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(body, { status: 402 }))
+      .mockResolvedValueOnce(new Response(body, { status: 402 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchWithX402('https://api.example.com/premium')).rejects.toThrow(/double-paying/i);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a 402 whose body is not x402 JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 402 })));
+
+    await expect(fetchWithX402('https://api.example.com/premium')).rejects.toThrow(/not valid x402 JSON/i);
+  });
+});

--- a/packages/sdk/test/x402-v2-offer.test.js
+++ b/packages/sdk/test/x402-v2-offer.test.js
@@ -1,0 +1,158 @@
+/**
+ * Quoting x402 v2 from the middleware.
+ *
+ * Verifying v2 proofs is only half of speaking the protocol. A facilitator
+ * that can verify v2 but only ever quotes v1 still cannot be paid by anyone,
+ * because no standard wallet can read the offer it hands out.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createX402Middleware, expectedForProof } from '../src/x402.js';
+import { buildPaymentRequiredV2, encodePaymentHeader } from '../src/x402-v2.js';
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const PAYEE = '0x1111111111111111111111111111111111111111';
+const PAYER = '0x9dBA414637c611a16BEa6f0796BFcbcBdc410df8';
+const RESOURCE = 'http://localhost/premium';
+
+function makeReqRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  const req = {
+    protocol: 'http',
+    originalUrl: '/premium',
+    headers: {},
+    get: () => 'localhost',
+  };
+  return { req, res };
+}
+
+describe('middleware protocol version', () => {
+  it('still quotes v1 by default, so existing payers are not broken', async () => {
+    const x402 = createX402Middleware({ apiKey: 'k', payTo: PAYEE });
+    const { req, res } = makeReqRes();
+
+    await x402({ amountUsd: 0.01, methods: ['usdc_base'] })(req, res, () => {});
+
+    expect(res.statusCode).toBe(402);
+    expect(res.body.x402Version).toBe(1);
+    expect(res.body.accepts[0]).toHaveProperty('maxAmountRequired');
+  });
+
+  it('quotes a real v2 offer when asked', async () => {
+    const x402 = createX402Middleware({ apiKey: 'k', payTo: PAYEE, x402Version: 2 });
+    const { req, res } = makeReqRes();
+
+    await x402({ amountUsd: 0.01, methods: ['usdc_base'] })(req, res, () => {});
+
+    expect(res.statusCode).toBe(402);
+    expect(res.body.x402Version).toBe(2);
+
+    const [entry] = res.body.accepts;
+    expect(entry.network).toBe('eip155:8453');
+    expect(entry.amount).toBe('10000');
+    expect(entry).not.toHaveProperty('maxAmountRequired');
+    expect(entry.extra).toEqual({ name: 'USD Coin', version: '2' });
+  });
+
+  it('refuses an unsupported protocol version rather than quoting nonsense', () => {
+    expect(() => createX402Middleware({ apiKey: 'k', payTo: PAYEE, x402Version: 3 })).toThrow(
+      /unsupported x402version/i,
+    );
+  });
+});
+
+describe('expectedForProof with a v2 proof', () => {
+  const offer = buildPaymentRequiredV2({
+    payTo: PAYEE,
+    amountUsd: 0.01,
+    resource: RESOURCE,
+    methods: ['usdc_base'],
+  });
+
+  function v2Header(overrides = {}) {
+    return encodePaymentHeader({
+      x402Version: 2,
+      scheme: 'exact',
+      network: 'eip155:8453',
+      payload: {
+        signature: '0xsig',
+        authorization: {
+          from: PAYER,
+          to: PAYEE,
+          value: '10000',
+          validAfter: '0',
+          validBefore: '9999999999',
+          nonce: '0x' + '11'.repeat(32),
+          ...overrides,
+        },
+      },
+    });
+  }
+
+  it('finds the offered price for a v2 proof', () => {
+    const expected = expectedForProof(v2Header(), offer, RESOURCE);
+
+    expect(expected).not.toBeNull();
+    expect(expected.amount).toBe('10000');
+    expect(expected.resource).toBe(RESOURCE);
+  });
+
+  it('supplies payTo and asset, which v2 verification cannot work without', () => {
+    const expected = expectedForProof(v2Header(), offer, RESOURCE);
+
+    // An EIP-3009 signature says nothing about which token it is denominated
+    // in, so without the asset there is no domain to verify it against.
+    expect(expected.payTo).toBe(PAYEE);
+    expect(expected.asset).toBe(USDC_BASE);
+  });
+
+  it('takes the price from the offer, never from the proof', () => {
+    // Payer claims to owe a single micro-unit.
+    const expected = expectedForProof(v2Header({ value: '1' }), offer, RESOURCE);
+    expect(expected.amount).toBe('10000');
+  });
+
+  it('returns null when the proof names a network that was not offered', () => {
+    const header = encodePaymentHeader({
+      x402Version: 2,
+      network: 'eip155:1',
+      payload: {
+        signature: '0xsig',
+        authorization: { from: PAYER, to: PAYEE, value: '10000', nonce: '0x1' },
+      },
+    });
+
+    expect(expectedForProof(header, offer, RESOURCE)).toBeNull();
+  });
+
+  it('still handles v1 proofs unchanged', () => {
+    const v1Offer = {
+      accepts: [
+        {
+          network: 'base',
+          asset: USDC_BASE,
+          maxAmountRequired: '10000',
+          extra: { methodKey: 'usdc_base' },
+        },
+      ],
+    };
+    const v1Header = Buffer.from(
+      JSON.stringify({ payload: { network: 'base', asset: USDC_BASE, methodKey: 'usdc_base' } }),
+    ).toString('base64');
+
+    const expected = expectedForProof(v1Header, v1Offer, RESOURCE);
+    expect(expected.amount).toBe('10000');
+    // v1 verification does not take these, and must not start receiving them.
+    expect(expected.payTo).toBeUndefined();
+  });
+});

--- a/packages/sdk/test/x402-v2.test.js
+++ b/packages/sdk/test/x402-v2.test.js
@@ -14,6 +14,9 @@ import {
   requiredAmount,
   randomNonce,
   TRANSFER_WITH_AUTHORIZATION_TYPES,
+  tokenDomain,
+  V2_METHODS,
+  buildPaymentRequiredV2,
 } from '../src/x402-v2.js';
 
 // USDC on Base, exactly as it appears in live discovery data.
@@ -199,5 +202,162 @@ describe('requiredAmount', () => {
 
   it('throws when neither is present', () => {
     expect(() => requiredAmount({})).toThrow(/amount/i);
+  });
+});
+
+describe('token domains', () => {
+  it('publishes domains read from the deployed contracts', () => {
+    // Verified over JSON-RPC against each deployment, and matching what
+    // GoPlausible's discovery index publishes for Base.
+    expect(tokenDomain('base', USDC_BASE)).toEqual({ name: 'USD Coin', version: '2' });
+    expect(tokenDomain('eip155:1', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')).toEqual({
+      name: 'USD Coin',
+      version: '2',
+    });
+    expect(tokenDomain('polygon', '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359')).toEqual({
+      name: 'USD Coin',
+      version: '2',
+    });
+  });
+
+  it('matches regardless of address casing', () => {
+    expect(tokenDomain('base', USDC_BASE.toLowerCase())).toEqual({ name: 'USD Coin', version: '2' });
+  });
+
+  it('returns null for a token whose domain we have not read', () => {
+    expect(tokenDomain('base', '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef')).toBeNull();
+    expect(tokenDomain('base', undefined)).toBeNull();
+  });
+
+  it('quotes only tokens, since EIP-3009 cannot authorise native currency', () => {
+    for (const method of Object.values(V2_METHODS)) {
+      expect(method.asset).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    }
+  });
+});
+
+describe('buildPaymentRequiredV2', () => {
+  const payTo = '0x1111111111111111111111111111111111111111';
+  const resource = 'https://api.example.com/premium';
+
+  it('emits a v2 body a standard payer can read', () => {
+    const body = buildPaymentRequiredV2({ payTo, amountUsd: 0.01, resource });
+
+    expect(body.x402Version).toBe(2);
+    expect(body.accepts.length).toBeGreaterThan(0);
+
+    for (const entry of body.accepts) {
+      expect(entry.scheme).toBe('exact');
+      expect(entry.network).toMatch(/^eip155:\d+$/);
+      expect(entry).toHaveProperty('amount');
+      expect(entry).not.toHaveProperty('maxAmountRequired');
+      expect(entry.extra).toEqual({ name: 'USD Coin', version: '2' });
+    }
+  });
+
+  it('carries the token domain, without which nothing can be signed', () => {
+    const [entry] = buildPaymentRequiredV2({
+      payTo,
+      amountUsd: 1,
+      resource,
+      methods: ['usdc_base'],
+    }).accepts;
+
+    expect(entry.extra.name).toBe('USD Coin');
+    expect(entry.extra.version).toBe('2');
+    expect(entry.asset).toBe(USDC_BASE);
+  });
+
+  it('converts USD to USDC micro-units', () => {
+    const [entry] = buildPaymentRequiredV2({
+      payTo,
+      amountUsd: 0.05,
+      resource,
+      methods: ['usdc_base'],
+    }).accepts;
+
+    expect(entry.amount).toBe('50000');
+  });
+
+  it('rounds a sub-cent price UP, so a quote is never below the asking price', () => {
+    const [entry] = buildPaymentRequiredV2({
+      payTo,
+      amountUsd: 0.0000005,
+      resource,
+      methods: ['usdc_base'],
+    }).accepts;
+
+    expect(entry.amount).toBe('1');
+  });
+
+  it('accepts an explicit smallest-unit amount', () => {
+    const [entry] = buildPaymentRequiredV2({
+      payTo,
+      amount: '6000',
+      resource,
+      methods: ['usdc_base'],
+    }).accepts;
+
+    expect(entry.amount).toBe('6000');
+  });
+
+  it('resolves a per-network payTo map, by CAIP-2 or legacy name', () => {
+    const body = buildPaymentRequiredV2({
+      payTo: { 'eip155:8453': '0xBase', polygon: '0xPoly' },
+      amountUsd: 1,
+      resource,
+      methods: ['usdc_base', 'usdc_polygon', 'usdc_eth'],
+    });
+
+    const byNetwork = Object.fromEntries(body.accepts.map((a) => [a.network, a.payTo]));
+    expect(byNetwork['eip155:8453']).toBe('0xBase');
+    expect(byNetwork['eip155:137']).toBe('0xPoly');
+    // No Ethereum address supplied, so no Ethereum option is advertised.
+    expect(byNetwork['eip155:1']).toBeUndefined();
+  });
+
+  it('honours an explicit method list', () => {
+    const body = buildPaymentRequiredV2({ payTo, amountUsd: 1, resource, methods: ['usdc_base'] });
+    expect(body.accepts).toHaveLength(1);
+    expect(body.accepts[0].network).toBe('eip155:8453');
+  });
+
+  it('carries the resource so the payer knows what it is buying', () => {
+    const [entry] = buildPaymentRequiredV2({ payTo, amountUsd: 1, resource, methods: ['usdc_base'] })
+      .accepts;
+    expect(entry.resource).toBe(resource);
+  });
+
+  it('throws rather than emitting an empty accepts array', () => {
+    expect(() =>
+      buildPaymentRequiredV2({
+        payTo: { 'eip155:1': '0xa' },
+        amountUsd: 1,
+        resource,
+        methods: ['usdc_base'],
+      }),
+    ).toThrow(/no payable options/i);
+  });
+
+  it('requires payTo, resource and a price', () => {
+    expect(() => buildPaymentRequiredV2({ amountUsd: 1, resource })).toThrow(/payTo/);
+    expect(() => buildPaymentRequiredV2({ payTo, amountUsd: 1 })).toThrow(/resource/);
+    expect(() => buildPaymentRequiredV2({ payTo, resource })).toThrow(/amount/);
+  });
+
+  it('round-trips: what it quotes, selectAcceptEntry can choose and pay', () => {
+    const body = buildPaymentRequiredV2({ payTo, amountUsd: 0.01, resource });
+    const entry = selectAcceptEntry(body.accepts, ['eip155:8453']);
+
+    expect(entry).not.toBeNull();
+    expect(requiredAmount(entry)).toBe('10000');
+    expect(() =>
+      buildEip3009Domain({
+        network: entry.network,
+        asset: entry.asset,
+        name: entry.extra.name,
+        version: entry.extra.version,
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/sdk/test/x402-v2.test.js
+++ b/packages/sdk/test/x402-v2.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  X402_VERSION,
+  CAIP2,
+  toCaip2,
+  fromCaip2,
+  evmChainId,
+  buildEip3009Domain,
+  buildAuthorization,
+  buildExactEvmPayment,
+  encodePaymentHeader,
+  decodePaymentHeader,
+  selectAcceptEntry,
+  requiredAmount,
+  randomNonce,
+  TRANSFER_WITH_AUTHORIZATION_TYPES,
+} from '../src/x402-v2.js';
+
+// USDC on Base, exactly as it appears in live discovery data.
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+describe('protocol version', () => {
+  it('is 2, matching the ecosystem', () => {
+    expect(X402_VERSION).toBe(2);
+  });
+});
+
+describe('CAIP-2 network identifiers', () => {
+  it('maps our chains to the ids other facilitators publish', () => {
+    expect(CAIP2.base).toBe('eip155:8453');
+    expect(CAIP2.ethereum).toBe('eip155:1');
+    expect(CAIP2.polygon).toBe('eip155:137');
+    expect(CAIP2.solana).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp');
+  });
+
+  it('translates bare legacy names', () => {
+    expect(toCaip2('base')).toBe('eip155:8453');
+    expect(fromCaip2('eip155:8453')).toBe('base');
+  });
+
+  it('passes through ids that are already CAIP-2', () => {
+    expect(toCaip2('eip155:8453')).toBe('eip155:8453');
+  });
+
+  it('leaves unknown networks alone rather than inventing an id', () => {
+    expect(toCaip2('bitcoin-cash')).toBe('bitcoin-cash');
+    expect(toCaip2('lightning')).toBe('lightning');
+  });
+
+  it('extracts the numeric chain id only for eip155 chains', () => {
+    expect(evmChainId('base')).toBe(8453);
+    expect(evmChainId('eip155:137')).toBe(137);
+    expect(evmChainId('solana')).toBeNull();
+    expect(evmChainId('bitcoin')).toBeNull();
+  });
+});
+
+describe('EIP-3009 domain', () => {
+  it('uses the TOKEN as verifyingContract, not a bespoke x402 domain', () => {
+    const domain = buildEip3009Domain({
+      network: 'base',
+      asset: USDC_BASE,
+      name: 'USD Coin',
+      version: '2',
+    });
+
+    expect(domain).toEqual({
+      name: 'USD Coin',
+      version: '2',
+      chainId: 8453,
+      verifyingContract: USDC_BASE,
+    });
+    // The old dialect used name 'x402' — the whole reason nothing interoperated.
+    expect(domain.name).not.toBe('x402');
+  });
+
+  it('refuses to guess the token name or version', () => {
+    expect(() => buildEip3009Domain({ network: 'base', asset: USDC_BASE, name: 'USD Coin' })).toThrow(
+      /name and version/i,
+    );
+  });
+
+  it('refuses a non-EVM network', () => {
+    expect(() =>
+      buildEip3009Domain({ network: 'solana', asset: USDC_BASE, name: 'x', version: '1' }),
+    ).toThrow(/not an evm network/i);
+  });
+
+  it('refuses a missing token address', () => {
+    expect(() => buildEip3009Domain({ network: 'base', name: 'x', version: '1' })).toThrow(
+      /verifyingContract/i,
+    );
+  });
+
+  it('declares the exact EIP-3009 struct', () => {
+    expect(TRANSFER_WITH_AUTHORIZATION_TYPES.TransferWithAuthorization).toEqual([
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'validAfter', type: 'uint256' },
+      { name: 'validBefore', type: 'uint256' },
+      { name: 'nonce', type: 'bytes32' },
+    ]);
+  });
+});
+
+describe('authorization', () => {
+  it('builds a well-formed authorization', () => {
+    const auth = buildAuthorization({ from: '0xPayer', to: '0xPayee', value: '6000' });
+
+    expect(auth.from).toBe('0xPayer');
+    expect(auth.to).toBe('0xPayee');
+    expect(auth.value).toBe('6000');
+    expect(auth.validAfter).toBe('0');
+    expect(Number(auth.validBefore)).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    expect(auth.nonce).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('leaves validAfter at 0 so clock skew cannot make it briefly invalid', () => {
+    expect(buildAuthorization({ from: '0xa', to: '0xb', value: '1' }).validAfter).toBe('0');
+  });
+
+  it('keeps large values exact as strings', () => {
+    const huge = '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+    expect(buildAuthorization({ from: '0xa', to: '0xb', value: huge }).value).toBe(huge);
+  });
+
+  it('requires from, to and value', () => {
+    expect(() => buildAuthorization({ to: '0xb', value: '1' })).toThrow(/from/);
+    expect(() => buildAuthorization({ from: '0xa', value: '1' })).toThrow(/to/);
+    expect(() => buildAuthorization({ from: '0xa', to: '0xb' })).toThrow(/value/);
+  });
+
+  it('mints distinct nonces', () => {
+    const seen = new Set(Array.from({ length: 50 }, () => randomNonce()));
+    expect(seen.size).toBe(50);
+  });
+});
+
+describe('payment header encoding', () => {
+  it('round-trips a payment', () => {
+    const payment = buildExactEvmPayment({
+      network: 'base',
+      signature: '0xsig',
+      authorization: buildAuthorization({ from: '0xa', to: '0xb', value: '6000' }),
+    });
+
+    expect(payment.x402Version).toBe(2);
+    expect(payment.network).toBe('eip155:8453');
+    expect(payment.scheme).toBe('exact');
+
+    expect(decodePaymentHeader(encodePaymentHeader(payment))).toEqual(payment);
+  });
+
+  it('survives non-ASCII content', () => {
+    const payment = { x402Version: 2, note: 'café — 支払い' };
+    expect(decodePaymentHeader(encodePaymentHeader(payment))).toEqual(payment);
+  });
+});
+
+describe('selecting an accepts entry', () => {
+  const accepts = [
+    { network: 'bitcoin', payTo: 'bc1q' },
+    { network: 'eip155:8453', payTo: '0xb' },
+    { network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', payTo: 'So1' },
+  ];
+
+  it("honours the merchant's ordering among what the payer supports", () => {
+    expect(selectAcceptEntry(accepts, ['eip155:8453', 'bitcoin']).network).toBe('bitcoin');
+  });
+
+  it('skips options the payer cannot sign', () => {
+    expect(selectAcceptEntry(accepts, ['eip155:8453']).payTo).toBe('0xb');
+  });
+
+  it('accepts capabilities given as legacy names', () => {
+    expect(selectAcceptEntry(accepts, ['base']).network).toBe('eip155:8453');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(selectAcceptEntry(accepts, ['eip155:1'])).toBeNull();
+    expect(selectAcceptEntry([], ['base'])).toBeNull();
+    expect(selectAcceptEntry(undefined, ['base'])).toBeNull();
+  });
+});
+
+describe('requiredAmount', () => {
+  it('reads the v2 `amount` field', () => {
+    expect(requiredAmount({ amount: '6000' })).toBe('6000');
+  });
+
+  it('still reads our v1 `maxAmountRequired`, so unmigrated 402s stay payable', () => {
+    expect(requiredAmount({ maxAmountRequired: '6000' })).toBe('6000');
+  });
+
+  it('prefers `amount` when both are present', () => {
+    expect(requiredAmount({ amount: '1', maxAmountRequired: '2' })).toBe('1');
+  });
+
+  it('throws when neither is present', () => {
+    expect(() => requiredAmount({})).toThrow(/amount/i);
+  });
+});

--- a/src/app/api/x402/settle/route.ts
+++ b/src/app/api/x402/settle/route.ts
@@ -36,6 +36,7 @@ import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { splitTieredPayment } from '@/lib/payments/fees';
 import { resolveScopedKey } from '@/lib/auth/scoped-keys';
 import { addressesEqual } from '@/lib/x402/address';
+import { isV2Payment } from '@/lib/x402/v2';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -330,13 +331,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid payment data' }, { status: 400 });
     }
 
-    const { network, scheme } = payment.payload;
-    const uniqueKey =
-      payment.payload.nonce ||
-      payment.payload.txId ||
-      payment.payload.txSignature ||
-      payment.payload.preimage ||
-      payment.payload.paymentIntentId;
+    // v2 proofs carry the network at the top level and the replay key inside
+    // `authorization`, so the v1 accessors below find neither. Reading them
+    // the v1 way would look up `unique_key IS NULL` on network `undefined` and
+    // report the payment as never verified.
+    const isV2 = isV2Payment(payment);
+
+    const network: string = isV2 ? payment.network : payment.payload.network;
+    const scheme: string = isV2 ? (payment.scheme ?? 'exact') : payment.payload.scheme;
+    const uniqueKey = isV2
+      ? payment.payload.authorization?.nonce
+      : payment.payload.nonce ||
+        payment.payload.txId ||
+        payment.payload.txSignature ||
+        payment.payload.preimage ||
+        payment.payload.paymentIntentId;
 
     // Find the verified payment record
     const query = supabase
@@ -433,7 +442,32 @@ export async function POST(request: NextRequest) {
     let result: { txHash: string; pending?: boolean; confirmed?: boolean; instant?: boolean; confirmations?: number };
 
     try {
-      if (scheme === 'bolt12' || network === 'lightning') {
+      if (isV2) {
+        // v2: nothing has been broadcast yet. Settling IS the broadcast — the
+        // token verifies the payer's signature itself and moves the funds,
+        // with our relayer paying the gas so the payer needs no native
+        // currency. The asset comes from the ledger rather than the request,
+        // so the caller cannot redirect settlement at a different token than
+        // the one the proof was verified against.
+        const authorization = payment.payload.authorization;
+        const signature = payment.payload.signature;
+        if (!authorization || !signature) {
+          throw new Error('v2 settlement needs payload.authorization and payload.signature');
+        }
+
+        // Imported here rather than at module scope: this pulls in the gas
+        // relayer and, through it, the system wallet, which drags ethers' `ws`
+        // dependency into every consumer of this route.
+        const { settleExactEvmV2 } = await import('@/lib/x402/settle-v2');
+
+        const settled = await settleExactEvmV2({
+          network,
+          asset: verifiedPayment.asset,
+          authorization,
+          signature,
+        });
+        result = { txHash: settled.txHash, confirmed: true };
+      } else if (scheme === 'bolt12' || network === 'lightning') {
         // Lightning: preimage proves payment, instant settlement
         // Funds already went to merchant's Lightning node via BOLT12 offer
         result = await settleLightning(payment);

--- a/src/app/api/x402/verify/route.test.ts
+++ b/src/app/api/x402/verify/route.test.ts
@@ -43,6 +43,17 @@ vi.mock('@/lib/auth/scoped-keys', () => ({
 }));
 
 // Mock ethers
+// The v2 verifier does real cryptography against a real token domain and is
+// covered in src/lib/x402/v2.test.ts. Here only the route's own behaviour is
+// under test — what it demands, what it records, how it answers — so the
+// verdict is stubbed. `isV2Payment` stays real, because routing to the v2 path
+// at all is part of what these tests check.
+const mockVerifyExactEvmV2 = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/x402/v2', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/x402/v2')>()),
+  verifyExactEvmV2: mockVerifyExactEvmV2,
+}));
+
 vi.mock('ethers', () => ({
   ethers: {
     verifyTypedData: vi.fn().mockReturnValue('0xBuyerAddress'),
@@ -420,5 +431,158 @@ describe('POST /api/x402/verify', () => {
       expect(res.status).toBe(200);
       expect(storedRow().to_address).toBe(EVM_PAYEE.toLowerCase());
     });
+  });
+});
+
+/**
+ * x402 v2 (EIP-3009) proofs.
+ *
+ * A v2 proof carries no `resource` field — EIP-3009 has nowhere to put one —
+ * so it cannot go through the v1 price/resource binding and takes its own
+ * path. These cover what that path demands and what it writes.
+ */
+describe('POST /api/x402/verify — v2 (EIP-3009) proofs', () => {
+  const NONCE = '0x' + '11'.repeat(32);
+  const PAYER = '0x9dBA414637c611a16BEa6f0796BFcbcBdc410df8';
+  const V2_PAYEE = '0x1111111111111111111111111111111111111111';
+  const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+  function v2Payment() {
+    return {
+      x402Version: 2,
+      scheme: 'exact',
+      network: 'eip155:8453',
+      payload: {
+        signature: '0xsig',
+        authorization: {
+          from: PAYER,
+          to: V2_PAYEE,
+          value: '6000',
+          validAfter: '0',
+          validBefore: String(Math.floor(Date.now() / 1000) + 600),
+          nonce: NONCE,
+        },
+      },
+    };
+  }
+
+  function fullExpectation(overrides: Record<string, unknown> = {}) {
+    return { amount: '6000', resource: RESOURCE, payTo: V2_PAYEE, asset: USDC_BASE, ...overrides };
+  }
+
+  function storedRow() {
+    expect(mockInsert).toHaveBeenCalled();
+    return mockInsert.mock.calls.at(-1)![0];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockResolveScopedKey.mockResolvedValue({
+      keyId: 'key1',
+      business: { id: 'biz1', merchant_id: 'm1', name: 'Biz', active: true },
+      scopes: [],
+    });
+    mockVerifyExactEvmV2.mockResolvedValue({
+      valid: true,
+      payment: {
+        from: PAYER,
+        to: V2_PAYEE,
+        amount: '6000',
+        asset: USDC_BASE,
+        network: 'eip155:8453',
+        uniqueKey: NONCE,
+        validBefore: '9999999999',
+      },
+    });
+    mockInsert.mockReturnValue({ error: null });
+  });
+
+  it('verifies a v2 proof and answers with x402Version 2', async () => {
+    const res = await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.x402Version).toBe(2);
+    expect(data.payment.network).toBe('eip155:8453');
+  });
+
+  it('records the EIP-3009 nonce as the replay key', async () => {
+    await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+    expect(storedRow().unique_key).toBe(NONCE);
+  });
+
+  it('records the resource even though the signature cannot bind it', async () => {
+    await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+    expect(storedRow().resource).toBe(RESOURCE);
+  });
+
+  it('never marks a v2 proof as pending — the signature is final', async () => {
+    const res = await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+    const data = await res.json();
+
+    expect(data.payment.pendingConfirmation).toBe(false);
+    expect(data.payment.amountAuthenticated).toBe(true);
+    expect(storedRow().pending_confirmation).toBe(false);
+  });
+
+  it.each(['amount', 'resource', 'payTo', 'asset'])(
+    'refuses when expected.%s is missing',
+    async (field) => {
+      const expected = fullExpectation();
+      delete (expected as Record<string, unknown>)[field];
+
+      const res = await POST(makeRequest({ payment: v2Payment(), expected }));
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain(field);
+      expect(mockInsert).not.toHaveBeenCalled();
+    },
+  );
+
+  it('passes the payee and asset through to the verifier', async () => {
+    await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+
+    expect(mockVerifyExactEvmV2).toHaveBeenCalledWith(expect.anything(), {
+      amount: '6000',
+      payTo: V2_PAYEE,
+      asset: USDC_BASE,
+    });
+  });
+
+  it("surfaces the verifier's rejection", async () => {
+    mockVerifyExactEvmV2.mockResolvedValue({ valid: false, error: 'Invalid payment signature' });
+
+    const res = await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid payment signature/i);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('reports a replayed nonce', async () => {
+    mockInsert.mockReturnValue({ error: { code: '23505', message: 'duplicate key' } });
+
+    const res = await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/replay/i);
+  });
+
+  it('fails closed when the proof cannot be recorded', async () => {
+    mockInsert.mockReturnValue({ error: { code: '42P01', message: 'missing table' } });
+
+    const res = await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).valid).toBeUndefined();
+  });
+
+  it('does not store the raw signature', async () => {
+    await POST(makeRequest({ payment: v2Payment(), expected: fullExpectation() }));
+    expect(storedRow().raw_proof).toContain('_redacted');
   });
 });

--- a/src/app/api/x402/verify/route.ts
+++ b/src/app/api/x402/verify/route.ts
@@ -15,6 +15,7 @@ import { createClient } from '@supabase/supabase-js';
 import { ethers } from 'ethers';
 import { resolveScopedKey } from '@/lib/auth/scoped-keys';
 import { normalizeAddressForNetwork } from '@/lib/x402/address';
+import { isV2Payment, verifyExactEvmV2, type V2Payment } from '@/lib/x402/v2';
 import { createHash } from 'crypto';
 
 function getSupabase() {
@@ -286,6 +287,107 @@ function redactProof(payment: any): string {
   return JSON.stringify({ ...payment, payload, _redacted: true });
 }
 
+/**
+ * Verify a v2 (EIP-3009) proof and record it.
+ *
+ * Kept separate from the v1 path rather than folded into it, because almost
+ * nothing is shared: there is no transaction to look up, no `pendingConfirmation`
+ * (the signature is final the moment it verifies), and the replay key is the
+ * EIP-3009 nonce rather than a grab-bag of possible identifiers.
+ */
+async function verifyV2(
+  _request: NextRequest,
+  supabase: ReturnType<typeof getSupabase>,
+  keyData: { business_id: string },
+  payment: unknown,
+  expected: {
+    amount?: string;
+    resource?: string;
+    payTo?: string;
+    asset?: string;
+  } | undefined,
+) {
+  if (!expected || typeof expected !== 'object') {
+    return NextResponse.json(
+      { error: 'Missing `expected` — verification requires the asking price, payee and asset' },
+      { status: 400 },
+    );
+  }
+  // `payTo` and `asset` are needed here but not in v1: an EIP-3009 signature
+  // says nothing about which token it is denominated in, so without the asset
+  // there is no domain to verify it against, and without the payee there is
+  // nothing to check `authorization.to` means the merchant.
+  for (const field of ['amount', 'resource', 'payTo', 'asset'] as const) {
+    if (!expected[field]) {
+      return NextResponse.json(
+        { error: `Missing \`expected.${field}\` — required to verify an x402 v2 proof` },
+        { status: 400 },
+      );
+    }
+  }
+
+  const result = await verifyExactEvmV2(payment as V2Payment, {
+    amount: expected.amount!,
+    payTo: expected.payTo!,
+    asset: expected.asset!,
+  });
+
+  if (!result.valid || !result.payment) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  const verified = result.payment;
+
+  const { error: insertError } = await supabase.from('x402_payments').insert({
+    business_id: keyData.business_id,
+    from_address: normalizeAddressForNetwork(verified.network, verified.from),
+    to_address: normalizeAddressForNetwork(verified.network, verified.to),
+    amount: verified.amount,
+    unique_key: verified.uniqueKey,
+    network: verified.network,
+    scheme: 'exact',
+    asset: verified.asset,
+    resource: expected.resource,
+    raw_proof: redactProof(payment),
+    status: 'verified',
+    // Nothing is pending: an EIP-3009 signature is complete on its own. What
+    // has not happened yet is settlement, which is a separate call.
+    pending_confirmation: false,
+  });
+
+  if (insertError) {
+    if (insertError.code === '23505') {
+      return NextResponse.json(
+        { error: 'Payment proof already used (replay detected)' },
+        { status: 400 },
+      );
+    }
+    console.error('x402 verify (v2): could not record payment', insertError);
+    return NextResponse.json(
+      { error: 'Could not record payment — verification refused' },
+      { status: 503 },
+    );
+  }
+
+  return NextResponse.json({
+    valid: true,
+    x402Version: 2,
+    payment: {
+      from: verified.from,
+      to: verified.to,
+      amount: verified.amount,
+      asset: verified.asset,
+      network: verified.network,
+      resource: expected.resource,
+      validBefore: verified.validBefore,
+      pendingConfirmation: false,
+      // The signature binds the amount, so it cannot be altered without
+      // invalidating the proof.
+      amountAuthenticated: true,
+    },
+  });
+}
+
 export async function POST(request: NextRequest) {
   try {
     const apiKey = request.headers.get('x-api-key');
@@ -318,6 +420,14 @@ export async function POST(request: NextRequest) {
         { error: 'Invalid payment proof: missing payload' },
         { status: 400 }
       );
+    }
+
+    // v2 proofs are a different object entirely: an EIP-3009 authorization
+    // that IS the payment, rather than a claim about a transaction. They carry
+    // no `resource` field — EIP-3009 has nowhere to put one — so they cannot
+    // go through `enforcePriceBinding`, which checks exactly that.
+    if (isV2Payment(payment)) {
+      return await verifyV2(request, supabase, keyData, payment, expected);
     }
 
     // What the merchant is charging, and for what. Checked before the proof is

--- a/src/lib/x402/settle-v2.ts
+++ b/src/lib/x402/settle-v2.ts
@@ -1,0 +1,146 @@
+/**
+ * x402 v2 settlement — broadcasting an EIP-3009 authorization.
+ *
+ * The v1 rail settles by looking up a transaction the payer already broadcast.
+ * v2 inverts that: the payer signed and broadcast nothing, so settling IS the
+ * broadcast. We call `transferWithAuthorization` on the token, the token
+ * verifies the signature itself and moves the funds from payer to payee, and
+ * the relayer pays the gas.
+ *
+ * That is what lets a payer with no native currency buy something — the whole
+ * reason the ecosystem settled on EIP-3009 for the `exact` scheme.
+ *
+ * The funds go payer -> payee directly. No CoinPayPortal wallet is in the
+ * path, so as on the v1 rail the platform fee is not collected here; see the
+ * header of src/app/api/x402/settle/route.ts.
+ */
+
+import { ethers } from 'ethers';
+import { getGasRelayer } from '@/lib/wallets/evm-gas';
+import type { SystemBlockchain } from '@/lib/wallets/system-wallet';
+import { evmChainId, type V2Authorization } from './v2';
+
+/**
+ * `transferWithAuthorization` in its (v, r, s) form.
+ *
+ * EIP-3009 also defines a variant taking a packed 65-byte signature, but the
+ * split form is the one every major deployment exposes, so it is what is used.
+ */
+export const EIP3009_ABI = [
+  'function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s)',
+  'function authorizationState(address authorizer, bytes32 nonce) view returns (bool)',
+];
+
+/** Gas limit for a `transferWithAuthorization` call. */
+export const TRANSFER_WITH_AUTHORIZATION_GAS_LIMIT = 150_000n;
+
+/** Which system wallet family funds the relayer on a given chain. */
+const CHAIN_TO_SYSTEM_WALLET: Record<number, SystemBlockchain> = {
+  1: 'ETH',
+  137: 'POL',
+  8453: 'ETH', // Base derives from the ETH family
+};
+
+const RPC_BY_CHAIN_ID: Record<number, string | undefined> = {
+  1: process.env.ETHEREUM_RPC_URL || 'https://eth.llamarpc.com',
+  137: process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
+  8453: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
+};
+
+export interface SettleV2Result {
+  txHash: string;
+  relayerAddress: string;
+  confirmed: boolean;
+}
+
+/**
+ * Broadcast an authorization, moving the funds.
+ *
+ * @param network        CAIP-2 id, or a legacy bare name
+ * @param asset          token contract address
+ * @param authorization  the signed EIP-3009 authorization
+ * @param signature      the payer's 65-byte signature over it
+ */
+export async function settleExactEvmV2({
+  network,
+  asset,
+  authorization,
+  signature,
+}: {
+  network: string;
+  asset: string;
+  authorization: V2Authorization;
+  signature: string;
+}): Promise<SettleV2Result> {
+  const chainId = evmChainId(network);
+  if (chainId === null) throw new Error(`Not an EVM network: ${network}`);
+
+  const rpcUrl = RPC_BY_CHAIN_ID[chainId];
+  if (!rpcUrl) throw new Error(`No RPC configured for chain ${chainId}`);
+
+  const family = CHAIN_TO_SYSTEM_WALLET[chainId];
+  if (!family) throw new Error(`No relayer configured for chain ${chainId}`);
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const relayer = await getGasRelayer(family, provider);
+
+  const token = new ethers.Contract(asset, EIP3009_ABI, relayer.wallet);
+
+  // Refuse early if the token has already seen this nonce. Broadcasting anyway
+  // would burn gas on a call the token reverts, and the revert reason is
+  // indistinguishable from a malformed signature once it comes back.
+  try {
+    const used = await token.authorizationState(authorization.from, authorization.nonce);
+    if (used) {
+      throw new Error('Authorization has already been used on-chain');
+    }
+  } catch (err) {
+    // A token that does not expose authorizationState is still settleable —
+    // only re-throw our own refusal.
+    if ((err as Error).message?.includes('already been used')) throw err;
+  }
+
+  // Split the signature. `ethers.Signature.from` validates the shape and
+  // normalises `v`, which wallets emit as either 0/1 or 27/28.
+  let sig: ethers.Signature;
+  try {
+    sig = ethers.Signature.from(signature);
+  } catch (err) {
+    throw new Error(`Malformed signature: ${(err as Error).message}`);
+  }
+
+  const estimatedCost = await estimateCost(provider);
+  if (relayer.balance < estimatedCost) {
+    throw new Error(
+      `Gas relayer ${relayer.address} has ${ethers.formatEther(relayer.balance)} on chain ` +
+        `${chainId}, needs about ${ethers.formatEther(estimatedCost)} — top up the float`,
+    );
+  }
+
+  const tx = await token.transferWithAuthorization(
+    authorization.from,
+    authorization.to,
+    authorization.value,
+    authorization.validAfter,
+    authorization.validBefore,
+    authorization.nonce,
+    sig.v,
+    sig.r,
+    sig.s,
+    { gasLimit: TRANSFER_WITH_AUTHORIZATION_GAS_LIMIT },
+  );
+
+  const receipt = await tx.wait();
+
+  if (!receipt || receipt.status !== 1) {
+    throw new Error(`Authorization transfer reverted (tx ${tx.hash})`);
+  }
+
+  return { txHash: tx.hash, relayerAddress: relayer.address, confirmed: true };
+}
+
+async function estimateCost(provider: ethers.Provider): Promise<bigint> {
+  const fee = await provider.getFeeData();
+  const price = fee.maxFeePerGas ?? fee.gasPrice ?? 0n;
+  return price * TRANSFER_WITH_AUTHORIZATION_GAS_LIMIT;
+}

--- a/src/lib/x402/v2.test.ts
+++ b/src/lib/x402/v2.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ethers } from 'ethers';
+
+// The token domain is read from the chain. Stub the resolver so these tests
+// exercise the verification logic rather than an RPC round-trip.
+const mockResolvePermitDomain = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/wallets/evm-gas', () => ({
+  resolvePermitDomain: mockResolvePermitDomain,
+}));
+
+import {
+  isV2Payment,
+  evmChainId,
+  verifyExactEvmV2,
+  TRANSFER_WITH_AUTHORIZATION_TYPES,
+} from './v2';
+import { TRANSFER_WITH_AUTHORIZATION_TYPES as SDK_TYPES } from '../../../packages/sdk/src/x402-v2.js';
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const PAYEE = '0x1111111111111111111111111111111111111111';
+
+// A real key, so signatures are genuinely recovered rather than stubbed.
+const wallet = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+);
+
+const DOMAIN = {
+  name: 'USD Coin',
+  version: '2',
+  chainId: 8453,
+  verifyingContract: USDC_BASE,
+};
+
+function authorization(overrides: Record<string, string> = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    from: wallet.address,
+    to: PAYEE,
+    value: '6000',
+    validAfter: '0',
+    validBefore: String(now + 600),
+    nonce: '0x' + '11'.repeat(32),
+    ...overrides,
+  };
+}
+
+async function signedPayment(overrides: Record<string, string> = {}, domain = DOMAIN) {
+  const auth = authorization(overrides);
+  const signature = await wallet.signTypedData(domain, TRANSFER_WITH_AUTHORIZATION_TYPES, auth);
+  return {
+    x402Version: 2,
+    scheme: 'exact',
+    network: 'eip155:8453',
+    payload: { signature, authorization: auth },
+  };
+}
+
+const expected = { amount: '6000', payTo: PAYEE, asset: USDC_BASE };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolvePermitDomain.mockResolvedValue(DOMAIN);
+});
+
+describe('struct definition', () => {
+  it('matches the SDK exactly, or the payer signs what we cannot verify', () => {
+    expect(TRANSFER_WITH_AUTHORIZATION_TYPES).toEqual(SDK_TYPES);
+  });
+});
+
+describe('isV2Payment', () => {
+  it('recognises a v2 proof by its nested authorization', () => {
+    expect(
+      isV2Payment({ payload: { signature: '0xsig', authorization: { nonce: '0x1' } } }),
+    ).toBe(true);
+  });
+
+  it('recognises an explicit x402Version: 2', () => {
+    expect(isV2Payment({ x402Version: 2, payload: {} })).toBe(true);
+  });
+
+  it('does not mistake a v1 proof for v2', () => {
+    expect(
+      isV2Payment({ payload: { network: 'base', to: '0xb', amount: '6000', nonce: '0xabc' } }),
+    ).toBe(false);
+  });
+
+  it('tolerates junk', () => {
+    expect(isV2Payment(null)).toBe(false);
+    expect(isV2Payment('nope')).toBe(false);
+    expect(isV2Payment({})).toBe(false);
+  });
+});
+
+describe('evmChainId', () => {
+  it('reads CAIP-2 ids', () => {
+    expect(evmChainId('eip155:8453')).toBe(8453);
+    expect(evmChainId('eip155:1')).toBe(1);
+  });
+
+  it('still accepts legacy bare names', () => {
+    expect(evmChainId('base')).toBe(8453);
+  });
+
+  it('rejects non-EVM networks', () => {
+    expect(evmChainId('solana')).toBeNull();
+    expect(evmChainId('bitcoin')).toBeNull();
+    expect(evmChainId(null)).toBeNull();
+  });
+});
+
+describe('verifyExactEvmV2', () => {
+  it('accepts a correctly signed authorization', async () => {
+    const result = await verifyExactEvmV2(await signedPayment(), expected);
+
+    expect(result.valid).toBe(true);
+    expect(result.payment).toMatchObject({
+      from: wallet.address,
+      to: PAYEE,
+      amount: '6000',
+      network: 'eip155:8453',
+      uniqueKey: '0x' + '11'.repeat(32),
+    });
+  });
+
+  it('uses the EIP-3009 nonce as the replay key', async () => {
+    const nonce = '0x' + 'ab'.repeat(32);
+    const result = await verifyExactEvmV2(await signedPayment({ nonce }), expected);
+    expect(result.payment?.uniqueKey).toBe(nonce);
+  });
+
+  it('accepts an overpayment', async () => {
+    const result = await verifyExactEvmV2(await signedPayment({ value: '9999' }), expected);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an underpayment', async () => {
+    const result = await verifyExactEvmV2(await signedPayment({ value: '5999' }), expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/underpayment/i);
+  });
+
+  it('compares amounts as integers, not floats', async () => {
+    const owed = '10000000000000000000000';
+    const paid = '9999999999999999999999';
+    const result = await verifyExactEvmV2(await signedPayment({ value: paid }), {
+      ...expected,
+      amount: owed,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/underpayment/i);
+  });
+
+  it('rejects an authorization that pays someone else', async () => {
+    const result = await verifyExactEvmV2(
+      await signedPayment({ to: '0x2222222222222222222222222222222222222222' }),
+      expected,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/is paid to/i);
+  });
+
+  it('rejects an expired authorization', async () => {
+    const past = String(Math.floor(Date.now() / 1000) - 10);
+    const result = await verifyExactEvmV2(await signedPayment({ validBefore: past }), expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expired/i);
+  });
+
+  it('rejects an authorization that is not valid yet', async () => {
+    const future = String(Math.floor(Date.now() / 1000) + 300);
+    const result = await verifyExactEvmV2(await signedPayment({ validAfter: future }), expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/not valid yet/i);
+  });
+
+  it('rejects a signature from a different key', async () => {
+    const payment = await signedPayment();
+    // Same authorization, but claim a different payer.
+    payment.payload.authorization.from = '0x3333333333333333333333333333333333333333';
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/invalid payment signature/i);
+  });
+
+  it('rejects a signature made against a domain the token does not use', async () => {
+    // Signed under the old bespoke x402 domain — exactly what a v1 client
+    // would produce, and precisely what must not verify.
+    const bogus = { name: 'x402', version: '1', chainId: 8453, verifyingContract: USDC_BASE };
+    const payment = await signedPayment({}, bogus);
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/invalid payment signature/i);
+  });
+
+  it('does not let the payer nominate the domain', async () => {
+    // The chain says the domain is DOMAIN; a proof signed under anything else
+    // must fail even if the proof itself claims otherwise.
+    mockResolvePermitDomain.mockResolvedValue(DOMAIN);
+    const payment = await signedPayment({}, { ...DOMAIN, name: 'Attacker Coin' });
+
+    expect((await verifyExactEvmV2(payment, expected)).valid).toBe(false);
+  });
+
+  it('refuses a token with no EIP-712 domain', async () => {
+    mockResolvePermitDomain.mockResolvedValue(null);
+    const result = await verifyExactEvmV2(await signedPayment(), expected);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/does not expose an EIP-712 domain/i);
+  });
+
+  it('rejects a non-EVM network', async () => {
+    const payment = await signedPayment();
+    payment.network = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/not an evm network/i);
+  });
+
+  it('rejects an incomplete authorization', async () => {
+    const payment = await signedPayment();
+    delete (payment.payload.authorization as Record<string, unknown>).nonce;
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing `nonce`/i);
+  });
+
+  it('rejects a proof with no signature', async () => {
+    const payment = await signedPayment();
+    delete (payment.payload as Record<string, unknown>).signature;
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/authorization and payload.signature/i);
+  });
+
+  it('refuses when the asset is unknown, since the domain cannot be resolved', async () => {
+    const result = await verifyExactEvmV2(await signedPayment(), { ...expected, asset: '' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expected\.asset/i);
+  });
+
+  it('reports a malformed signature rather than throwing', async () => {
+    const payment = await signedPayment();
+    payment.payload.signature = '0xdeadbeef';
+
+    const result = await verifyExactEvmV2(payment, expected);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/malformed signature/i);
+  });
+});

--- a/src/lib/x402/v2.ts
+++ b/src/lib/x402/v2.ts
@@ -1,0 +1,270 @@
+/**
+ * x402 v2 verification — EIP-3009 `exact` payments on EVM.
+ *
+ * A v2 proof is not a claim that a transaction happened; it IS the payment. The
+ * payer signs an EIP-3009 `TransferWithAuthorization` and hands it over, and
+ * whoever holds that signature can call `transferWithAuthorization` on the
+ * token to move the funds. So verification here is pure cryptography plus a
+ * few bounds checks — there is no chain lookup, because nothing has been
+ * broadcast yet.
+ *
+ * That is the opposite of the v1 path, where the payer broadcast first and we
+ * confirmed afterwards, and it is why v2 payers need no native currency: the
+ * facilitator broadcasts and pays the gas.
+ */
+
+import { ethers } from 'ethers';
+
+/**
+ * EIP-3009 `TransferWithAuthorization`.
+ *
+ * Mirrors `TRANSFER_WITH_AUTHORIZATION_TYPES` in
+ * `packages/sdk/src/x402-v2.js`. The two are asserted equal by
+ * `src/lib/x402/v2.test.ts` rather than shared through an import, so the Next
+ * build does not take a runtime dependency on the SDK package — but they must
+ * never drift, because the payer signs one and this verifies the other.
+ */
+export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+};
+
+/** CAIP-2 -> numeric EVM chain id, or null when it is not an eip155 chain. */
+export function evmChainId(network: string | null | undefined): number | null {
+  if (!network) return null;
+  const match = /^eip155:(\d+)$/.exec(network);
+  if (match) return Number(match[1]);
+
+  // Legacy bare names, so a v2 proof that names a chain the old way still works.
+  const legacy: Record<string, number> = { ethereum: 1, polygon: 137, base: 8453 };
+  return legacy[network] ?? null;
+}
+
+/** RPC endpoint per numeric chain id. */
+const RPC_BY_CHAIN_ID: Record<number, string | undefined> = {
+  1: process.env.ETHEREUM_RPC_URL || 'https://eth.llamarpc.com',
+  137: process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
+  8453: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
+};
+
+export interface V2Authorization {
+  from: string;
+  to: string;
+  value: string;
+  validAfter: string;
+  validBefore: string;
+  nonce: string;
+}
+
+export interface V2Payment {
+  x402Version?: number;
+  scheme?: string;
+  network?: string;
+  payload?: {
+    signature?: string;
+    authorization?: V2Authorization;
+  };
+}
+
+/**
+ * Does this look like a v2 proof rather than our v1 dialect?
+ *
+ * v1 payloads carry the payment fields flat (`payload.to`, `payload.amount`);
+ * v2 nests them under `payload.authorization` alongside a signature. Detecting
+ * on shape rather than on `x402Version` alone means a client that omits the
+ * version still routes correctly.
+ */
+export function isV2Payment(payment: unknown): payment is V2Payment {
+  const p = payment as V2Payment | null;
+  if (!p || typeof p !== 'object') return false;
+  const auth = p.payload?.authorization;
+  return (
+    p.x402Version === 2 ||
+    (!!auth && typeof auth === 'object' && typeof auth.nonce === 'string' && !!p.payload?.signature)
+  );
+}
+
+export interface V2VerifyExpectation {
+  /** Smallest-unit amount the resource costs. */
+  amount: string;
+  /** Address the merchant expects to be paid. */
+  payTo: string;
+  /** Token contract the payment must be denominated in. */
+  asset: string;
+}
+
+export interface V2VerifyResult {
+  valid: boolean;
+  error?: string;
+  /** Canonical fields for the ledger, present only when valid. */
+  payment?: {
+    from: string;
+    to: string;
+    amount: string;
+    asset: string;
+    network: string;
+    /** The EIP-3009 nonce — this proof's single-use replay identity. */
+    uniqueKey: string;
+    validBefore: string;
+  };
+}
+
+/** Parse a decimal or hex integer string, or return null. */
+function toBigInt(value: unknown): bigint | null {
+  try {
+    return BigInt(String(value));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify an EIP-3009 `exact` payment.
+ *
+ * Checks, in order: the shape is complete, the network is one we settle on,
+ * the authorization is currently valid in time, it pays the expected payee at
+ * least the asking price, and the signature recovers to the stated payer under
+ * the token's own EIP-712 domain.
+ *
+ * The domain is resolved from the token contract rather than taken from the
+ * proof. A payer who could nominate the domain could nominate one whose
+ * separator they control, sign under that, and have the recovery succeed
+ * against an authorization the real token would reject.
+ *
+ * NOTE ON RESOURCE BINDING: EIP-3009's struct has no field for the resource
+ * being bought, so unlike our v1 proofs a v2 proof cannot be cryptographically
+ * bound to a URL. What bounds it is the payee, the amount, and the nonce being
+ * spendable once. The residual exposure is that a proof minted for one
+ * resource can buy a DIFFERENT resource from the SAME merchant at the SAME or
+ * lower price. That is inherent to the scheme, not an oversight here, and the
+ * caller records the resource so it is at least auditable after the fact.
+ */
+export async function verifyExactEvmV2(
+  payment: V2Payment,
+  expected: V2VerifyExpectation,
+): Promise<V2VerifyResult> {
+  const auth = payment.payload?.authorization;
+  const signature = payment.payload?.signature;
+
+  if (!auth || !signature) {
+    return { valid: false, error: 'v2 proof must carry payload.authorization and payload.signature' };
+  }
+  for (const field of ['from', 'to', 'value', 'validAfter', 'validBefore', 'nonce'] as const) {
+    if (!auth[field]) {
+      return { valid: false, error: `v2 authorization is missing \`${field}\`` };
+    }
+  }
+
+  const chainId = evmChainId(payment.network);
+  if (chainId === null) {
+    return { valid: false, error: `Not an EVM network for the exact scheme: ${payment.network}` };
+  }
+  const rpcUrl = RPC_BY_CHAIN_ID[chainId];
+  if (!rpcUrl) {
+    return { valid: false, error: `No RPC configured for chain ${chainId}` };
+  }
+
+  if (!expected.asset) {
+    return { valid: false, error: 'Missing `expected.asset` — cannot resolve the token domain' };
+  }
+
+  // Time bounds. An expired authorization is worthless: the token itself will
+  // reject it, so accepting one here would promise a settlement that cannot
+  // happen.
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  const validAfter = toBigInt(auth.validAfter);
+  const validBefore = toBigInt(auth.validBefore);
+  if (validAfter === null || validBefore === null) {
+    return { valid: false, error: 'v2 authorization has a non-integer validity window' };
+  }
+  if (validBefore <= now) {
+    return { valid: false, error: 'Payment authorization has expired' };
+  }
+  if (validAfter > now) {
+    return { valid: false, error: 'Payment authorization is not valid yet' };
+  }
+
+  // Value and payee.
+  const value = toBigInt(auth.value);
+  const owed = toBigInt(expected.amount);
+  if (value === null || owed === null) {
+    return { valid: false, error: 'Invalid amount: expected an integer in the asset smallest unit' };
+  }
+  if (value < owed) {
+    return { valid: false, error: `Underpayment: authorization pays ${value}, resource costs ${owed}` };
+  }
+  if (auth.to.toLowerCase() !== expected.payTo.toLowerCase()) {
+    return {
+      valid: false,
+      error: `Authorization pays ${auth.to}, but this resource is paid to ${expected.payTo}`,
+    };
+  }
+
+  // The token's real domain, read from the contract.
+  let domain: ethers.TypedDataDomain | null;
+  try {
+    // Imported here rather than at module scope: `evm-gas` reaches the system
+    // wallet, which drags ethers' `ws` dependency into every module that so
+    // much as imports `isV2Payment` from this file.
+    const { resolvePermitDomain } = await import('@/lib/wallets/evm-gas');
+
+    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const token = new ethers.Contract(
+      expected.asset,
+      [
+        'function name() view returns (string)',
+        'function version() view returns (string)',
+        'function DOMAIN_SEPARATOR() view returns (bytes32)',
+      ],
+      provider,
+    );
+    domain = await resolvePermitDomain(token, BigInt(chainId));
+  } catch (err) {
+    return {
+      valid: false,
+      error: `Could not read the token's EIP-712 domain: ${(err as Error).message}`,
+    };
+  }
+
+  if (!domain) {
+    return {
+      valid: false,
+      error:
+        `Token ${expected.asset} does not expose an EIP-712 domain, ` +
+        'so an EIP-3009 authorization against it cannot be verified',
+    };
+  }
+
+  // Recover the signer.
+  let recovered: string;
+  try {
+    recovered = ethers.verifyTypedData(domain, TRANSFER_WITH_AUTHORIZATION_TYPES, auth, signature);
+  } catch (err) {
+    return { valid: false, error: `Malformed signature: ${(err as Error).message}` };
+  }
+
+  if (recovered.toLowerCase() !== auth.from.toLowerCase()) {
+    return { valid: false, error: 'Invalid payment signature' };
+  }
+
+  return {
+    valid: true,
+    payment: {
+      from: auth.from,
+      to: auth.to,
+      amount: auth.value,
+      asset: expected.asset,
+      network: payment.network ?? `eip155:${chainId}`,
+      // The nonce is the authorization's identity: the token rejects a second
+      // use of it, so it is exactly the right replay key for our ledger too.
+      uniqueKey: auth.nonce,
+      validBefore: auth.validBefore,
+    },
+  };
+}


### PR DESCRIPTION
Draft — the CoinPay Wallet path still needs EIP-712 signing in the extension. Everything here works today via MetaMask/Phantom.

Nothing could pay a CoinPay-gated endpoint before this. Standard clients could not, because we spoke a private dialect; CoinPay Wallet could not, because `window.coinpay` exposes only getState/connect/getAccounts/payBatch — while the README, both manifests and the store listing all advertise "one-click x402 payments" against no implementation.

## Supporting MetaMask and Phantom is what forced the dialect out

Those wallets sign standard structures and nothing else. MetaMask will happily sign our old `name: 'x402'` domain — the signature simply authorises no transfer on-chain and only we could interpret it. So spec compliance stopped being a nice-to-have and became a prerequisite.

Field shapes throughout were taken from live `/supported` and `/discovery/resources` responses on GoPlausible's and Coinbase's facilitators, not from memory of the spec.

## Three commits

**`3a6e108` — the payer.** `x402-v2.js` (CAIP-2 ids, `x402Version: 2`, `amount`, EIP-3009 with the token's own EIP-712 domain) and `x402-browser.js` (EIP-6963 discovery so multiple injected wallets are enumerated properly instead of racing over `window.ethereum`; CoinPay preferred; `fetchWithX402`).

Retries exactly once — a second 402 means the payment was refused rather than missing, and re-signing would spend the user's money on a resource that just said no. CoinPay is detected by the presence of `payX402`, not `isCoinPay`, so today's extension falls back to MetaMask instead of throwing a TypeError at someone who had a working wallet all along.

**`39e2a60` — verify and settle.** A v2 proof is not a claim that a transaction happened, it IS the payment, so verification is pure cryptography with no chain lookup — nothing has been broadcast yet.

The token's EIP-712 domain is resolved **from the contract**, reusing `resolvePermitDomain` from the permit relayer (#255), which hashes candidates against the token's own `DOMAIN_SEPARATOR()` rather than guessing the version field. A payer allowed to nominate the domain could nominate one whose separator they control, sign under that, and have recovery succeed against an authorization the real token would reject. Tested directly, along with a proof signed under the old `x402` domain failing.

Settlement inverts v1: the payer broadcast nothing, so settling IS the broadcast. We call the token, it verifies the signature itself, and the relayer pays the gas — which is what lets a payer holding no native currency buy anything. The asset comes from the ledger rather than the request, so a caller cannot redirect settlement at a different token than the one verified; `authorizationState` is checked first so a spent nonce fails before burning gas on a revert.

**`49f3a10` — quoting.** Verifying v2 while only ever quoting v1 still leaves you unpayable. `buildPaymentRequiredV2` emits a readable offer carrying `extra: {name, version}`.

Those domains were **read from the deployed contracts** over JSON-RPC, not copied from docs — all three USDC deployments report name `USD Coin` version `2`, and the Base values match GoPlausible's published index. A token whose domain has not been read is not quoted at all: guessing produces signatures that recover to the wrong address and fail with no useful diagnostic, so an unpayable entry is worse than an absent one.

The middleware takes `x402Version`, **defaulting to 1** — existing integrations keep the offer they have today, since their payers only understand our dialect.

## Known limitations, stated rather than hidden

**Resource binding is weaker on v2.** EIP-3009's struct has no field for the resource, so a v2 proof cannot be bound to a URL the way #248 bound v1 proofs. What bounds it is payee + amount + single-use nonce. Residual exposure: a proof minted for one resource can buy a *different* resource from the *same* merchant at the *same or lower* price. Inherent to the scheme; the resource is still recorded for audit.

**The platform fee is still not collected.** Funds move payer→payee directly here too, so the open decision from #263 is unchanged.

**Both hardcoded RPC fallbacks are dead.** Found while verifying the domains: `eth.llamarpc.com` returns 521, `polygon-rpc.com` reports "API key disabled". Ethereum and Polygon settlement depends on `ETHEREUM_RPC_URL` / `POLYGON_RPC_URL` being set in the deploy. Not changed here — worth checking before this ships.

## Tests

295 files / 4182 passing, `tsc --noEmit` clean, eslint 0 errors. 104 new tests, including real signature round-trips with a real key and a drift guard asserting the SDK's EIP-3009 struct matches the facilitator's — the payer signs one and the facilitator verifies the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)