### PR TITLE
Track and retry invoice email delivery

### DIFF
--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -1221,11 +1221,23 @@ async function handleInvoice(subcommand, args, flags) {
       const shareUrl = getInvoiceShareUrl(sent.id);
 
       if (flags.json) {
-        print.json({ ...sent, shareUrl });
+        const delivery = {};
+        for (const field of ['emailAccepted', 'emailTrackingSaved', 'warning', 'emailError']) {
+          if (Object.prototype.hasOwnProperty.call(result ?? {}, field)) {
+            delivery[field] = result[field];
+          }
+        }
+        print.json({ ...sent, shareUrl, ...delivery });
         break;
       }
 
-      print.success('Invoice sent and client notified');
+      if (result?.emailAccepted === false) {
+        print.warn('Invoice payment link created, but the email provider did not accept the message');
+      } else if (result?.emailAccepted === true) {
+        print.success('Invoice sent; email accepted by provider');
+      } else {
+        print.success('Invoice sent; email status was not reported by the server');
+      }
       if (legacySuccess) {
         print.warn('The server returned limited invoice details; run coinpay invoice get ' +
           id + ' to refresh them.');

--- a/packages/sdk/test/cli-invoice.test.js
+++ b/packages/sdk/test/cli-invoice.test.js
@@ -687,8 +687,60 @@ describe('CLI Invoice Commands', () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.output).toContain('Invoice sent and client notified');
+    expect(result.output).toContain('Invoice sent; email status was not reported by the server');
     expect(requests.map((request) => request.method)).toEqual(['GET', 'POST']);
+  });
+
+  it('warns when payment details are created but the email provider rejects the message', async () => {
+    respond = (request) => ({
+      body: {
+        success: true,
+        emailAccepted: false,
+        warning: 'The payment link is active, but the provider rejected the email.',
+        invoice: invoiceFixture({ status: request.method === 'POST' ? 'sent' : 'draft' }),
+      },
+    });
+
+    const result = await runCLI(
+      ['invoice', 'send', 'inv_mutation', '--yes'],
+      baseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('email provider did not accept the message');
+    expect(result.output).not.toContain('client notified');
+    expect(requests.map((request) => request.method)).toEqual(['GET', 'POST']);
+  });
+
+  it('reports email rejection in JSON without exposing private invoice fields', async () => {
+    respond = (request) => ({
+      body: {
+        success: true,
+        emailAccepted: false,
+        emailTrackingSaved: true,
+        warning: 'The payment link is active, but the provider rejected the email.',
+        emailError: 'Recipient suppressed',
+        invoice: invoiceFixture({
+          status: request.method === 'POST' ? 'sent' : 'draft',
+          clients: { email: 'private@example.com' },
+        }),
+      },
+    });
+
+    const result = await runCLI(
+      ['invoice', 'send', 'inv_mutation', '--yes', '--json'],
+      baseUrl
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status: 'sent',
+      emailAccepted: false,
+      emailTrackingSaved: true,
+      warning: 'The payment link is active, but the provider rejected the email.',
+      emailError: 'Recipient suppressed',
+    });
+    expect(result.stdout).not.toContain('private@example.com');
   });
 
   it('requires --yes for non-interactive send and JSON send', async () => {

--- a/src/app/api/invoices/[id]/resend-email/route.test.ts
+++ b/src/app/api/invoices/[id]/resend-email/route.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockAuthorizeInvoice = vi.fn();
+const mockDeliverInvoiceEmail = vi.fn();
+const mockCheckRateLimitAsync = vi.fn();
+const invoiceUpdatePayloads: Array<Record<string, unknown>> = [];
+
+let paymentResult: { data: Record<string, unknown> | null; error: unknown };
+let claimResult: { data: Record<string, unknown> | null; error: unknown };
+let finalizeResult: { data: Record<string, unknown> | null; error: unknown };
+
+const paymentQuery: any = {};
+paymentQuery.select = vi.fn(() => paymentQuery);
+paymentQuery.eq = vi.fn(() => paymentQuery);
+paymentQuery.order = vi.fn(() => paymentQuery);
+paymentQuery.limit = vi.fn(() => paymentQuery);
+paymentQuery.maybeSingle = vi.fn(() => Promise.resolve(paymentResult));
+
+const mockInvoiceUpdate = vi.fn((payload: Record<string, unknown>) => {
+  invoiceUpdatePayloads.push(payload);
+  const updateNumber = invoiceUpdatePayloads.length;
+  const query: any = {};
+  query.eq = vi.fn(() => query);
+  query.is = vi.fn(() => query);
+  query.select = vi.fn(() => query);
+  query.maybeSingle = vi.fn(() => Promise.resolve(
+    updateNumber === 1 ? claimResult : finalizeResult
+  ));
+  return query;
+});
+
+vi.mock('@/lib/auth/invoice-access', () => ({
+  authorizeInvoice: (...args: unknown[]) => mockAuthorizeInvoice(...args),
+}));
+
+vi.mock('@/lib/email/invoice-delivery', () => ({
+  deliverInvoiceEmail: (...args: unknown[]) => mockDeliverInvoiceEmail(...args),
+  getInvoicePaymentLink: (id: string) => `https://coinpayportal.com/now/${id}`,
+}));
+
+vi.mock('@/lib/web-wallet/rate-limit', () => ({
+  checkRateLimitAsync: (...args: unknown[]) => mockCheckRateLimitAsync(...args),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn((table: string) => table === 'payments'
+      ? paymentQuery
+      : { update: mockInvoiceUpdate }),
+  })),
+}));
+
+import { POST } from './route';
+
+const sentInvoice = {
+  id: 'inv-1',
+  invoice_number: 'INV-001',
+  status: 'sent',
+  amount: '40.00',
+  currency: 'USD',
+  crypto_amount: '0.52909283',
+  crypto_currency: 'SOL',
+  payment_address: 'existing-solana-payment-address',
+  business_id: 'biz-1',
+  metadata: null,
+  email_status: null,
+  email_last_attempted_at: null,
+  due_date: null,
+  notes: 'Weekly development milestones',
+  clients: { email: 'anthony@profullstack.com' },
+  businesses: { name: 'Profullstack' },
+};
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/invoices/inv-1/resend-email', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer test-token' },
+  });
+}
+
+describe('POST /api/invoices/[id]/resend-email', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invoiceUpdatePayloads.length = 0;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    mockAuthorizeInvoice.mockResolvedValue({
+      ok: true,
+      merchantId: 'merchant-1',
+      apiKeyBusinessId: null,
+      role: 'owner',
+      invoice: sentInvoice,
+    });
+    paymentResult = {
+      data: {
+        id: 'payment-1',
+        business_id: 'biz-1',
+        payment_address: 'existing-solana-payment-address',
+        status: 'pending',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    };
+    claimResult = { data: { id: 'inv-1' }, error: null };
+    finalizeResult = { data: { id: 'inv-1' }, error: null };
+    mockCheckRateLimitAsync.mockResolvedValue({ allowed: true, limit: 10, remaining: 9, resetAt: 0 });
+    mockDeliverInvoiceEmail.mockResolvedValue({
+      success: true,
+      messageId: 'email-message-2',
+      paymentLink: 'https://coinpayportal.com/now/inv-1',
+    });
+  });
+
+  it('resends a legacy sent invoice through its active existing payment', async () => {
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.invoice).toMatchObject({
+      id: 'inv-1',
+      payment_address: 'existing-solana-payment-address',
+      email_status: 'accepted',
+      email_message_id: 'email-message-2',
+    });
+    expect(paymentQuery.eq).toHaveBeenCalledWith('business_id', 'biz-1');
+    expect(paymentQuery.eq).toHaveBeenCalledWith('payment_address', 'existing-solana-payment-address');
+    expect(mockCheckRateLimitAsync).toHaveBeenCalledWith('biz-1', 'invoice_email_resend');
+    expect(mockDeliverInvoiceEmail).toHaveBeenCalledOnce();
+    expect(mockDeliverInvoiceEmail).toHaveBeenCalledWith(sentInvoice);
+    expect(invoiceUpdatePayloads[0]).toMatchObject({ email_status: 'pending' });
+    expect(invoiceUpdatePayloads[1]).toMatchObject({
+      email_status: 'accepted',
+      email_message_id: 'email-message-2',
+      email_last_error: null,
+    });
+  });
+
+  it('uses the linked payment id when newer invoice metadata provides one', async () => {
+    mockAuthorizeInvoice.mockResolvedValueOnce({
+      ok: true,
+      invoice: { ...sentInvoice, metadata: { coinpay_payment_id: 'payment-1' } },
+    });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+
+    expect(res.status).toBe(200);
+    expect(paymentQuery.eq).toHaveBeenCalledWith('id', 'payment-1');
+    expect(paymentQuery.order).not.toHaveBeenCalled();
+  });
+
+  it('records a provider rejection without changing payment details or inviting HTTP retries', async () => {
+    mockDeliverInvoiceEmail.mockResolvedValueOnce({
+      success: false,
+      error: 'Recipient suppressed',
+      paymentLink: 'https://coinpayportal.com/now/inv-1',
+    });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(false);
+    expect(body.emailError).toBe('Recipient suppressed');
+    expect(body.warning).toContain('payment link is still active');
+    expect(body.invoice).toMatchObject({
+      payment_address: 'existing-solana-payment-address',
+      email_status: 'failed',
+      email_last_error: 'Recipient suppressed',
+    });
+    expect(invoiceUpdatePayloads[1]).toMatchObject({ email_status: 'failed' });
+  });
+
+  it('does not advertise an expired payment link and prepares the invoice for re-issue', async () => {
+    paymentResult.data = {
+      ...paymentResult.data,
+      status: 'expired',
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+    };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe('PAYMENT_LINK_INACTIVE');
+    expect(body.canReissue).toBe(true);
+    expect(body.error).toContain('no longer active');
+    expect(body.invoice).toMatchObject({ id: 'inv-1', status: 'overdue' });
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+    expect(invoiceUpdatePayloads).toEqual([
+      expect.objectContaining({ status: 'overdue' }),
+    ]);
+  });
+
+  it('does not overwrite an invoice that changes while an inactive payment is checked', async () => {
+    paymentResult.data = {
+      ...paymentResult.data,
+      status: 'expired',
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+    };
+    claimResult = { data: null, error: null };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error).toContain('changed');
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+  });
+
+  it.each(['confirmed', 'forwarding', 'forwarded', 'forwarding_failed'])(
+    'does not reissue or email a payment in %s state',
+    async (status) => {
+      paymentResult.data = {
+        ...paymentResult.data,
+        status,
+      };
+
+      const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.code).toBe('PAYMENT_ALREADY_DETECTED');
+      expect(body.canReissue).toBe(false);
+      expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+      expect(mockInvoiceUpdate).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not reissue a payment whose address does not match the invoice', async () => {
+    paymentResult.data = {
+      ...paymentResult.data,
+      payment_address: 'different-payment-address',
+      status: 'confirmed',
+    };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe('PAYMENT_LINK_MISMATCH');
+    expect(body.canReissue).toBe(false);
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+    expect(mockInvoiceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for an unknown payment state', async () => {
+    paymentResult.data = {
+      ...paymentResult.data,
+      status: 'unexpected_state',
+    };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe('PAYMENT_STATUS_UNRESOLVED');
+    expect(body.canReissue).toBe(false);
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+    expect(mockInvoiceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rate limits provider-backed retries per business', async () => {
+    mockCheckRateLimitAsync.mockResolvedValueOnce({ allowed: false, limit: 10, remaining: 0, resetAt: 0 });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+
+    expect(res.status).toBe(429);
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+    expect(mockInvoiceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not send when the pending attempt cannot be claimed', async () => {
+    claimResult = { data: null, error: { message: 'Database unavailable' } };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to start invoice email retry');
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+  });
+
+  it('reports pending when provider acceptance cannot be persisted', async () => {
+    finalizeResult = { data: null, error: { message: 'Tracking unavailable' } };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.emailTrackingSaved).toBe(false);
+    expect(body.invoice.email_status).toBe('pending');
+    expect(body.warning).toContain('tracking status could not be saved');
+  });
+
+  it('does not let an older retry overwrite a newer email attempt', async () => {
+    finalizeResult = { data: null, error: null };
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.emailTrackingSaved).toBe(false);
+    expect(body.invoice.email_status).toBe('pending');
+    expect(body.warning).toContain('tracking status could not be saved');
+  });
+
+  it('does not resend overdue or closed invoices', async () => {
+    for (const status of ['overdue', 'draft', 'paid', 'cancelled', 'rejected']) {
+      mockAuthorizeInvoice.mockResolvedValueOnce({
+        ok: true,
+        invoice: { ...sentInvoice, status },
+      });
+
+      const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+      expect(res.status).toBe(400);
+    }
+
+    expect(mockDeliverInvoiceEmail).not.toHaveBeenCalled();
+    expect(mockInvoiceUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/invoices/[id]/resend-email/route.ts
+++ b/src/app/api/invoices/[id]/resend-email/route.ts
@@ -1,0 +1,303 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeInvoice } from '@/lib/auth/invoice-access';
+import { deliverInvoiceEmail, getInvoicePaymentLink } from '@/lib/email/invoice-delivery';
+import { checkRateLimitAsync } from '@/lib/web-wallet/rate-limit';
+
+/**
+ * POST /api/invoices/[id]/resend-email
+ * Retry only the invoice notification. The existing payment address and payment
+ * methods are reused; this route never creates or replaces a payment resource.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
+    const access = await authorizeInvoice(
+      supabase,
+      request,
+      id,
+      'invoice.write',
+      `
+        *,
+        clients (id, name, email, company_name),
+        businesses (id, name)
+      `,
+    );
+
+    if (!access.ok) {
+      return NextResponse.json({ success: false, error: access.error }, { status: access.status });
+    }
+
+    const { invoice } = access;
+    if (invoice.status !== 'sent') {
+      return NextResponse.json(
+        { success: false, error: `Cannot resend email for invoice with status: ${invoice.status}` },
+        { status: 400 }
+      );
+    }
+    if (!invoice.clients?.email) {
+      return NextResponse.json(
+        { success: false, error: 'Client email is required to resend invoice' },
+        { status: 400 }
+      );
+    }
+    if (!invoice.crypto_currency || !invoice.crypto_amount || !invoice.payment_address) {
+      return NextResponse.json(
+        { success: false, error: 'Invoice payment details are incomplete' },
+        { status: 400 }
+      );
+    }
+
+    // A legacy invoice may predate coinpay_payment_id metadata, so fall back to
+    // its payment address. In both cases, only re-advertise a payment that the
+    // normal monitor is still watching.
+    const metadata = invoice.metadata && typeof invoice.metadata === 'object'
+      ? invoice.metadata as Record<string, unknown>
+      : {};
+    const linkedPaymentId = typeof metadata.coinpay_payment_id === 'string'
+      ? metadata.coinpay_payment_id
+      : null;
+    let paymentLookup = supabase
+      .from('payments')
+      .select('id, business_id, payment_address, status, expires_at')
+      .eq('business_id', invoice.business_id);
+
+    paymentLookup = linkedPaymentId
+      ? paymentLookup.eq('id', linkedPaymentId)
+      : paymentLookup
+          .eq('payment_address', invoice.payment_address)
+          .order('created_at', { ascending: false })
+          .limit(1);
+
+    const { data: linkedPayment, error: paymentLookupError } = await paymentLookup.maybeSingle();
+    if (paymentLookupError) {
+      console.error('Failed to verify invoice payment before email retry:', {
+        invoiceId: invoice.id,
+        error: paymentLookupError,
+      });
+      return NextResponse.json(
+        { success: false, error: 'Failed to verify the existing invoice payment' },
+        { status: 500 }
+      );
+    }
+
+    const paymentExpiresAt = linkedPayment?.expires_at
+      ? new Date(linkedPayment.expires_at).getTime()
+      : 0;
+    const paymentMatchesInvoice = linkedPayment?.payment_address === invoice.payment_address;
+    const paymentStatus = typeof linkedPayment?.status === 'string'
+      ? linkedPayment.status
+      : null;
+    const paymentIsActive = paymentStatus === 'pending'
+      && paymentMatchesInvoice
+      && paymentExpiresAt > Date.now();
+
+    if (linkedPayment && !paymentMatchesInvoice) {
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'PAYMENT_LINK_MISMATCH',
+          error: 'The linked payment does not match this invoice. Review the payment before retrying or re-issuing it.',
+          canReissue: false,
+        },
+        { status: 409 }
+      );
+    }
+
+    const paymentAlreadyDetected = paymentStatus
+      ? ['confirmed', 'forwarding', 'forwarded', 'forwarding_failed'].includes(paymentStatus)
+      : false;
+    if (paymentAlreadyDetected) {
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'PAYMENT_ALREADY_DETECTED',
+          error: 'Payment has already been detected for this invoice. Wait for settlement or reconcile the payment before sending another request.',
+          canReissue: false,
+        },
+        { status: 409 }
+      );
+    }
+
+    const paymentIsDead = !linkedPayment
+      || (paymentStatus === 'pending' && paymentExpiresAt <= Date.now())
+      || (paymentStatus ? ['expired', 'cancelled', 'failed'].includes(paymentStatus) : false);
+
+    if (!paymentIsActive && !paymentIsDead) {
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'PAYMENT_STATUS_UNRESOLVED',
+          error: 'The existing payment is not in a state that can be emailed or re-issued safely.',
+          canReissue: false,
+        },
+        { status: 409 }
+      );
+    }
+
+    if (!paymentIsActive) {
+      // Keep the invoice state aligned with the payment state. Without a due
+      // date, the monitor cannot promote a legacy sent invoice to overdue, so
+      // the UI would otherwise keep offering only a retry that can never work.
+      // The conditional update also avoids overwriting a concurrent settlement.
+      const updatedAt = new Date().toISOString();
+      const { data: reissuableInvoice, error: reissueStateError } = await supabase
+        .from('invoices')
+        .update({ status: 'overdue', updated_at: updatedAt })
+        .eq('id', id)
+        .eq('status', 'sent')
+        .select('id')
+        .maybeSingle();
+
+      if (reissueStateError) {
+        console.error('Failed to mark invoice ready for payment re-issue:', {
+          invoiceId: id,
+          error: reissueStateError,
+        });
+        return NextResponse.json(
+          { success: false, error: 'The payment link is inactive, but the invoice could not be prepared for re-issue.' },
+          { status: 500 }
+        );
+      }
+      if (!reissuableInvoice) {
+        return NextResponse.json(
+          { success: false, error: 'The invoice changed while its payment link was being checked.' },
+          { status: 409 }
+        );
+      }
+
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'PAYMENT_LINK_INACTIVE',
+          error: 'The existing payment link is no longer active. Re-issue the invoice before emailing it again.',
+          canReissue: true,
+          invoice: { ...invoice, status: 'overdue', updated_at: updatedAt },
+        },
+        { status: 409 }
+      );
+    }
+
+    const resendRate = await checkRateLimitAsync(invoice.business_id, 'invoice_email_resend');
+    if (!resendRate.allowed) {
+      return NextResponse.json(
+        { success: false, error: 'Too many invoice email attempts; try again shortly.' },
+        { status: 429 }
+      );
+    }
+
+    const lastAttemptAt = invoice.email_last_attempted_at
+      ? new Date(invoice.email_last_attempted_at).getTime()
+      : 0;
+    if (invoice.email_status === 'pending' && lastAttemptAt > Date.now() - 2 * 60 * 1000) {
+      return NextResponse.json(
+        { success: false, error: 'An invoice email attempt is already in progress.' },
+        { status: 409 }
+      );
+    }
+
+    const emailAttemptedAt = new Date().toISOString();
+    let pendingUpdate = supabase
+      .from('invoices')
+      .update({
+        email_status: 'pending',
+        email_message_id: null,
+        email_last_error: null,
+        email_last_attempted_at: emailAttemptedAt,
+      })
+      .eq('id', id)
+      .eq('status', 'sent');
+
+    pendingUpdate = invoice.email_last_attempted_at
+      ? pendingUpdate.eq('email_last_attempted_at', invoice.email_last_attempted_at)
+      : pendingUpdate.is('email_last_attempted_at', null);
+
+    const { data: claimedInvoice, error: pendingError } = await pendingUpdate
+      .select('id')
+      .maybeSingle();
+
+    if (pendingError) {
+      console.error('Failed to start invoice email retry:', { invoiceId: id, error: pendingError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to start invoice email retry' },
+        { status: 500 }
+      );
+    }
+    if (!claimedInvoice) {
+      return NextResponse.json(
+        { success: false, error: 'The invoice changed or another email attempt already started.' },
+        { status: 409 }
+      );
+    }
+
+    let emailResult;
+    try {
+      emailResult = await deliverInvoiceEmail(invoice);
+    } catch (emailError) {
+      emailResult = {
+        success: false,
+        error: emailError instanceof Error ? emailError.message : 'Email provider failed unexpectedly',
+        paymentLink: getInvoicePaymentLink(invoice.id),
+      };
+    }
+
+    const emailState = {
+      email_status: emailResult.success ? 'accepted' : 'failed',
+      email_message_id: emailResult.messageId || null,
+      email_last_error: emailResult.success ? null : (emailResult.error || 'Email provider rejected the message'),
+      email_last_attempted_at: emailAttemptedAt,
+    };
+    const { data: finalizedEmailAttempt, error: trackingError } = await supabase
+      .from('invoices')
+      .update(emailState)
+      .eq('id', id)
+      .eq('email_last_attempted_at', emailAttemptedAt)
+      .select('id')
+      .maybeSingle();
+
+    const emailTrackingSaved = !trackingError && !!finalizedEmailAttempt;
+
+    if (!emailTrackingSaved) {
+      console.error('Failed to persist invoice email retry status:', {
+        invoiceId: invoice.id,
+        error: trackingError || 'A newer invoice email attempt replaced this tracking state',
+      });
+    }
+
+    const warning = !emailResult.success
+      ? 'The existing payment link is still active, but the email provider did not accept the message.'
+      : !emailTrackingSaved
+        ? 'The email provider accepted the message, but its tracking status could not be saved.'
+        : undefined;
+    const persistedEmailState = !emailTrackingSaved
+      ? {
+          email_status: 'pending',
+          email_message_id: null,
+          email_last_error: null,
+          email_last_attempted_at: emailAttemptedAt,
+        }
+      : emailState;
+
+    const responseBody = {
+      success: true,
+      invoice: { ...invoice, ...persistedEmailState },
+      emailAccepted: emailResult.success,
+      emailTrackingSaved,
+      paymentLink: emailResult.paymentLink,
+      ...(warning && { warning }),
+      ...(!emailResult.success && { emailError: emailResult.error }),
+    };
+
+    return NextResponse.json(responseBody);
+  } catch (error) {
+    console.error('Resend invoice email error:', error);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/invoices/[id]/send/route.test.ts
+++ b/src/app/api/invoices/[id]/send/route.test.ts
@@ -59,12 +59,12 @@ vi.mock('@/lib/server/optional-deps', () => ({
   }),
 }));
 
-const mockSingle = vi.fn();
-const mockEq2 = vi.fn().mockReturnValue({ single: mockSingle });
-const mockEq = vi.fn().mockReturnValue({ eq: mockEq2, single: mockSingle });
-const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
-const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'inv-1' }, error: null }) }) }) });
 const mockFrom = vi.fn();
+const invoiceUpdatePayloads: Array<Record<string, unknown>> = [];
+let pendingTrackingError: unknown = null;
+let finalTrackingError: unknown = null;
+let pendingTrackingMatched = true;
+let finalTrackingMatched = true;
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
@@ -85,6 +85,7 @@ vi.mock('@/lib/auth/authz', () => ({
 
 import { POST } from './route';
 import { createPayment } from '@/lib/payments/service';
+import { sendEmail } from '@/lib/email';
 
 const baseInvoice = {
   id: 'inv-1',
@@ -112,6 +113,11 @@ function makeRequest(): NextRequest {
 describe('POST /api/invoices/[id]/send', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invoiceUpdatePayloads.length = 0;
+    pendingTrackingError = null;
+    finalTrackingError = null;
+    pendingTrackingMatched = true;
+    finalTrackingMatched = true;
     vi.mocked(createPayment).mockResolvedValue({
       success: true,
       payment: {
@@ -120,6 +126,7 @@ describe('POST /api/invoices/[id]/send', () => {
         crypto_amount: 0.05,
       } as any,
     });
+    vi.mocked(sendEmail).mockResolvedValue({ success: true, messageId: 'email-message-1' });
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
     process.env.NEXT_PUBLIC_APP_URL = 'https://coinpayportal.com';
@@ -137,12 +144,28 @@ describe('POST /api/invoices/[id]/send', () => {
               single: vi.fn().mockResolvedValue({ data: invoice, error: null }),
             }),
           }),
-          update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              select: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { ...invoice, status: 'sent' }, error: null }),
-              }),
-            }),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            invoiceUpdatePayloads.push(payload);
+            const updateNumber = invoiceUpdatePayloads.length;
+            const query: any = {};
+            query.eq = vi.fn(() => query);
+            query.select = vi.fn(() => {
+              if (updateNumber === 1) {
+                return {
+                  single: vi.fn().mockResolvedValue({ data: { ...invoice, status: 'sent' }, error: null }),
+                };
+              }
+
+              const error = updateNumber === 2 ? pendingTrackingError : finalTrackingError;
+              const matched = updateNumber === 2 ? pendingTrackingMatched : finalTrackingMatched;
+              return {
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: error || !matched ? null : { id: invoice.id },
+                  error,
+                }),
+              };
+            });
+            return query;
           }),
         };
       }
@@ -170,6 +193,26 @@ describe('POST /api/invoices/[id]/send', () => {
     const body = await res.json();
 
     expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.invoice.email_status).toBe('accepted');
+    expect(body.invoice.email_message_id).toBe('email-message-1');
+    expect(body.paymentLink).toBe('https://coinpayportal.com/now/inv-1');
+    expect(invoiceUpdatePayloads[0]).not.toHaveProperty('email_status');
+    expect(invoiceUpdatePayloads[1]).toMatchObject({
+      email_status: 'pending',
+      email_message_id: null,
+      email_last_error: null,
+    });
+    expect(invoiceUpdatePayloads[2]).toMatchObject({
+      email_status: 'accepted',
+      email_message_id: 'email-message-1',
+      email_last_error: null,
+    });
+    expect(sendEmail).toHaveBeenCalledWith({
+      to: 'alice@example.com',
+      subject: 'Invoice from Acme',
+      html: '<p>Pay here</p>',
+    });
     expect(createPayment).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       business_id: 'biz-1',
       amount: 100,
@@ -231,5 +274,79 @@ describe('POST /api/invoices/[id]/send', () => {
 
     const createCall = mockStripeCreate.mock.calls[0][0];
     expect(createCall.payment_intent_data.application_fee_amount).toBe(50); // 0.5% of 10000
+  });
+
+  it('keeps the payment live and reports when the email provider rejects the message', async () => {
+    vi.mocked(sendEmail).mockResolvedValueOnce({
+      success: false,
+      error: 'Provider rejected the message',
+    });
+    setupMocks({ stripeAccount: null });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(false);
+    expect(body.emailTrackingSaved).toBe(true);
+    expect(body.emailError).toBe('Provider rejected the message');
+    expect(body.warning).toContain('payment link is active');
+    expect(body.invoice).toMatchObject({
+      id: 'inv-1',
+      status: 'sent',
+      email_status: 'failed',
+      email_message_id: null,
+      email_last_error: 'Provider rejected the message',
+    });
+    expect(body.paymentLink).toBe('https://coinpayportal.com/now/inv-1');
+    expect(createPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns an unexpected email exception into an explicit partial-success response', async () => {
+    vi.mocked(sendEmail).mockRejectedValueOnce(new Error('Email transport crashed'));
+    setupMocks({ stripeAccount: null });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(false);
+    expect(body.emailError).toBe('Email transport crashed');
+    expect(body.invoice.email_status).toBe('failed');
+    expect(createPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports pending when the final email tracking write fails', async () => {
+    finalTrackingError = { message: 'Tracking unavailable' };
+    setupMocks({ stripeAccount: null });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.emailTrackingSaved).toBe(false);
+    expect(body.invoice.email_status).toBe('pending');
+    expect(body.warning).toContain('tracking status could not be saved');
+    expect(invoiceUpdatePayloads[1]).toMatchObject({ email_status: 'pending' });
+    expect(invoiceUpdatePayloads[2]).toMatchObject({ email_status: 'accepted' });
+  });
+
+  it('does not let an older send overwrite a newer email attempt', async () => {
+    finalTrackingMatched = false;
+    setupMocks({ stripeAccount: null });
+
+    const res = await POST(makeRequest(), { params: Promise.resolve({ id: 'inv-1' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.emailAccepted).toBe(true);
+    expect(body.emailTrackingSaved).toBe(false);
+    expect(body.invoice.email_status).toBe('pending');
+    expect(body.warning).toContain('tracking status could not be saved');
   });
 });

--- a/src/app/api/invoices/[id]/send/route.ts
+++ b/src/app/api/invoices/[id]/send/route.ts
@@ -3,8 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { authorizeInvoice } from '@/lib/auth/invoice-access';
 import { createPayment, type Blockchain } from '@/lib/payments/service';
 import { isBusinessPaidTier } from '@/lib/entitlements/service';
-import { sendEmail } from '@/lib/email';
-import { invoiceSentTemplate } from '@/lib/email/invoice-templates';
+import { deliverInvoiceEmail, getInvoicePaymentLink } from '@/lib/email/invoice-delivery';
 import { createInvoiceStripeCheckout } from '@/lib/payments/invoice-stripe';
 import { businessHasPaypal } from '@/lib/paypal/accounts';
 import { getEnabledManualMethods } from '@/lib/payment-methods/manual';
@@ -166,7 +165,10 @@ export async function POST(
       console.error('Failed to resolve manual methods for invoice:', manualError);
     }
 
-    // Update invoice
+    const emailAttemptedAt = new Date().toISOString();
+
+    // Commit the live payment resource before attempting email. A provider
+    // failure must not orphan the payment address or pretend creation failed.
     const { data: updatedInvoice, error: updateError } = await supabase
       .from('invoices')
       .update({
@@ -185,7 +187,7 @@ export async function POST(
         ...(stripeSessionId && { stripe_session_id: stripeSessionId }),
         paypal_enabled: paypalEnabled,
         manual_methods: manualMethods,
-        updated_at: new Date().toISOString(),
+        updated_at: emailAttemptedAt,
       })
       .eq('id', id)
       .select(`*, clients (id, name, email, company_name), businesses (id, name)`)
@@ -195,30 +197,107 @@ export async function POST(
       return NextResponse.json({ success: false, error: 'Failed to update invoice' }, { status: 500 });
     }
 
-    // Send email to client
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://coinpayportal.com';
-    const paymentLink = `${appUrl}/invoices/${invoice.id}/pay`;
+    // Keep delivery tracking separate from the payment commit. This preserves
+    // the live invoice if application code is deployed before the migration or
+    // if observability storage is temporarily unavailable.
+    const pendingEmailState = {
+      email_status: 'pending',
+      email_message_id: null,
+      email_last_error: null,
+      email_last_attempted_at: emailAttemptedAt,
+    };
+    const { data: pendingTrackedInvoice, error: pendingTrackingError } = await supabase
+      .from('invoices')
+      .update(pendingEmailState)
+      .eq('id', id)
+      .select('id')
+      .maybeSingle();
 
-    const businessName = invoice.businesses?.name || 'CoinPay Merchant';
-    const template = invoiceSentTemplate({
-      invoiceNumber: invoice.invoice_number,
-      amount: parseFloat(invoice.amount),
-      currency: invoice.currency || 'USD',
-      cryptoAmount: cryptoAmount.toFixed(8),
-      cryptoCurrency: invoice.crypto_currency,
-      dueDate: invoice.due_date,
-      businessName,
-      paymentLink,
-      notes: invoice.notes,
+    const pendingTrackingSaved = !pendingTrackingError && !!pendingTrackedInvoice;
+
+    if (!pendingTrackingSaved) {
+      console.error('Failed to record invoice email attempt:', {
+        invoiceId: invoice.id,
+        error: pendingTrackingError || 'Invoice changed before the email attempt could be tracked',
+      });
+    }
+
+    let emailResult;
+    try {
+      emailResult = await deliverInvoiceEmail({
+        ...updatedInvoice,
+        crypto_amount: cryptoAmount.toFixed(8),
+        crypto_currency: invoice.crypto_currency,
+        clients: invoice.clients,
+        businesses: invoice.businesses,
+      });
+    } catch (emailError) {
+      emailResult = {
+        success: false,
+        error: emailError instanceof Error ? emailError.message : 'Email provider failed unexpectedly',
+        paymentLink: getInvoicePaymentLink(invoice.id),
+      };
+    }
+
+    const emailState = {
+      email_status: emailResult.success ? 'accepted' : 'failed',
+      email_message_id: emailResult.messageId || null,
+      email_last_error: emailResult.success ? null : (emailResult.error || 'Email provider rejected the message'),
+      email_last_attempted_at: emailAttemptedAt,
+    };
+
+    let emailTrackingError: unknown = pendingTrackingError;
+    let emailTrackingSaved = false;
+    if (pendingTrackingSaved) {
+      const { data: finalizedEmailAttempt, error: finalTrackingError } = await supabase
+        .from('invoices')
+        .update(emailState)
+        .eq('id', id)
+        .eq('email_last_attempted_at', emailAttemptedAt)
+        .select('id')
+        .maybeSingle();
+
+      emailTrackingError = finalTrackingError || (!finalizedEmailAttempt
+        ? 'A newer invoice email attempt replaced this tracking state'
+        : null);
+      emailTrackingSaved = !emailTrackingError && !!finalizedEmailAttempt;
+    }
+
+    if (!emailResult.success) {
+      console.error('Invoice email was not accepted by the provider:', {
+        invoiceId: invoice.id,
+        invoiceNumber: invoice.invoice_number,
+        error: emailResult.error,
+      });
+    }
+    if (!emailTrackingSaved) {
+      console.error('Failed to persist invoice email status:', {
+        invoiceId: invoice.id,
+        error: emailTrackingError,
+      });
+    }
+
+    const warning = !emailResult.success
+      ? 'The payment link is active, but the email provider did not accept the message. Copy the payment link or retry the email.'
+      : !emailTrackingSaved
+        ? 'The email provider accepted the message, but its tracking status could not be saved.'
+        : undefined;
+    const persistedInvoice = !emailTrackingSaved
+      ? {
+          ...updatedInvoice,
+          ...(pendingTrackingSaved && pendingEmailState),
+        }
+      : { ...updatedInvoice, ...emailState };
+
+    return NextResponse.json({
+      success: true,
+      invoice: persistedInvoice,
+      emailAccepted: emailResult.success,
+      emailTrackingSaved,
+      paymentLink: emailResult.paymentLink,
+      ...(warning && { warning }),
+      ...(!emailResult.success && { emailError: emailResult.error }),
     });
-
-    await sendEmail({
-      to: clientEmail,
-      subject: template.subject,
-      html: template.html,
-    });
-
-    return NextResponse.json({ success: true, invoice: updatedInvoice });
   } catch (error) {
     console.error('Send invoice error:', error);
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/src/app/invoices/[id]/page.test.tsx
+++ b/src/app/invoices/[id]/page.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InvoiceDetailPage from './page';
+
+const mockAuthFetch = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useParams: () => ({ id: 'inv-1' }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}));
+
+vi.mock('@/lib/auth/client', () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+const sentInvoice = {
+  id: 'inv-1',
+  invoice_number: 'INV-001',
+  status: 'sent',
+  currency: 'USD',
+  amount: '40.00',
+  crypto_currency: 'SOL',
+  crypto_amount: '0.52909283',
+  payment_address: 'existing-solana-payment-address',
+  stripe_checkout_url: null,
+  stripe_session_id: null,
+  merchant_wallet_address: 'merchant-solana-address',
+  fee_rate: '0.01',
+  fee_amount: '0.40',
+  due_date: null,
+  paid_at: null,
+  tx_hash: null,
+  notes: 'Weekly development milestones',
+  email_status: null,
+  email_message_id: null,
+  email_last_error: null,
+  email_last_attempted_at: null,
+  created_at: '2026-08-14T00:00:00.000Z',
+  updated_at: '2026-08-14T00:00:00.000Z',
+  clients: {
+    id: 'client-1',
+    name: 'Anthony',
+    email: 'anthony@profullstack.com',
+    company_name: 'Profullstack',
+  },
+  businesses: { id: 'biz-1', name: 'Profullstack' },
+  invoice_schedules: null,
+  metadata: null,
+};
+
+function mockInitialInvoice(invoice = sentInvoice) {
+  mockAuthFetch.mockImplementation((url: string) => {
+    if (url === '/api/invoices/inv-1') {
+      return Promise.resolve({ response: { ok: true }, data: { success: true, invoice } });
+    }
+    if (url === '/api/stripe/connect/status/biz-1') {
+      return Promise.resolve({ response: { ok: true }, data: { success: true, charges_enabled: false } });
+    }
+    return Promise.resolve({ response: { ok: true }, data: { success: true } });
+  });
+}
+
+describe('InvoiceDetailPage email delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialInvoice();
+  });
+
+  it('shows legacy sent invoices as unknown and safely resends their existing payment link', async () => {
+    const user = userEvent.setup();
+    const resentInvoice = {
+      ...sentInvoice,
+      email_status: 'accepted',
+      email_message_id: 'email-message-2',
+      email_last_attempted_at: '2026-08-17T10:00:00.000Z',
+    };
+
+    mockAuthFetch.mockImplementation((url: string) => {
+      if (url === '/api/invoices/inv-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, invoice: sentInvoice } });
+      }
+      if (url === '/api/stripe/connect/status/biz-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, charges_enabled: false } });
+      }
+      if (url === '/api/invoices/inv-1/resend-email') {
+        return Promise.resolve({
+          response: { ok: true },
+          data: { success: true, emailAccepted: true, invoice: resentInvoice },
+        });
+      }
+      return Promise.resolve({ response: { ok: true }, data: { success: true } });
+    });
+
+    render(<InvoiceDetailPage />);
+
+    expect(await screen.findByText('unknown')).toBeInTheDocument();
+    expect(screen.getByText(/No email acceptance record exists/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Resend Email/ }));
+
+    await waitFor(() => {
+      expect(mockAuthFetch).toHaveBeenCalledWith(
+        '/api/invoices/inv-1/resend-email',
+        { method: 'POST' },
+        expect.anything()
+      );
+    });
+    expect(await screen.findByText('accepted')).toBeInTheDocument();
+    expect(screen.getByText('The email provider accepted the invoice message.')).toBeInTheDocument();
+    expect(screen.getByText('existing-solana-payment-address')).toBeInTheDocument();
+  });
+
+  it('warns when initial send creates the payment but email submission fails', async () => {
+    const user = userEvent.setup();
+    const draftInvoice = { ...sentInvoice, status: 'draft', email_status: null };
+    const failedInvoice = {
+      ...sentInvoice,
+      email_status: 'failed',
+      email_last_error: 'Provider rejected the message',
+      email_last_attempted_at: '2026-08-17T10:00:00.000Z',
+    };
+
+    mockAuthFetch.mockImplementation((url: string) => {
+      if (url === '/api/invoices/inv-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, invoice: draftInvoice } });
+      }
+      if (url === '/api/stripe/connect/status/biz-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, charges_enabled: false } });
+      }
+      if (url === '/api/invoices/inv-1/send') {
+        return Promise.resolve({
+          response: { ok: true },
+          data: {
+            success: true,
+            emailAccepted: false,
+            warning: 'The payment link is active, but the email provider did not accept the message.',
+            invoice: failedInvoice,
+          },
+        });
+      }
+      return Promise.resolve({ response: { ok: true }, data: { success: true } });
+    });
+
+    render(<InvoiceDetailPage />);
+    await user.click(await screen.findByRole('button', { name: /Send Invoice/ }));
+
+    expect(await screen.findByText(/payment link is active/)).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Resend Email/ })).toBeInTheDocument();
+  });
+
+  it('does not offer email resend for an overdue payment link', async () => {
+    mockInitialInvoice({ ...sentInvoice, status: 'overdue' });
+
+    render(<InvoiceDetailPage />);
+
+    expect(await screen.findByRole('button', { name: /Re-issue Payment Details/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Resend Email/ })).not.toBeInTheDocument();
+  });
+
+  it('offers payment re-issue after a resend discovers an inactive legacy payment', async () => {
+    const user = userEvent.setup();
+    const overdueInvoice = { ...sentInvoice, status: 'overdue' };
+
+    mockAuthFetch.mockImplementation((url: string) => {
+      if (url === '/api/invoices/inv-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, invoice: sentInvoice } });
+      }
+      if (url === '/api/stripe/connect/status/biz-1') {
+        return Promise.resolve({ response: { ok: true }, data: { success: true, charges_enabled: false } });
+      }
+      if (url === '/api/invoices/inv-1/resend-email') {
+        return Promise.resolve({
+          response: { ok: false, status: 409 },
+          data: {
+            success: false,
+            code: 'PAYMENT_LINK_INACTIVE',
+            canReissue: true,
+            error: 'The existing payment link is no longer active. Re-issue the invoice before emailing it again.',
+            invoice: overdueInvoice,
+          },
+        });
+      }
+      return Promise.resolve({ response: { ok: true }, data: { success: true } });
+    });
+
+    render(<InvoiceDetailPage />);
+    await user.click(await screen.findByRole('button', { name: /Resend Email/ }));
+
+    expect(await screen.findByRole('button', { name: /Re-issue Payment Details/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Resend Email/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/no longer active/)).toBeInTheDocument();
+  });
+});

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -23,6 +23,10 @@ interface Invoice {
   paid_at: string | null;
   tx_hash: string | null;
   notes: string | null;
+  email_status: 'pending' | 'accepted' | 'failed' | null;
+  email_message_id: string | null;
+  email_last_error: string | null;
+  email_last_attempted_at: string | null;
   created_at: string;
   updated_at: string;
   clients: { id: string; name: string; email: string; company_name: string; phone?: string; address?: string } | null;
@@ -50,6 +54,7 @@ export default function InvoiceDetailPage() {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState('');
   const [error, setError] = useState('');
+  const [emailFeedback, setEmailFeedback] = useState<{ tone: 'success' | 'warning'; message: string } | null>(null);
   const [copiedLink, setCopiedLink] = useState(false);
   // null = unknown/loading. cardsEnabled reflects whether the invoice's business
   // has a Stripe Connect account with card charges enabled.
@@ -109,13 +114,43 @@ export default function InvoiceDetailPage() {
   };
 
   const handleSend = async () => {
+    if (invoice?.status === 'overdue' && !confirm(
+      'Re-issuing creates new payment details and replaces the current payment link. Continue?'
+    )) return;
     setActionLoading('send');
     setError('');
+    setEmailFeedback(null);
     const result = await authFetch(`/api/invoices/${invoiceId}/send`, { method: 'POST' }, router);
     if (result?.data.success) {
       setInvoice(result.data.invoice);
+      setEmailFeedback(result.data.emailAccepted === false || result.data.warning
+        ? {
+            tone: 'warning',
+            message: result.data.warning || 'The payment link is active, but the email was not accepted. Copy the link or retry the email.',
+          }
+        : { tone: 'success', message: 'The email provider accepted the invoice message.' });
     } else {
       setError(result?.data.error || 'Failed to send invoice');
+    }
+    setActionLoading('');
+  };
+
+  const handleResendEmail = async () => {
+    setActionLoading('resend-email');
+    setError('');
+    setEmailFeedback(null);
+    const result = await authFetch(`/api/invoices/${invoiceId}/resend-email`, { method: 'POST' }, router);
+
+    if (result?.data.invoice) {
+      setInvoice(result.data.invoice);
+    }
+    if (result?.data.success) {
+      setEmailFeedback({
+        tone: result.data.warning ? 'warning' : 'success',
+        message: result.data.warning || 'The email provider accepted the invoice message.',
+      });
+    } else {
+      setError(result?.data.error || 'Failed to resend invoice email. The existing payment link is still active.');
     }
     setActionLoading('');
   };
@@ -207,6 +242,15 @@ export default function InvoiceDetailPage() {
 
         {error && (
           <div className="mb-6 bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg">{error}</div>
+        )}
+        {emailFeedback && (
+          <div className={`mb-6 px-4 py-3 rounded-lg border ${
+            emailFeedback.tone === 'success'
+              ? 'bg-green-500/10 border-green-500/30 text-green-300'
+              : 'bg-amber-500/10 border-amber-500/30 text-amber-300'
+          }`}>
+            {emailFeedback.message}
+          </div>
         )}
 
         {/* An auto-generated invoice whose payee is not one of the account's own
@@ -353,6 +397,43 @@ export default function InvoiceDetailPage() {
               </div>
             )}
 
+            {['sent', 'overdue'].includes(invoice.status) && (
+              <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-6">
+                <h3 className="text-sm font-semibold text-gray-400 uppercase mb-3">Invoice Email</h3>
+                <div className="flex items-center gap-2">
+                  <span className={`h-2.5 w-2.5 rounded-full ${
+                    invoice.email_status === 'accepted'
+                      ? 'bg-green-400'
+                      : invoice.email_status === 'failed'
+                        ? 'bg-red-400'
+                        : invoice.email_status === 'pending'
+                          ? 'bg-amber-400'
+                          : 'bg-gray-500'
+                  }`} />
+                  <span className="text-white font-medium capitalize">
+                    {invoice.email_status || 'unknown'}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-500 mt-2">
+                  {invoice.email_status === 'accepted'
+                    ? 'Accepted by the email provider. This does not guarantee inbox delivery.'
+                    : invoice.email_status === 'failed'
+                      ? 'The provider did not accept the last attempt.'
+                      : invoice.email_status === 'pending'
+                        ? 'An email attempt is in progress or was interrupted.'
+                        : 'No email acceptance record exists for this legacy invoice.'}
+                </p>
+                {invoice.email_last_attempted_at && (
+                  <p className="text-xs text-gray-500 mt-2">
+                    Last attempt: {new Date(invoice.email_last_attempted_at).toLocaleString()}
+                  </p>
+                )}
+                {invoice.email_last_error && (
+                  <p className="text-xs text-red-300 mt-2 break-words">{invoice.email_last_error}</p>
+                )}
+              </div>
+            )}
+
             {/* Actions */}
             <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-6 space-y-3">
               <h3 className="text-sm font-semibold text-gray-400 uppercase mb-3">Actions</h3>
@@ -361,9 +442,17 @@ export default function InvoiceDetailPage() {
                 <button
                   onClick={handleSend}
                   disabled={actionLoading === 'send'}
-                  className="w-full px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg font-medium disabled:opacity-50 transition-colors"
+                  className={`w-full px-4 py-2 text-white rounded-lg font-medium disabled:opacity-50 transition-colors ${
+                    invoice.status === 'overdue'
+                      ? 'bg-amber-600 hover:bg-amber-500'
+                      : 'bg-purple-600 hover:bg-purple-500'
+                  }`}
                 >
-                  {actionLoading === 'send' ? 'Sending...' : '📧 Send Invoice'}
+                  {actionLoading === 'send'
+                    ? 'Sending...'
+                    : invoice.status === 'overdue'
+                      ? '↻ Re-issue Payment Details'
+                      : '📧 Send Invoice'}
                 </button>
               )}
 
