### PR TITLE
feat(extension): sign EIP-712, so CoinPay Wallet can pay x402

### DIFF
--- a/packages/extension/src/approval/app.ts
+++ b/packages/extension/src/approval/app.ts
@@ -40,7 +40,71 @@ export async function start(): Promise<void> {
 function render(): void {
   if (!approval) return;
   if (approval.kind === 'connect') return renderConnect(approval);
+  if (approval.kind === 'payX402') return renderX402(approval);
   return renderBatch(approval);
+}
+
+// ── x402 ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Approve paying an x402 invoice.
+ *
+ * Deliberately different in tone from a transfer. Nothing is broadcast and no
+ * gas is spent, but what the user authorises is a bearer instrument: whoever
+ * holds the signature can move exactly this amount from this account, once,
+ * until it expires. So the window states the amount, the payee and the URL
+ * being bought, and says plainly that the site can collect it.
+ */
+function renderX402(request: Extract<PendingApproval, { kind: 'payX402' }>): void {
+  const password = passwordField(request.needsUnlock);
+  const status = el('p', { class: 'muted' });
+  const { summary } = request;
+
+  const rows = el('div', { class: 'totals' }, [
+    el('div', { class: 'total-row grand' }, [
+      el('span', { text: 'Amount' }),
+      el('span', { text: `${summary.amount} ${summary.assetSymbol}` }),
+    ]),
+    el('div', { class: 'total-row' }, [
+      el('span', { class: 'chain', text: 'Network' }),
+      el('span', { text: summary.network }),
+    ]),
+    el('div', { class: 'total-row' }, [
+      el('span', { class: 'chain', text: 'To' }),
+      el('span', { text: shortAddress(summary.payTo) }),
+    ]),
+  ]);
+
+  mount(
+    brand('Approve payment'),
+    el('span', { class: 'origin', text: request.origin }),
+    ...(summary.resource
+      ? [el('p', { class: 'muted', text: `For: ${summary.resource}` })]
+      : []),
+    ...(summary.description
+      ? [el('p', { class: 'muted', text: summary.description })]
+      : []),
+    rows,
+    el('p', {
+      class: 'warn',
+      text: 'Approving authorises this site to collect this amount once. No network fee is charged to you.',
+    }),
+    ...(password ? [password.row] : []),
+    status,
+    el('div', { class: 'row' }, [
+      button('Reject', () => void decide(false), 'btn'),
+      button(
+        `Pay ${summary.amount} ${summary.assetSymbol}`,
+        () => void decide(true, password?.input.value, status),
+        'btn primary',
+      ),
+    ]),
+  );
+}
+
+/** Middle-elide an address so both ends stay checkable at a glance. */
+function shortAddress(address: string): string {
+  return address.length > 16 ? `${address.slice(0, 8)}…${address.slice(-6)}` : address;
 }
 
 // ── Connect ──────────────────────────────────────────────────────────────────

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -41,8 +41,21 @@ import {
   type BatchFunding,
 } from '../core/batch.js';
 import { PAY_CHAINS, signingChain, toPayChain } from '../core/pay-chains.js';
+import {
+  selectPayableEntry,
+  buildAuthorization,
+  signX402Payment,
+  summarizeX402,
+  type PaymentRequired,
+} from '../core/x402.js';
 import type { NativeChain } from '../core/chains.js';
-import type { WalletRequest, WalletResponse, PendingApproval, WalletEvent } from '../messages.js';
+import type {
+  WalletRequest,
+  WalletResponse,
+  PendingApproval,
+  WalletEvent,
+  X402ApprovalSummary,
+} from '../messages.js';
 
 const AUTO_LOCK_ALARM = 'coinpay-auto-lock';
 const DEFAULT_IDLE_MINUTES = 15;
@@ -510,6 +523,90 @@ async function sendersFor(from?: string): Promise<
   return senders;
 }
 
