### PR TITLE
Fail closed on mismatched Solana forwarding records

### DIFF
--- a/src/lib/blockchain/providers.test.ts
+++ b/src/lib/blockchain/providers.test.ts
@@ -314,6 +314,49 @@ describe('Blockchain Providers', () => {
       expect(provider.sendTransaction).toBeDefined();
     });
 
+    it('should reject a transfer when the signer does not control the source address', async () => {
+      const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');
+
+      await expect(
+        provider.sendTransaction('different-address', 'recipient', '0.5', 'private-key')
+      ).rejects.toThrow('Solana signer address mismatch');
+    });
+
+    it('should reject a split transfer when the signer does not control the source address', async () => {
+      const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');
+
+      await expect(
+        provider.sendSplitTransaction(
+          'different-address',
+          [{ address: 'recipient', amount: '0.5' }],
+          'private-key'
+        )
+      ).rejects.toThrow('Solana signer address mismatch');
+    });
+
+    it('should allow a transfer when the signer controls the source address', async () => {
+      const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');
+
+      await expect(
+        provider.sendTransaction('mockpublickey', 'recipient', '0.5', 'private-key')
+      ).resolves.toBe('mocksoltxsignature');
+    });
+
+    it('should allow a split transfer when the signer controls the source address', async () => {
+      const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');
+
+      await expect(
+        provider.sendSplitTransaction(
+          'mockpublickey',
+          [
+            { address: 'merchant', amount: '0.99' },
+            { address: 'platform', amount: '0.01' },
+          ],
+          'private-key'
+        )
+      ).resolves.toBe('mocksoltxsignature');
+    });
+
     describe('Rent-Exempt Minimum for One-Time Payment Addresses', () => {
       it('should have RENT_EXEMPT_MINIMUM set to 0 for one-time payment addresses', () => {
         const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');

--- a/src/lib/blockchain/providers.ts
+++ b/src/lib/blockchain/providers.ts
@@ -618,6 +618,15 @@ export class SolanaProvider implements BlockchainProvider {
     this.connection = new Connection(rpcUrl, 'confirmed');
   }
 
+  private assertSignerControls(from: string, keypair: Keypair): void {
+    const signerAddress = keypair.publicKey.toString();
+    if (signerAddress !== from) {
+      throw new Error(
+        `Solana signer address mismatch: expected ${from}, derived ${signerAddress}`
+      );
+    }
+  }
+
   async getBalance(address: string): Promise<string> {
     try {
       const publicKey = new PublicKey(address);
@@ -707,12 +716,10 @@ export class SolanaProvider implements BlockchainProvider {
       // Create keypair from secret key
       const keypair = Keypair.fromSecretKey(secretKey);
 
-      // Verify the from address matches the keypair
-      if (keypair.publicKey.toString() !== from) {
-        console.log(`[SOL] Address mismatch: expected ${from}, got ${keypair.publicKey.toString()}`);
-        // Don't throw - the address derivation might differ slightly
-        // Just log and continue
-      }
+      // A forwarding key must control the address whose balance was checked.
+      // Continuing on a mismatch could spend a different derived account while
+      // leaving the customer's deposit untouched.
+      this.assertSignerControls(from, keypair);
 
       // Convert amount to lamports
       let lamports = Math.floor(parseFloat(amount) * LAMPORTS_PER_SOL);
@@ -810,6 +817,8 @@ export class SolanaProvider implements BlockchainProvider {
       }
 
       const keypair = Keypair.fromSecretKey(secretKey);
+
+      this.assertSignerControls(from, keypair);
 
       // Get current balance
       const currentBalance = await this.connection.getBalance(keypair.publicKey);

--- a/src/lib/wallets/secure-forwarding-binding.test.ts
+++ b/src/lib/wallets/secure-forwarding-binding.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { validateForwardingBinding } from './secure-forwarding';
+
+const PAYMENT = {
+  id: 'payment-123',
+  blockchain: 'SOL',
+  payment_address: 'source-address',
+  merchant_wallet_address: 'merchant-address',
+};
+
+const ADDRESS_RECORD = {
+  payment_id: 'payment-123',
+  cryptocurrency: 'SOL' as const,
+  address: 'source-address',
+  merchant_wallet: 'merchant-address',
+  commission_wallet: 'commission-address',
+};
+
+const COMMISSION_WALLET = 'commission-address';
+
+describe('validateForwardingBinding', () => {
+  it('accepts matching payment and signing records', () => {
+    expect(
+      validateForwardingBinding(PAYMENT, ADDRESS_RECORD, COMMISSION_WALLET)
+    ).toBeNull();
+  });
+
+  it('accepts surrounding whitespace in recorded addresses', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        {
+          ...ADDRESS_RECORD,
+          address: ' source-address ',
+          merchant_wallet: ' merchant-address ',
+          commission_wallet: ' commission-address ',
+        },
+        COMMISSION_WALLET
+      )
+    ).toBeNull();
+  });
+
+  it('rejects a payment-id mismatch', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        { ...ADDRESS_RECORD, payment_id: 'other-payment' },
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment address record belongs to a different payment');
+  });
+
+  it('rejects a missing source address', () => {
+    expect(
+      validateForwardingBinding(
+        { ...PAYMENT, payment_address: null },
+        ADDRESS_RECORD,
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment has no recorded source address');
+  });
+
+  it('rejects a source-address mismatch', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        { ...ADDRESS_RECORD, address: 'other-source' },
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment source address does not match its signing record');
+  });
+
+  it('rejects a missing blockchain', () => {
+    expect(
+      validateForwardingBinding(
+        { ...PAYMENT, blockchain: null },
+        ADDRESS_RECORD,
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment has no recorded blockchain');
+  });
+
+  it('rejects a merchant-address mismatch', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        { ...ADDRESS_RECORD, merchant_wallet: 'other-merchant' },
+        COMMISSION_WALLET
+      )
+    ).toBe('Merchant payout address does not match its signing record');
+  });
+
+  it('rejects a missing merchant address', () => {
+    expect(
+      validateForwardingBinding(
+        { ...PAYMENT, merchant_wallet_address: null },
+        ADDRESS_RECORD,
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment has no recorded merchant payout address');
+  });
+
+  it('rejects a blockchain mismatch', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        { ...ADDRESS_RECORD, cryptocurrency: 'BTC' },
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment blockchain does not match its signing record');
+  });
+
+  it('rejects a missing platform fee wallet', () => {
+    expect(
+      validateForwardingBinding(
+        PAYMENT,
+        { ...ADDRESS_RECORD, commission_wallet: ' ' },
+        COMMISSION_WALLET
+      )
+    ).toBe('Payment signing record has no platform fee wallet');
+  });
+
+  it('rejects a platform fee wallet that differs from server configuration', () => {
+    expect(
+      validateForwardingBinding(PAYMENT, ADDRESS_RECORD, 'other-commission-address')
+    ).toBe('Platform fee wallet does not match server configuration');
+  });
+
+  it('compares EVM addresses case-insensitively', () => {
+    expect(
+      validateForwardingBinding(
+        {
+          ...PAYMENT,
+          blockchain: 'ETH',
+          payment_address: '0xAbCd',
+          merchant_wallet_address: '0xEf01',
+        },
+        {
+          ...ADDRESS_RECORD,
+          cryptocurrency: 'ETH',
+          address: '0xabcd',
+          merchant_wallet: '0xef01',
+          commission_wallet: '0xab02',
+        },
+        '0xAb02'
+      )
+    ).toBeNull();
+  });
+});

--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -36,7 +36,7 @@ import {
   ensureGasForTransfers,
   forwardTokenViaRelayer,
 } from './evm-gas';
-import type { SystemBlockchain } from './system-wallet';
+import { getCommissionWallet, type SystemBlockchain } from './system-wallet';
 import { checkBalance as checkAddressBalance } from '@/app/api/cron/monitor-payments/balance-checkers';
 
 const EVM_TOKEN_CONFIG = {
@@ -87,6 +87,72 @@ interface PaymentAddressData {
   merchant_amount: number;
   is_used: boolean;
   is_escrow?: boolean;
+}
+
+interface ForwardingPaymentBinding {
+  id: string;
+  blockchain: string | null;
+  payment_address: string | null;
+  merchant_wallet_address: string | null;
+}
+
+function addressesMatch(left: string, right: string): boolean {
+  const a = left.trim();
+  const b = right.trim();
+  return a.startsWith('0x') && b.startsWith('0x')
+    ? a.toLowerCase() === b.toLowerCase()
+    : a === b;
+}
+
+/**
+ * Fail closed when the payment and its signing record no longer describe the
+ * same source, chain, and payout destination.
+ */
+export function validateForwardingBinding(
+  payment: ForwardingPaymentBinding,
+  addressData: Pick<
+    PaymentAddressData,
+    'payment_id' | 'cryptocurrency' | 'address' | 'merchant_wallet' | 'commission_wallet'
+  >,
+  expectedCommissionWallet: string
+): string | null {
+  if (addressData.payment_id !== payment.id) {
+    return 'Payment address record belongs to a different payment';
+  }
+
+  if (!payment.payment_address) {
+    return 'Payment has no recorded source address';
+  }
+
+  if (!addressesMatch(payment.payment_address, addressData.address)) {
+    return 'Payment source address does not match its signing record';
+  }
+
+  if (!payment.blockchain) {
+    return 'Payment has no recorded blockchain';
+  }
+
+  if (payment.blockchain !== addressData.cryptocurrency) {
+    return 'Payment blockchain does not match its signing record';
+  }
+
+  if (!payment.merchant_wallet_address) {
+    return 'Payment has no recorded merchant payout address';
+  }
+
+  if (!addressesMatch(payment.merchant_wallet_address, addressData.merchant_wallet)) {
+    return 'Merchant payout address does not match its signing record';
+  }
+
+  if (!addressData.commission_wallet.trim()) {
+    return 'Payment signing record has no platform fee wallet';
+  }
+
+  if (!addressesMatch(expectedCommissionWallet, addressData.commission_wallet)) {
+    return 'Platform fee wallet does not match server configuration';
+  }
+
+  return null;
 }
 
 /**
@@ -446,6 +512,35 @@ export async function forwardPaymentSecurely(
         error:
           `Payment ${paymentId} has no merchant payout address on its payment_addresses row. ` +
           `Set merchant_wallet to the merchant's ${addressData.cryptocurrency} address before forwarding.`,
+      };
+    }
+
+    let expectedCommissionWallet: string;
+    try {
+      expectedCommissionWallet = getCommissionWallet(
+        addressData.cryptocurrency as SystemBlockchain
+      );
+    } catch (commissionWalletError) {
+      console.error(
+        `[SECURE] Cannot validate platform fee wallet for payment ${paymentId}:`,
+        commissionWalletError
+      );
+      return {
+        success: false,
+        error: 'Platform fee wallet configuration is unavailable',
+      };
+    }
+
+    const bindingError = validateForwardingBinding(
+      payment,
+      addressData,
+      expectedCommissionWallet
+    );
+    if (bindingError) {
+      console.error(`[SECURE] Refusing to forward payment ${paymentId}: ${bindingError}`);
+      return {
+        success: false,
+        error: `Forwarding record mismatch: ${bindingError}`,
       };
     }
 

--- a/src/lib/wallets/system-wallet.test.ts
+++ b/src/lib/wallets/system-wallet.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import { SolanaProvider } from '../blockchain/providers';
 import {
   deriveSystemPaymentAddress,
   calculateSplit,
@@ -232,6 +234,21 @@ describe('System Wallet', () => {
         const result0 = await deriveSystemPaymentAddress('SOL', 0);
         const result1 = await deriveSystemPaymentAddress('SOL', 1);
         expect(result0.address).not.toBe(result1.address);
+      });
+
+      it('should restore the stored seed to the same Solana signer address', async () => {
+        const result = await deriveSystemPaymentAddress('SOL', 7);
+        const provider = new SolanaProvider('https://api.mainnet-beta.solana.com');
+        const deriveFullKeypair = (
+          provider as unknown as {
+            deriveFullKeypair(seed: Uint8Array): Promise<Uint8Array>;
+          }
+        ).deriveFullKeypair.bind(provider);
+
+        const seed = Uint8Array.from(Buffer.from(result.privateKey, 'hex'));
+        const restored = Keypair.fromSecretKey(await deriveFullKeypair(seed));
+
+        expect(restored.publicKey.toString()).toBe(result.address);
       });
     });
 


### PR DESCRIPTION
## What changed

- verify the payment row and encrypted signing record agree on source address, chain, and merchant destination before claiming a payment
- verify the stored platform-fee destination still matches server configuration
- reject native SOL sends when the decrypted key does not control the address whose balance was checked
- cover both single and split transfers, plus an unmocked stored-seed-to-Solana-signer round trip

## Why

Forwarding previously logged a Solana signer/source mismatch and continued. A stale or corrupted signing record could therefore spend a different account while leaving the customer deposit untouched. These checks fail before any transaction is broadcast, keeping the funds at the intermediary address for recovery instead of guessing.

## Verification

- `pnpm type-check`
- `pnpm vitest run` (301 files, 4,283 passed, 3 skipped)
- focused forwarding/provider tests (133 passed)
- staged pre-commit suite (209 passed)