### PR TITLE
Backfill five migrations applied to prod but never committed

### DIFF
--- a/supabase/migrations/20260814123817_admin_escrow_summary_disbursed_split.sql
+++ b/supabase/migrations/20260814123817_admin_escrow_summary_disbursed_split.sql
@@ -1,0 +1,143 @@
+create or replace function public.admin_escrow_summary()
+returns json
+language sql
+stable
+security invoker
+set search_path = public
+as $fn$
+  with e as (
+    select
+      *,
+      (funded_at is not null and settled_at is null and refunded_at is null) as is_held
+    from escrows
+  ),
+  totals as (
+    select
+      count(*)                                                as escrows_total,
+      min(created_at)                                         as first_created_at,
+      max(created_at)                                         as last_created_at,
+      count(*) filter (where funded_at is not null)           as ever_funded,
+      count(*) filter (where settled_at is not null)          as ever_disbursed,
+      count(*) filter (where released_at is not null)         as ever_released,
+      count(*) filter (where disputed_at is not null)         as ever_disputed,
+      count(*) filter (where status = 'settled')              as status_settled,
+      count(*) filter (where status = 'refunded')             as status_refunded,
+      count(*) filter (where status = 'expired')              as expired,
+      count(*) filter (where is_held)                         as held_count,
+      count(*) filter (where is_held and expires_at is not null and expires_at < now())
+                                                              as stranded_count,
+      count(*) filter (where dispute_status in ('open', 'under_review'))
+                                                              as disputes_open,
+      count(*) filter (where series_id is not null)           as in_series,
+      count(*) filter (where allow_auto_release)              as auto_release,
+      count(*) filter (where business_id is not null)         as with_business,
+      count(distinct business_id)                             as businesses,
+      count(*) filter (where created_at >= now() - interval '30 days')  as created_30d,
+      count(*) filter (where settled_at >= now() - interval '30 days')  as settled_30d,
+      coalesce(sum(amount_usd), 0)                                      as created_value_usd,
+      coalesce(sum(amount_usd) filter (where funded_at is not null), 0) as funded_value_usd,
+      coalesce(sum(amount_usd) filter (where settled_at is not null), 0)   as disbursed_value_usd,
+      coalesce(sum(amount_usd) filter (where status = 'settled'), 0)       as released_value_usd,
+      coalesce(sum(amount_usd) filter (where status = 'refunded'), 0)      as refunded_value_usd,
+      coalesce(sum(amount_usd) filter (where is_held), 0)               as held_value_usd,
+      coalesce(max(amount_usd), 0)                                      as largest_usd,
+      coalesce(percentile_cont(0.5) within group (order by amount_usd), 0) as median_usd,
+      percentile_cont(0.5) within group (
+        order by extract(epoch from (funded_at - created_at)) / 3600.0
+      )                                                                 as median_hours_to_fund,
+      percentile_cont(0.5) within group (
+        order by extract(epoch from (settled_at - funded_at)) / 3600.0
+      )                                                                 as median_hours_to_settle
+    from e
+  ),
+  by_status as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.status), '[]'::json) as j
+    from (
+      select status, count(*) as total, coalesce(sum(amount_usd), 0) as value_usd
+      from e group by status
+    ) r
+  ),
+  by_chain as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.chain), '[]'::json) as j
+    from (
+      select chain,
+             count(*) as total,
+             count(*) filter (where settled_at is not null) as settled,
+             coalesce(sum(amount_usd) filter (where settled_at is not null), 0) as settled_usd,
+             coalesce(sum(amount_usd) filter (where funded_at is not null
+               and settled_at is null and refunded_at is null), 0) as held_usd
+      from e group by chain
+    ) r
+  ),
+  by_model as (
+    select coalesce(json_agg(row_to_json(r) order by r.total desc, r.escrow_model), '[]'::json) as j
+    from (
+      select escrow_model,
+             count(*) as total,
+             count(*) filter (where settled_at is not null) as settled
+      from e group by escrow_model
+    ) r
+  ),
+  months as (
+    select coalesce(json_agg(row_to_json(r) order by r.month), '[]'::json) as j
+    from (
+      select to_char(g.m, 'YYYY-MM') as month,
+             count(e.id) filter (where date_trunc('month', e.created_at) = g.m) as created,
+             count(e.id) filter (where date_trunc('month', e.funded_at)  = g.m) as funded,
+             count(e.id) filter (where date_trunc('month', e.settled_at) = g.m) as settled,
+             coalesce(sum(e.amount_usd) filter (where date_trunc('month', e.settled_at) = g.m), 0)
+               as settled_usd
+      from generate_series(
+             (select date_trunc('month', min(created_at)) from e),
+             date_trunc('month', now()),
+             interval '1 month'
+           ) g(m)
+      left join e on date_trunc('month', e.created_at) = g.m
+                  or date_trunc('month', e.funded_at)  = g.m
+                  or date_trunc('month', e.settled_at) = g.m
+      group by g.m
+    ) r
+  )
+  select json_build_object(
+    'escrows_total',           t.escrows_total,
+    'first_created_at',        t.first_created_at,
+    'last_created_at',         t.last_created_at,
+    'ever_funded',             t.ever_funded,
+    'ever_disbursed',          t.ever_disbursed,
+    'ever_released',           t.ever_released,
+    'ever_disputed',           t.ever_disputed,
+    'status_settled',          t.status_settled,
+    'status_refunded',         t.status_refunded,
+    'expired',                 t.expired,
+    'held_count',              t.held_count,
+    'stranded_count',          t.stranded_count,
+    'disputes_open',           t.disputes_open,
+    'in_series',               t.in_series,
+    'auto_release',            t.auto_release,
+    'with_business',           t.with_business,
+    'businesses',              t.businesses,
+    'created_30d',             t.created_30d,
+    'settled_30d',             t.settled_30d,
+    'created_value_usd',       t.created_value_usd,
+    'funded_value_usd',        t.funded_value_usd,
+    'disbursed_value_usd',     t.disbursed_value_usd,
+    'released_value_usd',      t.released_value_usd,
+    'refunded_value_usd',      t.refunded_value_usd,
+    'held_value_usd',          t.held_value_usd,
+    'largest_usd',             t.largest_usd,
+    'median_usd',              t.median_usd,
+    'median_hours_to_fund',    t.median_hours_to_fund,
+    'median_hours_to_settle',  t.median_hours_to_settle,
+    'by_status',               (select j from by_status),
+    'by_chain',                (select j from by_chain),
+    'by_model',                (select j from by_model),
+    'months',                  (select j from months)
+  )
+  from totals t;
+$fn$;
+
+comment on function public.admin_escrow_summary() is
+  'All-time escrow totals, lifecycle funnel, per-chain and per-status breakdowns and a monthly history for the admin console header. service_role only. Created value and settled value are separate figures and must not be added.';
+
+revoke all on function public.admin_escrow_summary() from public;
+grant execute on function public.admin_escrow_summary() to service_role;