+/**
+ * Sign an x402 invoice.
+ *
+ * Unlike `payBatch` this broadcasts nothing and costs no gas: an EIP-3009
+ * authorization IS the payment, and the facilitator submits it. So the account
+ * paying needs the token but no native currency on that chain, and there is no
+ * balance check here — there is no transaction to fund.
+ *
+ * The signature is a bearer instrument: whoever holds it can move exactly this
+ * amount from this account, once, before it expires. That is why it goes
+ * through the same approval window as a transfer rather than being signed
+ * silently.
+ */
+async function handleSitePayX402(
+  origin: string,
+  rawPaymentRequired: unknown,
+  from?: string,
+): Promise<WalletResponse> {
+  if (!(await connections.isConnected(origin))) {
+    return { ok: false, error: 'Site is not connected to this wallet' };
+  }
+  if (!(await wallet.isInitialized())) {
+    return { ok: false, error: 'No wallet has been set up yet' };
+  }
+
+  const entry = selectPayableEntry(rawPaymentRequired as PaymentRequired);
+  if (!entry) {
+    return {
+      ok: false,
+      error:
+        'None of the offered payment options can be paid by this wallet. ' +
+        'It signs EIP-3009 payments on Ethereum, Polygon and Base.',
+    };
+  }
+
+  let summary: X402ApprovalSummary;
+  try {
+    summary = summarizeX402(entry);
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+
+  const requestId = newRequestId();
+  const approved = await requestApproval({
+    kind: 'payX402',
+    requestId,
+    origin,
+    needsUnlock: !(await wallet.isUnlocked()),
+    summary,
+  });
+
+  if (!approved) {
+    await clearApproval(requestId);
+    return { ok: false, error: 'Payment request rejected' };
+  }
+
+  try {
+    // Approving requires unlocking, so the seed is available by here.
+    const seed = await wallet.requireSeed();
+    const senders = await sendersFor(from);
+    const sender = senders.ETH;
+    if (!sender) {
+      return { ok: false, error: 'This wallet has no Ethereum-family address to pay from' };
+    }
+
+    // Every EVM chain shares one derived key, so the ETH address is the payer
+    // on Polygon and Base too.
+    const privateKey = derivePrivateKey(seed, 'ETH', sender.index);
+    try {
+      const authorization = buildAuthorization(entry, sender.address);
+      const paymentHeader = signX402Payment(entry, authorization, privateKey);
+      await connections.touch(origin);
+      return { ok: true, paymentHeader };
+    } finally {
+      // The key is a live spending credential; do not leave it in memory.
+      privateKey.fill(0);
+    }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  } finally {
+    await clearApproval(requestId);
+  }
+}
+
 async function handleSend(
   chain: string,
   to: string,
@@ -810,6 +907,12 @@ async function handle(
         const origin = senderOrigin(sender);
         if (!origin) return { ok: false, error: 'Unknown origin' };
         return handleSitePayBatch(origin, req.payments, sender, req.from);
+      }
+
+      case 'site:payX402': {
+        const origin = senderOrigin(sender);
+        if (!origin) return { ok: false, error: 'Unknown origin' };
+        return handleSitePayX402(origin, req.paymentRequired, req.from);
       }
 
       // ── approval window ──

--- a/packages/extension/src/core/__tests__/x402.test.ts
+++ b/packages/extension/src/core/__tests__/x402.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import {
+  entryChainId,
+  entryAmount,
+  selectPayableEntry,
+  buildAuthorization,
+  signX402Payment,
+  summarizeX402,
+  formatAmount,
+  randomNonce,
+  encodePaymentHeader,
+  type AcceptsEntry,
+} from '../x402.js';
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const PAYEE = '0x1111111111111111111111111111111111111111';
+const PAYER = '0x9dBA414637c611a16BEa6f0796BFcbcBdc410df8';
+
+// A real 32-byte key, so signatures are genuinely produced.
+const PRIVATE_KEY = new Uint8Array(32).fill(7);
+
+function entry(overrides: Partial<AcceptsEntry> = {}): AcceptsEntry {
+  return {
+    scheme: 'exact',
+    network: 'eip155:8453',
+    amount: '6000',
+    asset: USDC_BASE,
+    payTo: PAYEE,
+    maxTimeoutSeconds: 300,
+    extra: { name: 'USD Coin', version: '2' },
+    ...overrides,
+  };
+}
+
+function decode(header: string): any {
+  return JSON.parse(new TextDecoder().decode(Uint8Array.from(atob(header), (c) => c.charCodeAt(0))));
+}
+
+describe('entryChainId', () => {
+  it('reads CAIP-2 ids', () => {
+    expect(entryChainId('eip155:8453')).toBe(8453);
+    expect(entryChainId('eip155:1')).toBe(1);
+    expect(entryChainId('eip155:137')).toBe(137);
+  });
+
+  it('still accepts legacy bare names', () => {
+    expect(entryChainId('base')).toBe(8453);
+  });
+
+  it('rejects chains the wallet cannot sign an exact payment on', () => {
+    expect(entryChainId('bitcoin')).toBeNull();
+    expect(entryChainId('solana')).toBeNull();
+    expect(entryChainId(undefined)).toBeNull();
+  });
+});
+
+describe('entryAmount', () => {
+  it('reads the v2 field and the v1 one', () => {
+    expect(entryAmount({ amount: '6000' })).toBe('6000');
+    expect(entryAmount({ maxAmountRequired: '6000' })).toBe('6000');
+  });
+
+  it('throws when an option names no amount', () => {
+    expect(() => entryAmount({})).toThrow(/no amount/i);
+  });
+});
+
+describe('selectPayableEntry', () => {
+  it('picks a payable option', () => {
+    expect(selectPayableEntry({ accepts: [entry()] })?.asset).toBe(USDC_BASE);
+  });
+
+  it("honours the merchant's ordering", () => {
+    const first = entry({ network: 'eip155:1', asset: '0xAAA0000000000000000000000000000000000000' });
+    expect(selectPayableEntry({ accepts: [first, entry()] })?.network).toBe('eip155:1');
+  });
+
+  it('skips chains the wallet cannot sign', () => {
+    const btc = entry({ network: 'bitcoin', asset: 'BTC' });
+    expect(selectPayableEntry({ accepts: [btc, entry()] })?.network).toBe('eip155:8453');
+  });
+
+  it('skips an option with no token domain, which cannot be signed', () => {
+    // Without extra.name/version there is no EIP-712 domain to sign against,
+    // and guessing one yields a signature that recovers to the wrong address.
+    expect(selectPayableEntry({ accepts: [entry({ extra: {} })] })).toBeNull();
+    expect(selectPayableEntry({ accepts: [entry({ extra: { name: 'USD Coin' } })] })).toBeNull();
+  });
+
+  it('skips an option with no asset or payee', () => {
+    expect(selectPayableEntry({ accepts: [entry({ asset: undefined })] })).toBeNull();
+    expect(selectPayableEntry({ accepts: [entry({ payTo: undefined })] })).toBeNull();
+  });
+
+  it('skips a scheme other than exact', () => {
+    expect(selectPayableEntry({ accepts: [entry({ scheme: 'upto' })] })).toBeNull();
+  });
+
+  it('tolerates a malformed 402 body', () => {
+    expect(selectPayableEntry({} as any)).toBeNull();
+    expect(selectPayableEntry({ accepts: [] })).toBeNull();
+    expect(selectPayableEntry(null as any)).toBeNull();
+  });
+});
+
+describe('buildAuthorization', () => {
+  it('pays the amount and payee the option names', () => {
+    const auth = buildAuthorization(entry(), PAYER, 1_000_000);
+
+    expect(auth.from).toBe(PAYER);
+    expect(auth.to).toBe(PAYEE);
+    expect(auth.value).toBe('6000');
+    expect(auth.validBefore).toBe(String(1_000_000 + 300));
+  });
+
+  it('leaves validAfter at 0, so clock skew cannot make it briefly invalid', () => {
+    expect(buildAuthorization(entry(), PAYER).validAfter).toBe('0');
+  });
+
+  it('mints a fresh 32-byte nonce each time', () => {
+    const nonces = new Set(
+      Array.from({ length: 25 }, () => buildAuthorization(entry(), PAYER).nonce),
+    );
+    expect(nonces.size).toBe(25);
+    for (const nonce of nonces) expect(nonce).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('defaults the validity window when the option gives none', () => {
+    const auth = buildAuthorization(entry({ maxTimeoutSeconds: undefined }), PAYER, 0);
+    expect(auth.validBefore).toBe('600');
+  });
+});
+
+describe('randomNonce', () => {
+  it('is 32 bytes of hex', () => {
+    expect(randomNonce()).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});
+
+describe('signX402Payment', () => {
+  it('produces a decodable v2 payment', () => {
+    const auth = buildAuthorization(entry(), PAYER);
+    const payment = decode(signX402Payment(entry(), auth, PRIVATE_KEY));
+
+    expect(payment.x402Version).toBe(2);
+    expect(payment.scheme).toBe('exact');
+    expect(payment.network).toBe('eip155:8453');
+    expect(payment.payload.authorization).toEqual(auth);
+    expect(payment.payload.signature).toMatch(/^0x[0-9a-f]{130}$/);
+  });
+
+  it('normalises a legacy network name to CAIP-2', () => {
+    // The facilitator should see a standard proof regardless of how the offer
+    // happened to name the chain.
+    const legacy = entry({ network: 'base' });
+    const payment = decode(signX402Payment(legacy, buildAuthorization(legacy, PAYER), PRIVATE_KEY));
+    expect(payment.network).toBe('eip155:8453');
+  });
+
+  it('refuses an option with no token domain', () => {
+    const bad = entry({ extra: {} });
+    expect(() => signX402Payment(bad, buildAuthorization(bad, PAYER), PRIVATE_KEY)).toThrow(
+      /EIP-712 domain/i,
+    );
+  });
+
+  it('refuses an unsupported network', () => {
+    const bad = entry({ network: 'solana' });
+    expect(() => signX402Payment(bad, buildAuthorization(bad, PAYER), PRIVATE_KEY)).toThrow(
+      /unsupported network/i,
+    );
+  });
+});
+
+describe('encodePaymentHeader', () => {
+  it('survives non-ASCII', () => {
+    const header = encodePaymentHeader({ note: 'café — 支払い' });
+    expect(decode(header).note).toBe('café — 支払い');
+  });
+});
+
+describe('formatAmount', () => {
+  it('scales smallest units into a readable figure', () => {
+    expect(formatAmount({ amount: '6000' })).toBe('0.006');
+    expect(formatAmount({ amount: '1000000' })).toBe('1');
+    expect(formatAmount({ amount: '1500000' })).toBe('1.5');
+    expect(formatAmount({ amount: '0' })).toBe('0');
+  });
+
+  it('does not lose precision on large amounts', () => {
+    expect(formatAmount({ amount: '123456789012345' })).toBe('123456789.012345');
+  });
+});
+
+describe('summarizeX402', () => {
+  it('describes the payment in terms a person can check', () => {
+    const summary = summarizeX402(entry({ resource: 'https://api.example.com/premium' }));
+
+    expect(summary).toMatchObject({
+      network: 'Base',
+      chainId: 8453,
+      amount: '0.006',
+      assetSymbol: 'USD Coin',
+      payTo: PAYEE,
+      resource: 'https://api.example.com/premium',
+    });
+  });
+
+  it('names each supported chain', () => {
+    expect(summarizeX402(entry({ network: 'eip155:1' })).network).toBe('Ethereum');
+    expect(summarizeX402(entry({ network: 'eip155:137' })).network).toBe('Polygon');
+  });
+
+  it('refuses to summarise an unsupported network', () => {
+    expect(() => summarizeX402(entry({ network: 'solana' }))).toThrow(/unsupported network/i);
+  });
+});

--- a/packages/extension/src/core/eip712.ts
+++ b/packages/extension/src/core/eip712.ts
@@ -1,0 +1,241 @@
+/**
+ * EIP-712 typed-data hashing and signing.
+ *
+ * The wallet could sign transactions and nothing else, which is why it could
+ * not pay an x402 invoice: the `exact` scheme is an EIP-3009
+ * `TransferWithAuthorization`, and that is typed data, not a transaction.
+ *
+ * Built on the same primitives the rest of the wallet uses — `@noble/curves`
+ * and `@noble/hashes` — rather than pulling in ethers, which would add
+ * megabytes to an extension bundle for one hash function and one signature.
+ *
+ * Only the encodings EIP-3009 needs are implemented: atomic types plus
+ * `string` and `bytes`. Nested structs and arrays throw rather than encode
+ * wrongly, because a silently wrong encoding produces a signature that
+ * recovers to some other address, and the only symptom is an authorization
+ * nobody can spend.
+ */
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { keccak_256 } from '@noble/hashes/sha3.js';
+
+export interface TypedDataField {
+  name: string;
+  type: string;
+}
+
+export type TypedDataTypes = Record<string, TypedDataField[]>;
+
+export interface TypedDataDomain {
+  name?: string;
+  version?: string;
+  chainId?: number | bigint | string;
+  verifyingContract?: string;
+  salt?: string;
+}
+
+/** Fields of EIP712Domain, in the order the spec fixes. */
+const DOMAIN_FIELDS: TypedDataField[] = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+  { name: 'salt', type: 'bytes32' },
+];
+
+const utf8 = new TextEncoder();
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) throw new Error(`Odd-length hex: ${hex}`);
+  if (clean.length > 0 && !/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error(`Not hex: ${hex}`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return `0x${hex}`;
+}
+
+/** A 32-byte big-endian encoding of a non-negative integer. */
+function encodeUint(value: unknown): Uint8Array {
+  let n: bigint;
+  try {
+    n = BigInt(value as string | number | bigint);
+  } catch {
+    throw new Error(`Not an integer: ${String(value)}`);
+  }
+  if (n < 0n) throw new Error(`Negative value for an unsigned field: ${n}`);
+  if (n >= 1n << 256n) throw new Error(`Value exceeds uint256: ${n}`);
+
+  const out = new Uint8Array(32);
+  for (let i = 31; i >= 0 && n > 0n; i--) {
+    out[i] = Number(n & 0xffn);
+    n >>= 8n;
+  }
+  return out;
+}
+
+/** A 20-byte address, left-padded into a 32-byte word. */
+function encodeAddress(value: unknown): Uint8Array {
+  const bytes = hexToBytes(String(value));
+  if (bytes.length !== 20) {
+    throw new Error(`Address must be 20 bytes, got ${bytes.length}: ${String(value)}`);
+  }
+  const out = new Uint8Array(32);
+  out.set(bytes, 12);
+  return out;
+}
+
+/** Encode one field to its 32-byte EIP-712 representation. */
+function encodeValue(type: string, value: unknown): Uint8Array {
+  if (type === 'string') {
+    return keccak_256(utf8.encode(String(value ?? '')));
+  }
+  if (type === 'bytes') {
+    return keccak_256(hexToBytes(String(value ?? '0x')));
+  }
+  if (type === 'address') {
+    return encodeAddress(value);
+  }
+  if (type === 'bool') {
+    const out = new Uint8Array(32);
+    out[31] = value ? 1 : 0;
+    return out;
+  }
+
+  const fixedBytes = /^bytes([0-9]{1,2})$/.exec(type);
+  if (fixedBytes) {
+    const width = Number(fixedBytes[1]);
+    if (width < 1 || width > 32) throw new Error(`Invalid fixed-bytes width: ${type}`);
+    const bytes = hexToBytes(String(value));
+    if (bytes.length !== width) {
+      throw new Error(`${type} must be ${width} bytes, got ${bytes.length}`);
+    }
+    const out = new Uint8Array(32);
+    out.set(bytes, 0); // fixed bytes are RIGHT-padded
+    return out;
+  }
+
+  if (/^uint([0-9]{1,3})?$/.test(type)) {
+    return encodeUint(value);
+  }
+
+  // Arrays and nested structs would need recursive encoding. Refusing is the
+  // only safe response: a wrong encoding still yields a valid-looking
+  // signature, for an authorization that recovers to the wrong signer.
+  throw new Error(`Unsupported EIP-712 type: ${type}`);
+}
+
+/**
+ * The canonical type string, e.g.
+ * `TransferWithAuthorization(address from,address to,...)`.
+ */
+export function encodeType(primaryType: string, types: TypedDataTypes): string {
+  const fields = types[primaryType];
+  if (!fields) throw new Error(`Unknown type: ${primaryType}`);
+  const args = fields.map((f) => `${f.type} ${f.name}`).join(',');
+  return `${primaryType}(${args})`;
+}
+
+export function typeHash(primaryType: string, types: TypedDataTypes): Uint8Array {
+  return keccak_256(utf8.encode(encodeType(primaryType, types)));
+}
+
+/** `keccak256(typeHash ‖ encodeData(...))`. */
+export function hashStruct(
+  primaryType: string,
+  types: TypedDataTypes,
+  data: Record<string, unknown>,
+): Uint8Array {
+  const fields = types[primaryType];
+  if (!fields) throw new Error(`Unknown type: ${primaryType}`);
+
+  const parts: Uint8Array[] = [typeHash(primaryType, types)];
+  for (const field of fields) {
+    parts.push(encodeValue(field.type, data[field.name]));
+  }
+
+  const buf = new Uint8Array(parts.length * 32);
+  parts.forEach((p, i) => buf.set(p, i * 32));
+  return keccak_256(buf);
+}
+
+/**
+ * The domain separator.
+ *
+ * Only the fields actually present are included, and in the spec's order. A
+ * domain that lists a field the token omits (or vice versa) hashes to a
+ * different separator, and the signature is then rejected on-chain.
+ */
+export function hashDomain(domain: TypedDataDomain): Uint8Array {
+  const present = DOMAIN_FIELDS.filter(
+    (f) => domain[f.name as keyof TypedDataDomain] !== undefined,
+  );
+  if (present.length === 0) throw new Error('EIP-712 domain is empty');
+
+  return hashStruct('EIP712Domain', { EIP712Domain: present }, domain as Record<string, unknown>);
+}
+
+/**
+ * The 32-byte digest a signature is made over:
+ * `keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct(message))`.
+ */
+export function eip712Digest(
+  domain: TypedDataDomain,
+  types: TypedDataTypes,
+  primaryType: string,
+  message: Record<string, unknown>,
+): Uint8Array {
+  const domainSeparator = hashDomain(domain);
+  const structHash = hashStruct(primaryType, types, message);
+
+  const preimage = new Uint8Array(2 + 32 + 32);
+  preimage[0] = 0x19;
+  preimage[1] = 0x01;
+  preimage.set(domainSeparator, 2);
+  preimage.set(structHash, 34);
+
+  return keccak_256(preimage);
+}
+
+/**
+ * Sign typed data, returning a 65-byte `r ‖ s ‖ v` signature as hex.
+ *
+ * `v` is 27/28 rather than 0/1. Both conventions exist, but Solidity's
+ * `ecrecover` — which is what `transferWithAuthorization` calls — expects
+ * 27/28, and a signature with a raw recovery bit simply recovers to the zero
+ * address there.
+ */
+export function signTypedData(
+  domain: TypedDataDomain,
+  types: TypedDataTypes,
+  primaryType: string,
+  message: Record<string, unknown>,
+  privateKey: Uint8Array,
+): string {
+  const digest = eip712Digest(domain, types, primaryType, message);
+
+  // `format: 'recovered'` yields [recovery, r(32), s(32)]. `prehash: false`
+  // because the digest is already the hash to sign — hashing it again would
+  // sign the wrong thing.
+  const signed = secp256k1.sign(digest, privateKey, { format: 'recovered', prehash: false });
+
+  if (signed.length !== 65) {
+    throw new Error(`Expected a 65-byte recovered signature, got ${signed.length}`);
+  }
+  const recovery = signed[0] as number;
+
+  const out = new Uint8Array(65);
+  out.set(signed.slice(1, 65), 0); // r ‖ s
+  out[64] = recovery + 27;
+
+  return bytesToHex(out);
+}

--- a/packages/extension/src/core/x402.ts
+++ b/packages/extension/src/core/x402.ts
@@ -1,0 +1,231 @@
+/**
+ * Paying an x402 invoice from the wallet.
+ *
+ * The `exact` scheme on EVM is an EIP-3009 `TransferWithAuthorization`: the
+ * signature IS the payment, and the facilitator broadcasts it and pays the
+ * gas. So paying here means signing typed data, not building and broadcasting
+ * a transaction — the wallet spends no native currency at all, and the user
+ * needs none on the chain being paid.
+ */
+
+import { signTypedData, type TypedDataDomain } from './eip712.js';
+
+/** CAIP-2 ids the wallet can sign an `exact` payment on, to the EVM chain id. */
+export const SUPPORTED_X402_NETWORKS: Record<string, number> = {
+  'eip155:1': 1,
+  'eip155:137': 137,
+  'eip155:8453': 8453,
+};
+
+/** Legacy bare names, for offers that have not moved to CAIP-2 yet. */
+const LEGACY_NETWORK_IDS: Record<string, number> = {
+  ethereum: 1,
+  polygon: 137,
+  base: 8453,
+};
+
+export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+};
+
+export interface AcceptsEntry {
+  scheme?: string;
+  network?: string;
+  amount?: string;
+  maxAmountRequired?: string;
+  asset?: string;
+  payTo?: string;
+  resource?: string;
+  description?: string;
+  maxTimeoutSeconds?: number;
+  extra?: { name?: string; version?: string; [k: string]: unknown };
+}
+
+export interface PaymentRequired {
+  x402Version?: number;
+  accepts?: AcceptsEntry[];
+}
+
+/** The EVM chain id an entry names, or null if the wallet cannot pay it. */
+export function entryChainId(network: string | undefined): number | null {
+  if (!network) return null;
+  return SUPPORTED_X402_NETWORKS[network] ?? LEGACY_NETWORK_IDS[network] ?? null;
+}
+
+/** Amount in the asset's smallest unit; v2 says `amount`, our v1 said `maxAmountRequired`. */
+export function entryAmount(entry: AcceptsEntry): string {
+  const raw = entry.amount ?? entry.maxAmountRequired;
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Payment option specifies no amount');
+  }
+  return String(raw);
+}
+
+/**
+ * Choose an option this wallet can actually sign.
+ *
+ * The order of `accepts` is the merchant's preference, so it is honoured
+ * rather than re-ranked. An entry is only payable if it names a supported
+ * chain, a token contract, a payee, and the token's EIP-712 domain — without
+ * `extra.name`/`extra.version` there is no domain to sign against, and a
+ * guessed one yields a signature that recovers to the wrong address.
+ */
+export function selectPayableEntry(paymentRequired: PaymentRequired): AcceptsEntry | null {
+  const accepts = paymentRequired?.accepts;
+  if (!Array.isArray(accepts)) return null;
+
+  return (
+    accepts.find(
+      (entry) =>
+        (entry.scheme ?? 'exact') === 'exact' &&
+        entryChainId(entry.network) !== null &&
+        !!entry.asset &&
+        !!entry.payTo &&
+        !!entry.extra?.name &&
+        !!entry.extra?.version,
+    ) ?? null
+  );
+}
+
+/** A random 32-byte EIP-3009 nonce. */
+export function randomNonce(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return `0x${hex}`;
+}
+
+export interface Authorization {
+  from: string;
+  to: string;
+  value: string;
+  validAfter: string;
+  validBefore: string;
+  nonce: string;
+}
+
+/**
+ * Build the authorization to sign.
+ *
+ * `validAfter` stays 0 rather than "now": the payer's clock and the chain's
+ * differ, and a validAfter slightly in the future makes the authorization
+ * briefly unspendable for no benefit.
+ */
+export function buildAuthorization(
+  entry: AcceptsEntry,
+  from: string,
+  now = Math.floor(Date.now() / 1000),
+): Authorization {
+  if (!entry.payTo) throw new Error('Payment option names no payee');
+
+  const validForSeconds = entry.maxTimeoutSeconds ?? 600;
+
+  return {
+    from,
+    to: entry.payTo,
+    value: entryAmount(entry),
+    validAfter: '0',
+    validBefore: String(now + validForSeconds),
+    nonce: randomNonce(),
+  };
+}
+
+/** base64 of the payment payload, as the `X-PAYMENT` header carries it. */
+export function encodePaymentHeader(payment: unknown): string {
+  const json = JSON.stringify(payment);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * Sign an authorization and produce the `X-PAYMENT` header.
+ *
+ * The private key is used and not retained; the caller owns zeroing it.
+ */
+export function signX402Payment(
+  entry: AcceptsEntry,
+  authorization: Authorization,
+  privateKey: Uint8Array,
+): string {
+  const chainId = entryChainId(entry.network);
+  if (chainId === null) throw new Error(`Unsupported network: ${entry.network}`);
+  if (!entry.extra?.name || !entry.extra?.version) {
+    throw new Error('Payment option is missing the token EIP-712 domain (extra.name/version)');
+  }
+
+  // The domain belongs to the TOKEN, not to x402: `verifyingContract` is the
+  // token address and name/version are the token's own, which is why a v2
+  // offer has to carry them.
+  const domain: TypedDataDomain = {
+    name: entry.extra.name,
+    version: entry.extra.version,
+    chainId,
+    verifyingContract: entry.asset,
+  };
+
+  const signature = signTypedData(
+    domain,
+    TRANSFER_WITH_AUTHORIZATION_TYPES,
+    'TransferWithAuthorization',
+    authorization as unknown as Record<string, unknown>,
+    privateKey,
+  );
+
+  return encodePaymentHeader({
+    x402Version: 2,
+    scheme: 'exact',
+    // Always emit CAIP-2, even when the offer used a legacy bare name, so the
+    // facilitator sees a standard proof regardless of how it was quoted.
+    network: `eip155:${chainId}`,
+    payload: { signature, authorization },
+  });
+}
+
+/** Human-readable amount, for the approval window. */
+export function formatAmount(entry: AcceptsEntry, decimals = 6): string {
+  const raw = BigInt(entryAmount(entry));
+  const divisor = 10n ** BigInt(decimals);
+  const whole = raw / divisor;
+  const fraction = (raw % divisor).toString().padStart(decimals, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : String(whole);
+}
+
+/** What the approval window shows the user. */
+export interface X402Summary {
+  network: string;
+  chainId: number;
+  amount: string;
+  assetSymbol: string;
+  payTo: string;
+  resource?: string;
+  description?: string;
+}
+
+export function summarizeX402(entry: AcceptsEntry): X402Summary {
+  const chainId = entryChainId(entry.network);
+  if (chainId === null) throw new Error(`Unsupported network: ${entry.network}`);
+
+  const chainNames: Record<number, string> = { 1: 'Ethereum', 137: 'Polygon', 8453: 'Base' };
+
+  return {
+    network: chainNames[chainId] ?? `Chain ${chainId}`,
+    chainId,
+    amount: formatAmount(entry),
+    // The offer names the token by its EIP-712 domain name, which for the
+    // stablecoins we support is the human name too.
+    assetSymbol: String(entry.extra?.name ?? 'tokens'),
+    payTo: String(entry.payTo),
+    resource: entry.resource,
+    description: entry.description,
+  };
+}

--- a/packages/extension/src/inpage/provider.ts
+++ b/packages/extension/src/inpage/provider.ts
@@ -187,6 +187,29 @@ const provider = {
     }
   },
 
+  /**
+   * Pay an x402 invoice and return the `X-PAYMENT` header to retry with.
+   *
+   * Takes the body of a `402 Payment Required` response and returns a base64
+   * header value; the caller sets it on `X-PAYMENT` and repeats the request.
+   * Rejects if the user declines or if none of the offered options is one this
+   * wallet can sign.
+   *
+   * Nothing is broadcast and no gas is spent. The `exact` scheme is an EIP-3009
+   * authorization — the signature IS the payment, and the facilitator submits
+   * it — so this works with an account holding no native currency.
+   *
+   * @example
+   *   const res = await fetch(url);
+   *   if (res.status === 402) {
+   *     const header = await window.coinpay.payX402(await res.json());
+   *     return fetch(url, { headers: { 'X-PAYMENT': header } });
+   *   }
+   */
+  payX402(paymentRequired: unknown, options: { from?: string } = {}): Promise<string> {
+    return send({ type: 'site:payX402', paymentRequired, from: options.from });
+  },
+
   /** Subscribe to progress independently of a `payBatch` call. */
   onProgress(listener: (progress: CoinPayProgress) => void): () => void {
     progressListeners.add(listener);

--- a/packages/extension/src/messages.ts
+++ b/packages/extension/src/messages.ts
@@ -70,6 +70,12 @@ export type WalletRequest =
   | { type: 'site:getAccounts' }
   /** `from` picks which of a chain's addresses pays, as for `send`. */
   | { type: 'site:payBatch'; payments: BatchPaymentRequest[]; from?: string }
+  /**
+   * `paymentRequired` is the body of a 402 response, straight from the page,
+   * so it is untrusted and validated in the background before anything is
+   * signed.
+   */
+  | { type: 'site:payX402'; paymentRequired: unknown; from?: string }
   // ── approval window ──
   | { type: 'approval:get'; requestId: string }
   | { type: 'approval:approve'; requestId: string; password?: string }
@@ -154,7 +160,33 @@ export type PendingApproval =
        * the seed, and this window is what asks for the password.
        */
       funding?: BatchFunding[];
+    }
+  | {
+      kind: 'payX402';
+      requestId: string;
+      origin: string;
+      needsUnlock: boolean;
+      /**
+       * What the user is agreeing to pay. Summarised rather than raw, because
+       * an approval window that shows an EIP-3009 struct asks the user to
+       * verify something they cannot read.
+       */
+      summary: X402ApprovalSummary;
     };
+
+/** The human-facing shape of an x402 payment awaiting approval. */
+export interface X402ApprovalSummary {
+  /** Chain name, e.g. "Base". */
+  network: string;
+  chainId: number;
+  /** Display amount, already scaled out of smallest units. */
+  amount: string;
+  assetSymbol: string;
+  payTo: string;
+  /** The URL being bought, when the offer names one. */
+  resource?: string;
+  description?: string;
+}
 
 export type WalletResponse =
   | { ok: true; state: WalletState }
@@ -173,6 +205,8 @@ export type WalletResponse =
   | { ok: true; portal: PortalAccountStatus[] }
   | { ok: true; balances: AddressBalance[] }
   | { ok: true; transactions: WalletTransaction[] }
+  /** The `X-PAYMENT` header value for an approved x402 payment. */
+  | { ok: true; paymentHeader: string }
   | { ok: true }
   | { ok: false; error: string };
 

--- a/src/lib/x402/eip712-parity.test.ts
+++ b/src/lib/x402/eip712-parity.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Parity between the extension's hand-rolled EIP-712 and ethers.
+ *
+ * The extension cannot depend on ethers — it would add megabytes to the bundle
+ * for one hash and one signature — so `packages/extension/src/core/eip712.ts`
+ * implements the encoding itself on @noble primitives. That is only safe if it
+ * is byte-identical to a reference implementation, because a subtly wrong
+ * encoding still produces a well-formed signature: it just recovers to some
+ * other address, and the only symptom is an authorization nobody can spend.
+ *
+ * So every case here is checked against ethers rather than against a constant
+ * this file made up.
+ */
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  encodeType,
+  hashDomain,
+  hashStruct,
+  eip712Digest,
+  signTypedData,
+  bytesToHex,
+} from '../../../packages/extension/src/core/eip712';
+import { TRANSFER_WITH_AUTHORIZATION_TYPES } from './v2';
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const PAYEE = '0x1111111111111111111111111111111111111111';
+
+const PRIVATE_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+const wallet = new ethers.Wallet(PRIVATE_KEY);
+const privateKeyBytes = ethers.getBytes(PRIVATE_KEY);
+
+// The real USDC-on-Base domain, as read from the deployed contract.
+const DOMAIN = {
+  name: 'USD Coin',
+  version: '2',
+  chainId: 8453,
+  verifyingContract: USDC_BASE,
+};
+
+function authorization(overrides: Record<string, string> = {}) {
+  return {
+    from: wallet.address,
+    to: PAYEE,
+    value: '6000',
+    validAfter: '0',
+    validBefore: '1800000000',
+    nonce: '0x' + 'ab'.repeat(32),
+    ...overrides,
+  };
+}
+
+describe('encodeType', () => {
+  it('matches the canonical EIP-3009 type string', () => {
+    expect(encodeType('TransferWithAuthorization', TRANSFER_WITH_AUTHORIZATION_TYPES)).toBe(
+      'TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)',
+    );
+  });
+});
+
+describe('hashDomain', () => {
+  it('matches ethers for the real USDC domain', () => {
+    expect(bytesToHex(hashDomain(DOMAIN))).toBe(ethers.TypedDataEncoder.hashDomain(DOMAIN));
+  });
+
+  it('matches ethers for a salt-based domain with no chainId', () => {
+    // Polygon's bridged tokens use this shape.
+    const salted = {
+      name: 'USD Coin (PoS)',
+      version: '1',
+      verifyingContract: USDC_BASE,
+      salt: ethers.zeroPadValue(ethers.toBeHex(137), 32),
+    };
+    expect(bytesToHex(hashDomain(salted))).toBe(ethers.TypedDataEncoder.hashDomain(salted));
+  });
+
+  it('matches ethers when version is absent', () => {
+    const partial = { name: 'Token', chainId: 1, verifyingContract: USDC_BASE };
+    expect(bytesToHex(hashDomain(partial))).toBe(ethers.TypedDataEncoder.hashDomain(partial));
+  });
+
+  it('refuses an empty domain rather than hashing nothing', () => {
+    expect(() => hashDomain({})).toThrow(/empty/i);
+  });
+});
+
+describe('hashStruct', () => {
+  it('matches ethers for an EIP-3009 authorization', () => {
+    const auth = authorization();
+    expect(bytesToHex(hashStruct('TransferWithAuthorization', TRANSFER_WITH_AUTHORIZATION_TYPES, auth))).toBe(
+      ethers.TypedDataEncoder.hashStruct(
+        'TransferWithAuthorization',
+        TRANSFER_WITH_AUTHORIZATION_TYPES,
+        auth,
+      ),
+    );
+  });
+
+  it('matches across a range of values, including the extremes', () => {
+    const cases = [
+      authorization({ value: '0' }),
+      authorization({ value: '1' }),
+      // Max uint256 — where a naive bit-shift encoder overflows.
+      authorization({
+        value: '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      }),
+      authorization({ validAfter: '1', validBefore: '2' }),
+      authorization({ nonce: '0x' + '00'.repeat(32) }),
+      authorization({ nonce: '0x' + 'ff'.repeat(32) }),
+      // Mixed-case (checksummed) addresses must encode the same as lowercase.
+      authorization({ to: PAYEE.toUpperCase().replace('0X', '0x') }),
+    ];
+
+    for (const auth of cases) {
+      expect(
+        bytesToHex(hashStruct('TransferWithAuthorization', TRANSFER_WITH_AUTHORIZATION_TYPES, auth)),
+      ).toBe(
+        ethers.TypedDataEncoder.hashStruct(
+          'TransferWithAuthorization',
+          TRANSFER_WITH_AUTHORIZATION_TYPES,
+          auth,
+        ),
+      );
+    }
+  });
+
+  it('matches ethers for string, bool and dynamic bytes fields', () => {
+    const types = {
+      Mixed: [
+        { name: 'label', type: 'string' },
+        { name: 'flag', type: 'bool' },
+        { name: 'blob', type: 'bytes' },
+        { name: 'who', type: 'address' },
+      ],
+    };
+    const value = {
+      label: 'café — 支払い',
+      flag: true,
+      blob: '0xdeadbeef',
+      who: PAYEE,
+    };
+
+    expect(bytesToHex(hashStruct('Mixed', types, value))).toBe(
+      ethers.TypedDataEncoder.hashStruct('Mixed', types, value),
+    );
+  });
+});
+
+describe('eip712Digest', () => {
+  it('matches ethers, including the 0x1901 prefix', () => {
+    const auth = authorization();
+    expect(
+      bytesToHex(eip712Digest(DOMAIN, TRANSFER_WITH_AUTHORIZATION_TYPES, 'TransferWithAuthorization', auth)),
+    ).toBe(ethers.TypedDataEncoder.hash(DOMAIN, TRANSFER_WITH_AUTHORIZATION_TYPES, auth));
+  });
+});
+
+describe('signTypedData', () => {
+  it('produces a signature ethers recovers to the right signer', async () => {
+    const auth = authorization();
+    const signature = signTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      'TransferWithAuthorization',
+      auth,
+      privateKeyBytes,
+    );
+
+    const recovered = ethers.verifyTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      auth,
+      signature,
+    );
+    expect(recovered).toBe(wallet.address);
+  });
+
+  it('is byte-identical to what ethers itself would sign', async () => {
+    const auth = authorization();
+    const mine = signTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      'TransferWithAuthorization',
+      auth,
+      privateKeyBytes,
+    );
+    const theirs = await wallet.signTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      auth,
+    );
+
+    expect(mine).toBe(theirs);
+  });
+
+  it('emits v as 27 or 28, which is what Solidity ecrecover expects', () => {
+    // A raw 0/1 recovery bit recovers to the zero address in Solidity, so this
+    // is not cosmetic.
+    for (let i = 0; i < 12; i++) {
+      const signature = signTypedData(
+        DOMAIN,
+        TRANSFER_WITH_AUTHORIZATION_TYPES,
+        'TransferWithAuthorization',
+        authorization({ nonce: '0x' + i.toString(16).padStart(2, '0').repeat(32) }),
+        privateKeyBytes,
+      );
+      const v = Number.parseInt(signature.slice(-2), 16);
+      expect([27, 28]).toContain(v);
+    }
+  });
+
+  it('is 65 bytes', () => {
+    const signature = signTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      'TransferWithAuthorization',
+      authorization(),
+      privateKeyBytes,
+    );
+    expect(signature).toMatch(/^0x[0-9a-f]{130}$/);
+  });
+
+  it('signs a low-s signature, as Ethereum requires', () => {
+    // High-s signatures are malleable and rejected by EIP-2. ethers agreeing
+    // byte-for-byte above already implies this, but it is asserted directly so
+    // a regression names the actual problem.
+    const signature = signTypedData(
+      DOMAIN,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      'TransferWithAuthorization',
+      authorization(),
+      privateKeyBytes,
+    );
+    const s = BigInt('0x' + signature.slice(2 + 64, 2 + 128));
+    const halfOrder = BigInt(
+      '0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0',
+    );
+    expect(s <= halfOrder).toBe(true);
+  });
+});
+
+describe('refusals', () => {
+  it('rejects an unsupported type rather than encoding it wrongly', () => {
+    expect(() =>
+      hashStruct('Bad', { Bad: [{ name: 'xs', type: 'uint256[]' }] }, { xs: [1, 2] }),
+    ).toThrow(/unsupported/i);
+  });
+
+  it('rejects a malformed address', () => {
+    expect(() =>
+      hashStruct('T', { T: [{ name: 'a', type: 'address' }] }, { a: '0x1234' }),
+    ).toThrow(/20 bytes/i);
+  });
+
+  it('rejects a wrong-width bytes32', () => {
+    expect(() =>
+      hashStruct('T', { T: [{ name: 'n', type: 'bytes32' }] }, { n: '0xdeadbeef' }),
+    ).toThrow(/32 bytes/i);
+  });
+
+  it('rejects a negative uint', () => {
+    expect(() =>
+      hashStruct('T', { T: [{ name: 'v', type: 'uint256' }] }, { v: '-1' }),
+    ).toThrow(/negative/i);
+  });
+
+  it('rejects a value wider than uint256', () => {
+    expect(() =>
+      hashStruct('T', { T: [{ name: 'v', type: 'uint256' }] }, { v: (1n << 256n).toString() }),
+    ).toThrow(/exceeds uint256/i);
+  });
+});