@@ -374,6 +463,16 @@ export default function InvoiceDetailPage() {
                   className="w-full px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg font-medium disabled:opacity-50 transition-colors"
                 >
                   {actionLoading === 'paid' ? 'Updating...' : '✅ Mark as Paid'}
+                </button>
+              )}
+
+              {invoice.status === 'sent' && invoice.payment_address && invoice.crypto_amount && invoice.crypto_currency && (
+                <button
+                  onClick={handleResendEmail}
+                  disabled={actionLoading === 'resend-email'}
+                  className="w-full px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg font-medium disabled:opacity-50 transition-colors"
+                >
+                  {actionLoading === 'resend-email' ? 'Resending...' : '📧 Resend Email'}
                 </button>
               )}
 

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -13,6 +13,7 @@ interface Invoice {
   amount: string;
   crypto_currency: string | null;
   crypto_amount: string | null;
+  email_status: 'pending' | 'accepted' | 'failed' | null;
   due_date: string | null;
   created_at: string;
   clients: { id: string; name: string; email: string; company_name: string } | null;
@@ -127,6 +128,19 @@ function InvoicesTab() {
                   </td>
                   <td className="px-6 py-4">
                     <span className={`inline-flex px-2 py-1 rounded-full text-xs font-medium ${statusColors[invoice.status] || ''}`}>{invoice.status}</span>
+                    {['sent', 'overdue'].includes(invoice.status) && (
+                      <p className={`mt-1 text-xs ${
+                        invoice.email_status === 'accepted'
+                          ? 'text-green-400'
+                          : invoice.email_status === 'failed'
+                            ? 'text-red-400'
+                            : invoice.email_status === 'pending'
+                              ? 'text-amber-400'
+                              : 'text-gray-500'
+                      }`}>
+                        Email {invoice.email_status || 'unknown'}
+                      </p>
+                    )}
                   </td>
                   <td className="px-6 py-4 text-gray-400 text-sm">{invoice.due_date ? new Date(invoice.due_date).toLocaleDateString() : '—'}</td>
                   <td className="px-6 py-4">

--- a/src/lib/email/invoice-delivery.test.ts
+++ b/src/lib/email/invoice-delivery.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSendEmail = vi.fn();
+const mockInvoiceSentTemplate = vi.fn(() => ({
+  subject: 'Invoice INV-001',
+  html: '<p>Invoice</p>',
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock('@/lib/email/invoice-templates', () => ({
+  invoiceSentTemplate: (...args: unknown[]) => mockInvoiceSentTemplate(...args),
+}));
+
+import { deliverInvoiceEmail, getInvoicePaymentLink } from './invoice-delivery';
+
+const invoice = {
+  id: 'inv-1',
+  invoice_number: 'INV-001',
+  amount: '40.00',
+  currency: 'USD',
+  crypto_amount: '0.52909283',
+  crypto_currency: 'SOL',
+  due_date: null,
+  notes: 'Weekly milestone',
+  clients: { email: 'client@example.com' },
+  businesses: { name: 'Profullstack' },
+};
+
+describe('invoice email delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://coinpayportal.com/';
+    mockSendEmail.mockResolvedValue({ success: true, messageId: 'message-1' });
+  });
+
+  it('builds the canonical payment link without a duplicate slash', () => {
+    expect(getInvoicePaymentLink('inv-1')).toBe('https://coinpayportal.com/now/inv-1');
+  });
+
+  it('sends the invoice template and returns provider acceptance details', async () => {
+    const result = await deliverInvoiceEmail(invoice);
+
+    expect(mockInvoiceSentTemplate).toHaveBeenCalledWith(expect.objectContaining({
+      invoiceNumber: 'INV-001',
+      paymentLink: 'https://coinpayportal.com/now/inv-1',
+      businessName: 'Profullstack',
+    }));
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      to: 'client@example.com',
+      subject: 'Invoice INV-001',
+      html: '<p>Invoice</p>',
+    });
+    expect(result).toEqual({
+      success: true,
+      messageId: 'message-1',
+      paymentLink: 'https://coinpayportal.com/now/inv-1',
+    });
+  });
+
+  it('does not call the provider when the client email is missing', async () => {
+    const result = await deliverInvoiceEmail({ ...invoice, clients: null });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Client email is required to send invoice',
+      paymentLink: 'https://coinpayportal.com/now/inv-1',
+    });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/email/invoice-delivery.ts
+++ b/src/lib/email/invoice-delivery.ts
@@ -1,0 +1,56 @@
+import { sendEmail, type SendEmailResult } from '.';
+import { invoiceSentTemplate } from './invoice-templates';
+
+export interface InvoiceEmailData {
+  id: string;
+  invoice_number: string;
+  amount: string | number;
+  currency?: string | null;
+  crypto_amount: string | number;
+  crypto_currency: string;
+  due_date?: string | null;
+  notes?: string | null;
+  clients?: { email?: string | null } | null;
+  businesses?: { name?: string | null } | null;
+}
+
+export interface InvoiceEmailResult extends SendEmailResult {
+  paymentLink: string;
+}
+
+export function getInvoicePaymentLink(invoiceId: string): string {
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL || 'https://coinpayportal.com').replace(/\/$/, '');
+  return `${appUrl}/now/${invoiceId}`;
+}
+
+export async function deliverInvoiceEmail(invoice: InvoiceEmailData): Promise<InvoiceEmailResult> {
+  const clientEmail = invoice.clients?.email;
+  if (!clientEmail) {
+    return {
+      success: false,
+      error: 'Client email is required to send invoice',
+      paymentLink: getInvoicePaymentLink(invoice.id),
+    };
+  }
+
+  const paymentLink = getInvoicePaymentLink(invoice.id);
+  const template = invoiceSentTemplate({
+    invoiceNumber: invoice.invoice_number,
+    amount: Number(invoice.amount),
+    currency: invoice.currency || 'USD',
+    cryptoAmount: String(invoice.crypto_amount),
+    cryptoCurrency: invoice.crypto_currency,
+    dueDate: invoice.due_date || undefined,
+    businessName: invoice.businesses?.name || 'CoinPay Merchant',
+    paymentLink,
+    notes: invoice.notes || undefined,
+  });
+
+  const result = await sendEmail({
+    to: clientEmail,
+    subject: template.subject,
+    html: template.html,
+  });
+
+  return { ...result, paymentLink };
+}

--- a/src/lib/web-wallet/rate-limit.test.ts
+++ b/src/lib/web-wallet/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterAll, beforeAll, describe, it, expect, beforeEach } from 'vitest';
 import {
   checkRateLimit,
   resetRateLimits,
@@ -6,6 +6,28 @@ import {
   resetSeenSignatures,
   RATE_LIMITS,
 } from './rate-limit';
+
+const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const originalServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+beforeAll(() => {
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+});
+
+afterAll(() => {
+  if (originalSupabaseUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+  }
+
+  if (originalServiceRoleKey === undefined) {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  } else {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceRoleKey;
+  }
+});
 
 describe('rate-limit', () => {
   beforeEach(() => {

--- a/src/lib/web-wallet/rate-limit.ts
+++ b/src/lib/web-wallet/rate-limit.ts
@@ -93,6 +93,7 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'lnurl_resolve': { limit: 10, windowSeconds: 60 },          // 10/min per business
   'usage_mutate': { limit: 60, windowSeconds: 60 },           // 60/min per business
   'invoice_mutate': { limit: 30, windowSeconds: 60 },         // 30/min per caller
+  'invoice_email_resend': { limit: 10, windowSeconds: 300 },  // 10/5min per business
   'p2p_request': { limit: 30, windowSeconds: 60 },           // 30/min per issuing platform
   'cli_auth_start': { limit: 10, windowSeconds: 300 },       // 10/5min per IP
 };

--- a/supabase/migrations/20260817010000_invoice_email_delivery_status.sql
+++ b/supabase/migrations/20260817010000_invoice_email_delivery_status.sql
@@ -1,0 +1,17 @@
+-- Track invoice email attempts separately from the invoice payment state.
+-- Existing rows stay NULL because their historical delivery state is unknown.
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS email_status TEXT
+    CHECK (email_status IN ('pending', 'accepted', 'failed')),
+  ADD COLUMN IF NOT EXISTS email_message_id TEXT,
+  ADD COLUMN IF NOT EXISTS email_last_error TEXT,
+  ADD COLUMN IF NOT EXISTS email_last_attempted_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN invoices.email_status IS
+  'Email provider acceptance state. NULL means unknown for invoices sent before tracking was added.';
+COMMENT ON COLUMN invoices.email_message_id IS
+  'Message identifier returned by the configured email provider.';
+COMMENT ON COLUMN invoices.email_last_error IS
+  'Most recent email submission error, cleared after provider acceptance.';
+COMMENT ON COLUMN invoices.email_last_attempted_at IS
+  'Timestamp of the most recent invoice email submission attempt.';


### PR DESCRIPTION
## Summary
- track invoice email provider acceptance separately from payment status
- preserve active payment details when delivery fails and safely retry the same link
- recover legacy sent invoices with dead payment links through explicit reissue
- expose delivery status in the invoice UI and CLI while guarding concurrent attempts

## Safety
- resend never creates or replaces payment resources
- settling, settled, mismatched, and unknown payment states fail closed
- existing invoice rows intentionally display Unknown until a new attempt is recorded

## Checks
- Claude Opus max-effort review: approved with no blockers
- 100 focused tests pass
- pre-commit related suite: 265 tests pass
- TypeScript type-check passes
- lint: 0 errors (6 existing React hook warnings)
- full suite previously reached 4257 passing / 3 skipped; one unrelated DNS-dependent webhook test failed locally, while an independent run passed all 4258 tests

## Deploy
Apply `20260817010000_invoice_email_delivery_status.sql` before deploying the resend route.