--- a/supabase/migrations/20260814123928_admin_escrow_stats_revoke_browser_roles.sql
+++ b/supabase/migrations/20260814123928_admin_escrow_stats_revoke_browser_roles.sql
@@ -1,0 +1,4 @@
+revoke all on function public.admin_escrow_stats(text, text, text, text, text, text, int, int) from public, anon, authenticated;
+revoke all on function public.admin_escrow_summary() from public, anon, authenticated;
+grant execute on function public.admin_escrow_stats(text, text, text, text, text, text, int, int) to service_role;
+grant execute on function public.admin_escrow_summary() to service_role;

--- a/supabase/migrations/20260814133536_backup_inflated_escrows_before_delete.sql
+++ b/supabase/migrations/20260814133536_backup_inflated_escrows_before_delete.sql
@@ -1,0 +1,23 @@
+-- Snapshot of the never-funded, inflated-amount escrows before removing them.
+--
+-- Kept in a `backup` schema rather than `public` on purpose: these rows carry
+-- `release_token` and `beneficiary_token` (bearer credentials that can release
+-- an escrow) plus counterparty emails. PostgREST exposes `public` only, so a
+-- backup table there would be reachable over the REST API.
+create schema if not exists backup;
+
+revoke all on schema backup from public, anon, authenticated;
+
+create table backup.escrows_inflated_20260814 as
+  select * from public.escrows where amount_usd >= 1000000;
+
+create table backup.escrow_events_inflated_20260814 as
+  select * from public.escrow_events
+  where escrow_id in (select id from public.escrows where amount_usd >= 1000000);
+
+comment on table backup.escrows_inflated_20260814 is
+  'Snapshot taken 2026-08-14 before deleting 12 never-funded escrows whose amount_usd '
+  'ranged from $32.7M to $9.86B. None had a deposit transaction, so no funds were involved. '
+  'Restore with: insert into public.escrows select * from backup.escrows_inflated_20260814;';
+
+revoke all on all tables in schema backup from public, anon, authenticated;

