### PR TITLE
docs(skill.md): document wallet auth signing spec exactly (SHA-256 prehash, nonce-in-message, low-S)

### DIFF
--- a/public/skill.md
+++ b/public/skill.md
@@ -104,13 +104,23 @@ Sign each request with your secp256k1 private key:
 Authorization: Wallet <wallet_id>:<signature>:<timestamp>:<nonce>
 ```
 
-**Message to sign:** `{METHOD}:{PATH}:{UNIX_TIMESTAMP}:{BODY}`
+**Message to sign:** `{METHOD}:{PATH}:{UNIX_TIMESTAMP}:{NONCE}:{BODY}`
 
-Example: `GET:/api/web-wallet/abc123/balances:1706432100:`
+Every field must match the request exactly: the HTTP method, the URL path (with query string if present), the UNIX timestamp in seconds from the header, the nonce from the header, and the raw request body bytes (empty string for GET/DELETE). The body is included as-is — do not format or re-serialize it.
 
-Sign the message bytes with secp256k1, hex-encode the 64-byte compact signature.
+Example with nonce: `GET:/api/web-wallet/abc123/balances:1706432100:kX9fQ2mZ:`
 
-**Nonce** (recommended): Append a random string (e.g. 8 chars from `crypto.randomUUID()`) as the 4th field. This prevents replay errors when firing concurrent requests in the same second. The nonce is optional for backwards compatibility.
+The nonce is optional for backwards compatibility. If you omit it, sign the 4-field message `{METHOD}:{PATH}:{UNIX_TIMESTAMP}:{BODY}` and send `Wallet <wallet_id>:<signature>:<timestamp>` (3 fields). Note that a request tuple (`wallet_id`, `signature`, `timestamp`, `nonce`) is single-use — the server rejects replays, so concurrent requests within the same second MUST use distinct nonces (a random string works).
+
+**Hashing (mandatory):** SHA-256 the message bytes first, then sign the 32-byte digest with secp256k1. The server verifies against the raw message with SHA-256 prehashing (the same behavior as `@noble/curves` v2 defaults: `secp256k1.verify` hashes internally unless `prehash: false` is passed). Signing the raw message without hashing will produce `401 {"code":"UNAUTHORIZED","message":"Invalid signature"}`.
+
+**Low-S signatures (mandatory):** the signature must be low-S, i.e. `s <= n/2` where `n = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141`. If your library produces high-S values, normalize with `s' = n - s` before hex-encoding. `@noble/curves`, ethers v6 and viem normalize automatically; raw libraries (e.g. Python `ecdsa`) do not. High-S signatures are rejected with the same `401 Invalid signature`.
+
+Hex-encode the 64-byte compact signature (`r || s`) in the header.
+
+**Timestamp window:** the server accepts timestamps within 300 seconds of its own clock (±5 min window) — keep your clock in sync.
+
+**Body must match the wire:** for POST/PUT/PATCH the signed message body must be byte-identical to the body you send. Build the message from the same string you pass to your HTTP client.
 
 ### 3. Check Balances
 


### PR DESCRIPTION
Fixes #273

Following skill.md §2 exactly produces `401 {"code":"UNAUTHORIZED","message":"Invalid signature"}`. The section omits three server-required details; this PR documents them precisely.

**1. SHA-256 prehash is mandatory.** The server verifies with

```ts
// src/lib/web-wallet/auth.ts
const isValid = verifySecp256k1Signature(signatureHex, messageBytes, wallet.public_key_secp256k1);
// → secp256k1.verify(sigBytes, messageBytes, pubKeyBytes) with no options
```

`@noble/curves` v2 (pinned here: 2.0.1) hashes messages with SHA-256 by default: *"Uses sha256 to hash messages. To use a different hash, pass `{ prehash: false }`"* — so the client must sign `sha256(message)`, not the raw message bytes.

**2. The nonce is part of the signed message.** The server reconstructs

```ts
const message = nonce
  ? `${method}:${path}:${timestamp}:${nonce}:${body || ''}`
  : `${method}:${path}:${timestamp}:${body || ''}`;
```

If the header carries a nonce, the signed message must contain it as the 4th field — the old doc's `METHOD:PATH:TS:BODY` example silently drops it.

**3. Low-S only.** `secp256k1.verify` rejects high-S signatures by default (`lowS: true`). Libraries that do not normalize (raw Python `ecdsa`, etc.) produce high-S values roughly 50% of the time → intermittent 401s.

Verified end-to-end against the production API with a working client before opening this issue: with the corrected recipe (nonce in message, sha256 prehash, low-S normalization) requests authenticate successfully on the first try.
