### PR TITLE
chore(release): extension v0.10.0 and SDK 0.8.0

### DIFF
--- a/packages/extension/manifest/manifest.chrome.json
+++ b/packages/extension/manifest/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvd6F0ByGMFO/ZfxK/kyuYMrlBlmwY0u2I9MfRRYf88YA2YQVmiUqM2444gPxyI4rhTyejAZX9IwMDwY0N+kgclQArkfTmbs+mo7E/RCgrMFy+FreMlrqEm5LACIKPgVZjzWUEjDxQGnmpNtvXWUN2ZN9srKF+Efr2tFKVZMwBKd3cJeh+4XGw0+AN6CKDbURWvgm6op+5bL4lTv+aJ8LbfC45ouEOsxHZgdN2HuC3x4kE232oStYYjmigr2NSKgE835U2nKO+hY7fCzBntMp8VI9hUkCDBwZwxbcWFQmtMKqJa6Mu3lgcwJQPYRzx9hujehn2OSsPE6b2k/jOYVtcwIDAQAB",
   "action": {
     "default_title": "CoinPay",
@@ -12,11 +12,16 @@
     "service_worker": "background/index.js",
     "type": "module"
   },
-  "permissions": ["storage", "alarms"],
+  "permissions": [
+    "storage",
+    "alarms"
+  ],
   "host_permissions": [
     "https://coinpayportal.com/*",
     "https://ugig.net/*",
-    "https://www.ugig.net/*"
+    "https://www.ugig.net/*",
+    "http://localhost/*",
+    "http://127.0.0.1/*"
   ],
   "content_scripts": [
     {
@@ -27,13 +32,17 @@
         "http://localhost/*",
         "http://127.0.0.1/*"
       ],
-      "js": ["content/bridge.js"],
+      "js": [
+        "content/bridge.js"
+      ],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["inpage/provider.js"],
+      "resources": [
+        "inpage/provider.js"
+      ],
       "matches": [
         "https://coinpayportal.com/*",
         "https://ugig.net/*",

--- a/packages/extension/manifest/manifest.firefox.json
+++ b/packages/extension/manifest/manifest.firefox.json
@@ -2,20 +2,27 @@
   "manifest_version": 3,
   "name": "CoinPay Wallet",
   "description": "Non-custodial multi-chain CoinPay wallet with one-click x402 payments and bulk payouts.",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "action": {
     "default_title": "CoinPay",
     "default_popup": "popup/index.html"
   },
   "background": {
-    "scripts": ["background/index.js"],
+    "scripts": [
+      "background/index.js"
+    ],
     "type": "module"
   },
-  "permissions": ["storage", "alarms"],
+  "permissions": [
+    "storage",
+    "alarms"
+  ],
   "host_permissions": [
     "https://coinpayportal.com/*",
     "https://ugig.net/*",
-    "https://www.ugig.net/*"
+    "https://www.ugig.net/*",
+    "http://localhost/*",
+    "http://127.0.0.1/*"
   ],
   "content_scripts": [
     {
@@ -26,13 +33,17 @@
         "http://localhost/*",
         "http://127.0.0.1/*"
       ],
-      "js": ["content/bridge.js"],
+      "js": [
+        "content/bridge.js"
+      ],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["inpage/provider.js"],
+      "resources": [
+        "inpage/provider.js"
+      ],
       "matches": [
         "https://coinpayportal.com/*",
         "https://ugig.net/*",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay-extension",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "CoinPay cross-browser (MV3) wallet + x402 payment extension with bulk payouts. See docs/BROWSER_EXTENSION_PRD.md and docs/BULK_PAYMENTS.md.",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/coinpay",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "CoinPay SDK & CLI — Accept cryptocurrency payments (BTC, ETH, SOL, POL, BCH, USDC) with wallet and swap support",
   "type": "module",
   "main": "./src/index.js",
@@ -45,6 +45,9 @@
     },
     "./x402-browser": {
       "import": "./src/x402-browser.js"
+    },
+    "./x402-pay-server": {
+      "import": "./src/x402-pay-server.js"
     }
   },
   "files": [


### PR DESCRIPTION
Version bumps for the x402 work, plus a fix to a mistake I made in #266.

## The #266 mistake

#266 added localhost to `content_scripts` and `web_accessible_resources` but deliberately withheld `host_permissions`, reasoning that MV3 injects statically-declared content scripts without it. That's true in general and **wrong here**: `chrome.tabs.sendMessage` needs host permission for the tab, so the payment-progress relay would be silently dropped for any localhost page.

`packages/extension/src/__tests__/packaging.test.ts` asserts exactly this invariant — every content-script match must also be a host permission — and explains why in a comment. It failed, correctly.

**It failed only locally.** The extension suite isn't in the root vitest include, so it never ran on #266 and CI went green on a manifest violating an invariant the repo already tests for. That's the second thing this gap has hidden, after the two pre-existing `api.test.ts` failures. Worth wiring up separately.

## Versions

- **Extension 0.9.3 → 0.10.0** — x402 payment support (#265) and the localhost match (#266)
- **SDK 0.7.5 → 0.8.0** — minor, not patch: new x402 v2 protocol module, browser payer, local pay server

Also adds the missing `./x402-pay-server` export. The CLI reaches it by relative path, so its absence was invisible in-repo while making it unimportable for consumers.

⚠️ **Users updating from 0.9.3 will see a new permission prompt**, since both the content-script match set and host permissions changed.

## Already shipped

- **npm: `@profullstack/coinpay@0.8.0` is published and `latest`** (02:40 UTC). Verified against the registry directly. This also closes the pre-existing gap — npm was on 0.6.11 while the repo had been on 0.7.x, so everything between ships at once.
- **GitHub release `extension-v0.10.0`** with Chrome and Firefox zips.

## Verification

The published tarball was smoke-tested as a consumer, not from the working tree: installed `profullstack-coinpay-0.8.0.tgz` into a scratch project, resolved `./x402-v2`, `./x402-browser` and `./x402-pay-server` through the export map, built a v2 offer (`eip155:8453`, amount `10000`, `extra: {name: "USD Coin", version: "2"}`) and rendered the approval page.

Extension artifacts rebuilt after the manifest fix and verified to carry v0.10.0, all five host permissions, and the x402 code in both the provider and background bundles.

Extension suite: 24/25 files passing (the 1 failure is the pre-existing `api.test.ts`, byte-identical to master and untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)