### PR DESCRIPTION
Follows #264, which shipped the payer, the facilitator and v2 quoting. This is the last piece: the CoinPay Wallet path.

The wallet could sign transactions and nothing else, which is exactly why it could not pay an x402 invoice — the `exact` scheme is an EIP-3009 `TransferWithAuthorization`, and that is typed data, not a transaction. `window.coinpay` exposed only getState/connect/getAccounts/payBatch, while the README, both manifests and the tronbrowser.dev store listing all advertised "one-click x402 payments". This is the implementation that copy was describing.

## Verified against ethers, not against constants I made up

`core/eip712.ts` implements the encoding on `@noble/curves` + `@noble/hashes` rather than pulling in ethers, which would add megabytes to an extension bundle for one hash and one signature.

That is only safe if it is byte-identical to a reference implementation, because a subtly wrong encoding still produces a well-formed signature — it just recovers to a different address, and the only symptom is an authorization nobody can spend. So `src/lib/x402/eip712-parity.test.ts` checks the type string, domain separator, struct hash and final digest against ethers, and asserts a produced signature is **byte-identical** to `wallet.signTypedData` for the same key and message. Across:

- zero, one, and max-uint256 values (where a naive encoder overflows)
- all-zero and all-ones nonces
- checksummed vs lowercase addresses
- salt-based domains with no chainId (Polygon's bridged tokens)
- `string` / `bool` / `bytes` fields, including non-ASCII

It lives in the root suite because that is where ethers is available.

Nested structs and arrays throw rather than encode. The refusal is the point.

`v` is emitted as **27/28** — a raw 0/1 recovery bit recovers to the zero address in Solidity, which is what `transferWithAuthorization` calls.

## Choosing and signing

`core/x402.ts` skips any entry without `extra.name`/`extra.version`: no token EIP-712 domain means nothing to sign against, and a guessed one recovers to the wrong address. Whatever the offer called the chain, the emitted proof always names it in CAIP-2, so the facilitator sees a standard payment regardless of how it was quoted.

## The approval window

Deliberately worded differently from a transfer. Nothing is broadcast and no gas is spent, but what the user authorises is a bearer instrument: whoever holds the signature can move exactly this amount from this account, once, until it expires. So it names the amount, payee and URL, and says plainly that the site can collect it.

The private key is zeroed in a `finally` — it is a live spending credential, not a derivation artefact. There is no balance check, because there is no transaction to fund: the payer needs the token but no native currency, which is the whole point of EIP-3009.

## Pre-existing, untouched

`packages/extension/src/core/__tests__/api.test.ts` has 2 failures (CoinPayApi request signing). Both that file and `api.ts` are byte-identical to `origin/master` here and neither is touched by this branch. Worth noting separately: **the extension suite is not in the root vitest include, so it does not run in CI** — presumably how those went unnoticed.

## Tests

Root suite 296 files / 4201 passing, `tsc --noEmit` clean, eslint 0 errors. 46 new tests (19 parity + 27 unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)