--- a/supabase/migrations/20260816013627_audit_invoice_uniqueness_and_fee_events.sql
+++ b/supabase/migrations/20260816013627_audit_invoice_uniqueness_and_fee_events.sql
@@ -1,0 +1,28 @@
+-- V-010: invoice numbers are allocated with an unlocked read-then-write MAX+1,
+-- so concurrent creates claim the same number. The application cannot make that
+-- atomic, so the guarantee lives here: a collision becomes an error the route
+-- retries instead of a silent duplicate. Verified zero existing duplicates, so
+-- this is added VALID.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'invoices_business_id_invoice_number_key'
+  ) THEN
+    ALTER TABLE public.invoices
+      ADD CONSTRAINT invoices_business_id_invoice_number_key
+      UNIQUE (business_id, invoice_number);
+  END IF;
+END $$;
+
+-- N-015: a failed escrow fee forward was caught, logged, and forgotten — the
+-- escrow was marked settled with fee_tx_hash NULL and nothing recorded that the
+-- platform was still owed. The settle route now writes an escrow_events row,
+-- which needs the event type permitted.
+ALTER TABLE public.escrow_events DROP CONSTRAINT IF EXISTS escrow_events_event_type_check;
+ALTER TABLE public.escrow_events
+  ADD CONSTRAINT escrow_events_event_type_check
+  CHECK (event_type IN (
+    'created','pending','funded','released','settled','disputed','dispute_resolved',
+    'refunded','expired','metadata_updated','multisig_created','proposal_created',
+    'signature_added','tx_broadcast','fee_forward_failed'
+  )) NOT VALID;

--- a/supabase/migrations/20260816020041_payment_idempotency_key.sql
+++ b/supabase/migrations/20260816020041_payment_idempotency_key.sql
@@ -1,0 +1,17 @@
+-- N-014: idempotency for payment creation.
+--
+-- The route checks for an existing payment with the same Idempotency-Key
+-- before inserting, but that is a read-then-write: two retries arriving
+-- together both find nothing and both insert. This partial unique index makes
+-- the database the arbiter, so concurrent retries cannot both create a payment.
+--
+-- Partial (WHERE ... IS NOT NULL) so the overwhelming majority of payments,
+-- which send no key, are unaffected and pay no index cost.
+CREATE UNIQUE INDEX IF NOT EXISTS payments_business_idempotency_key_uidx
+  ON public.payments (business_id, ((metadata ->> 'idempotency_key')))
+  WHERE metadata ->> 'idempotency_key' IS NOT NULL;
+
+COMMENT ON INDEX public.payments_business_idempotency_key_uidx IS
+  'Enforces one payment per (business, Idempotency-Key). Creating a payment '
+  'allocates an HD address and spends monthly quota, so a client retrying after '
+  'a timeout must not produce a second charge.';


### PR DESCRIPTION
Five migrations were applied to the prod Supabase project (`mlywdeoogwsebabohskk`) via the Supabase MCP and are recorded in `supabase_migrations.schema_migrations`, but no file ever landed in `supabase/migrations/`. The directory understated prod by five entries. This adds them.

- `20260814123817_admin_escrow_summary_disbursed_split.sql`
- `20260814123928_admin_escrow_stats_revoke_browser_roles.sql`
- `20260814133536_backup_inflated_escrows_before_delete.sql`
- `20260816013627_audit_invoice_uniqueness_and_fee_events.sql`
- `20260816020041_payment_idempotency_key.sql`

Each file's contents are byte-identical to the statement stored in prod, verified by comparing md5 of the file against `md5(statements[1] || E'\n')` server-side. Each filename uses the version prod recorded, so the directory and `schema_migrations` now agree on both name and version.

**This does not re-apply anything.** No workflow in this repo applies migrations, and the statements are idempotent-guarded anyway. It is a record of what already ran.

After this, local files and prod migrations both number 133 with a clean diff in both directions.