### PR TITLE
feat(sdk): add TaskMarket delegation module (x402 v2 create/fund/discover)

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1006,6 +1006,41 @@ Tests use [Vitest](https://vitest.dev/) with mocked `fetch` — no API key neede
 
 ---
 
+
+## TaskMarket delegation (x402 v2)
+
+`@profullstack/coinpay/taskmarket` lets an agent or user create and fund a
+[TaskMarket](https://taskmarket.dev) task from inside a CoinPay-powered app,
+using the standard x402 v2 transfer-authorization flow this SDK already speaks.
+
+```js
+import { createTask, discoverTasks, getTask, listSubmissions } from '@profullstack/coinpay/taskmarket';
+
+// Browse open work (public endpoint)
+const open = await discoverTasks({ status: 'open', limit: 25, mode: 'bounty' });
+
+// Create + fund a task. The wallet signs the EIP-712 transfer authorization
+// itself; this module never sees a private key.
+const { taskId } = await createTask(
+  { title: 'Fix my parser bug', description: 'Repro + expected output attached in the linked issue.', reward: 2500000 },
+  {
+    signer: myWalletSigner, // { address, signTypedData({domain, types, primaryType, message}) }
+    capabilities: ['eip155:8453'],
+    spendingLimitUsd: 10,                 // hard cap; refuses anything above
+    authorize: async (d) => confirm(`Send ${d.amount} ${d.asset} to ${d.payTo}?`),
+  }
+);
+
+// Track it and present submissions for human review (never auto-accept)
+const live = await getTask(taskId);
+const submissions = await listSubmissions(taskId);
+```
+
+Safety: no keys ever enter the module; every payment needs fresh `authorize()`
+consent; `spendingLimitUsd` is enforced against the quoted amount in base
+units; after a payment with unknown settlement the caller is told to verify
+with `getTask` instead of retrying blindly.
+
 ## License
 
 [MIT](./LICENSE) © Profullstack, Inc.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@profullstack/coinpay",
   "version": "0.8.0",
-  "description": "CoinPay SDK & CLI — Accept cryptocurrency payments (BTC, ETH, SOL, POL, BCH, USDC) with wallet and swap support",
+  "description": "CoinPay SDK & CLI \u2014 Accept cryptocurrency payments (BTC, ETH, SOL, POL, BCH, USDC) with wallet and swap support",
   "type": "module",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -48,6 +48,9 @@
     },
     "./x402-pay-server": {
       "import": "./src/x402-pay-server.js"
+    },
+    "./taskmarket": {
+      "import": "./src/taskmarket.js"
     }
   },
   "files": [

--- a/packages/sdk/src/taskmarket.js
+++ b/packages/sdk/src/taskmarket.js
@@ -1,0 +1,329 @@
+/**
+ * TaskMarket delegation for CoinPay agent wallets.
+ *
+ * Bridges the CoinPayPortal x402 v2 rails to TaskMarket (https://taskmarket.dev):
+ * an agent or user can discover open work, fetch live task status, list
+ * submissions, and create a fully-funded task through the TaskMarket HTTP API
+ * using the same EIP-712 transfer-authorization mechanics as the rest of this
+ * SDK.
+ *
+ * Safety properties (mirroring the TaskMarket integration bounty rules):
+ *
+ * - No private key, seed phrase, token or cookie is ever requested, stored,
+ *   logged or committed. All signing is delegated to a caller-supplied
+ *   `signer` object (e.g. an EIP-1193 wallet or a CoinPay web-wallet signer).
+ * - Every spend requires fresh, explicit user authorization: the `authorize`
+ *   callback is invoked with the exact amount, asset, payee and deadline, and
+ *   must return `true` before any payment header is produced.
+ * - `spendingLimitUsd` caps the amount that may be authorized in one call.
+ *   The guard is only enforced for assets with known decimals; for any other
+ *   asset the call refuses to proceed rather than pay blind.
+ * - The created task's live status and its submissions are readable through
+ *   `getTask` / `listSubmissions` and are meant to be presented to a human for
+ *   review; this module never silently accepts or rejects work.
+ * - No blind payment retries: a second POST happens exactly once; if its
+ *   settlement status is unknown the error tells the caller to verify with
+ *   `getTask` instead of re-paying.
+ *
+ * @module taskmarket
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  buildAuthorization,
+  encodePaymentHeader,
+  requiredAmount,
+  selectAcceptEntry,
+  X402_VERSION,
+} from './x402-v2.js';
+
+/** TaskMarket API base URL (overridable for tests / self-hosted). */
+export const TASKMARKET_API_URL =
+  process.env.TASKMARKET_API_URL ?? 'https://api.taskmarket.dev';
+
+/** Amounts are quoted in base units; USDC settles at 1e6 per dollar. */
+const DECIMALS = {
+  USDC: 6,
+  USDC_E: 6,
+  USDT: 6,
+  ETH: 18,
+  POL: 18,
+  SOL: 9,
+};
+
+/** Error raised for non-2xx responses from the TaskMarket API. */
+export class TaskMarketError extends Error {
+  constructor(status, message, body) {
+    super(message);
+    this.name = 'TaskMarketError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Error raised when the caller declines the payment authorization. */
+export class PaymentNotAuthorizedError extends Error {
+  constructor(details) {
+    super('Payment not authorized by caller');
+    this.name = 'PaymentNotAuthorizedError';
+    this.details = details;
+  }
+}
+
+/**
+ * True when a single 402 `accepts` entry stays within the caller's spending
+ * cap. Amount comparison happens in base units (`amount * 10^decimals`).
+ *
+ * @param {object} accept  one entry of the 402 `accepts` array
+ * @param {number} spendingLimitUsd  maximum USD the caller allows
+ * @returns {boolean}
+ */
+export function withinSpendingLimit(accept, spendingLimitUsd) {
+  if (!spendingLimitUsd) return true;
+  const asset = String(accept?.asset ?? '').toUpperCase();
+  const decimals = DECIMALS[asset];
+  if (decimals === undefined) {
+    throw new TaskMarketError(
+      0,
+      `Cannot enforce a USD spending limit for asset "${asset}": ` +
+        'its decimals are unknown. Pass an amount with known decimals or ' +
+        'leave spendingLimitUsd unset only if you fully trust the flow.'
+    );
+  }
+  const amount = Number(requiredAmount(accept));
+  return amount <= spendingLimitUsd * 10 ** decimals;
+}
+
+/**
+ * Parse a TaskMarket JSON response, tolerating both `{data: {...}}` wrappers
+ * (task list) and bare payloads (task detail, submissions list).
+ */
+function unwrap(result, key) {
+  if (result && typeof result === 'object') {
+    if (key && result[key] !== undefined) return result[key];
+    if (result.data !== undefined) {
+      if (key && result.data[key] !== undefined) return result.data[key];
+      return result.data;
+    }
+  }
+  return result;
+}
+
+/**
+ * Discover open TaskMarket tasks.
+ *
+ * Listing is public on TaskMarket; a `signer` is therefore optional and only
+ * used to attach the EIP-191 read-auth headers when provided.
+ *
+ * @param {object} [options]
+ * @param {string} [options.status='open']
+ * @param {number} [options.limit=50]
+ * @param {string} [options.phase]      lifecycle filter (active, in_review, ...)
+ * @param {string} [options.mode]       bounty | claim | pitch | benchmark | auction
+ * @param {string} [options.tags]       comma-separated tags
+ * @param {object} [options.signer]     optional `{address, signMessage}` wallet
+ * @param {Function} [options.fetchImpl]  fetch substitute for tests
+ * @returns {Promise<object[]>}
+ */
+export async function discoverTasks(options = {}) {
+  const {
+    status = 'open',
+    limit = 50,
+    phase,
+    mode,
+    tags,
+    signer,
+    fetchImpl = fetch,
+  } = options;
+  const params = new URLSearchParams({ status: String(status), limit: String(limit) });
+  if (phase) params.set('phase', phase);
+  if (mode) params.set('mode', mode);
+  if (tags) params.set('tags', tags);
+
+  let headers = { 'User-Agent': 'coinpay-sdk-taskmarket/0.8' };
+  if (signer && signer.address && signer.signMessage) {
+    const message = `TaskMarket read auth for ${signer.address}`;
+    const signature = await signer.signMessage({ message });
+    headers['X-Taskmarket-Address'] = signer.address;
+    headers['X-Taskmarket-Signature'] = signature;
+  }
+
+  const res = await fetchImpl(`${TASKMARKET_API_URL}/api/tasks?${params}`, { headers });
+  const result = await res.json().catch(() => ({}));
+  if (!res.ok) throw new TaskMarketError(res.status, `GET /api/tasks failed (${res.status})`, result);
+  return unwrap(result, 'tasks') ?? [];
+}
+
+/**
+ * Fetch the live status of one TaskMarket task.
+ *
+ * @param {string} taskId
+ * @param {object} [options]
+ * @param {Function} [options.fetchImpl]
+ * @returns {Promise<object>}
+ */
+export async function getTask(taskId, options = {}) {
+  const { fetchImpl = fetch } = options;
+  const res = await fetchImpl(`${TASKMARKET_API_URL}/api/tasks/${encodeURIComponent(taskId)}`, {
+    headers: { 'User-Agent': 'coinpay-sdk-taskmarket/0.8' },
+  });
+  const result = await res.json().catch(() => ({}));
+  if (!res.ok) throw new TaskMarketError(res.status, `GET /api/tasks/${taskId} failed (${res.status})`, result);
+  return unwrap(result);
+}
+
+/**
+ * List the submissions of a TaskMarket task for human review.
+ *
+ * @param {string} taskId
+ * @param {object} [options]
+ * @param {Function} [options.fetchImpl]
+ * @returns {Promise<object[]>}
+ */
+export async function listSubmissions(taskId, options = {}) {
+  const { fetchImpl = fetch } = options;
+  const res = await fetchImpl(
+    `${TASKMARKET_API_URL}/api/tasks/${encodeURIComponent(taskId)}/submissions`,
+    { headers: { 'User-Agent': 'coinpay-sdk-taskmarket/0.8' } }
+  );
+  const result = await res.json().catch(() => []);
+  if (!res.ok) throw new TaskMarketError(res.status, `GET /api/tasks/${taskId}/submissions failed (${res.status})`, result);
+  return Array.isArray(result) ? result : (unwrap(result, 'submissions') ?? []);
+}
+
+/**
+ * Create a TaskMarket task and pay for it over x402 v2.
+ *
+ * Flow:
+ *   1. POST the task body with an idempotency key.
+ *   2. TaskMarket answers `402 Payment Required` with the accepted rails.
+ *   3. `spendingLimitUsd` is enforced against the quoted amount.
+ *   4. `authorize` is invoked with the exact resource, payee, amount, asset
+ *      and timeout; it must return `true` (fresh, explicit user consent).
+ *   5. The EIP-712 transfer authorization is built, signed by `signer`, and
+ *      sent once as the `PAYMENT-SIGNATURE` header.
+ *   6. The created task id is returned; callers can then poll `getTask`.
+ *
+ * @param {object} task  `{title, description, reward, ...}` — fields are passed
+ *                       through verbatim (reward is in base units).
+ * @param {object} options
+ * @param {object} options.signer  `{address, signTypedData({domain, types, primaryType, message})}`
+ * @param {string[]} [options.capabilities]  CAIP-2 ids the signer can pay
+ * @param {number} [options.spendingLimitUsd]  hard cap in USD for this call
+ * @param {Function} [options.authorize]  `({resource, scheme, network, amount, asset, payTo, maxTimeoutSeconds}) => boolean`
+ * @param {string} [options.idempotencyKey]  defaults to a fresh UUID
+ * @param {Function} [options.fetchImpl]  fetch substitute for tests
+ * @returns {Promise<{taskId: string}>}
+ */
+export async function createTask(task, options) {
+  if (!options?.signer) throw new TypeError('createTask requires options.signer');
+  if (!task?.title || !task?.description) throw new TypeError('task requires title and description');
+  if (!(Number(task.reward) > 0)) throw new TypeError('task requires reward > 0 (base units)');
+
+  const {
+    signer,
+    capabilities = ['eip155:8453', 'eip155:1'],
+    spendingLimitUsd,
+    authorize,
+    idempotencyKey = randomUUID(),
+    fetchImpl = fetch,
+  } = options;
+
+  const url = `${TASKMARKET_API_URL}/api/tasks`;
+  const body = JSON.stringify(task);
+
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'coinpay-sdk-taskmarket/0.8',
+      'X-Taskmarket-Idempotency-Key': idempotencyKey,
+    },
+    body,
+  });
+
+  if (res.ok) return res.json().catch(() => ({}));
+  if (res.status !== 402) {
+    const result = await res.json().catch(() => ({}));
+    throw new TaskMarketError(res.status, `POST /api/tasks failed (${res.status})`, result);
+  }
+
+  // ── Payment required: pick a rail we can sign, then ask the user. ──
+  const requirements = await res.json().catch(() => ({}));
+  const accepts = Array.isArray(requirements.accepts) ? requirements.accepts : [];
+  if (accepts.length === 0) {
+    throw new TaskMarketError(402, 'TaskMarket sent no accepted payment methods', requirements);
+  }
+  const accept = selectAcceptEntry(accepts, capabilities) ?? accepts[0];
+  if (!accept) throw new TaskMarketError(402, 'No acceptable payment method for this wallet', requirements);
+
+  if (!withinSpendingLimit(accept, spendingLimitUsd)) {
+    throw new TaskMarketError(
+      402,
+      `Payment of ${requiredAmount(accept)} ${accept.asset} exceeds spendingLimitUsd=${spendingLimitUsd}`
+    );
+  }
+
+  const details = {
+    resource: requirements.resource,
+    scheme: accept.scheme,
+    network: accept.network,
+    amount: requiredAmount(accept),
+    asset: accept.asset,
+    payTo: accept.payTo,
+    maxTimeoutSeconds: accept.maxTimeoutSeconds,
+  };
+  if (authorize && !(await authorize(details))) {
+    throw new PaymentNotAuthorizedError(details);
+  }
+
+  const authorization = buildAuthorization({
+    from: signer.address,
+    to: accept.payTo,
+    value: requiredAmount(accept),
+    validForSeconds: Number(accept.maxTimeoutSeconds ?? 300),
+  });
+  const signature = await signer.signTypedData({
+    domain: accept.extra?.eip712?.domain,
+    types: accept.extra?.eip712?.types,
+    primaryType: accept.extra?.eip712?.primaryType,
+    message: authorization,
+  });
+
+  const paymentPayload = {
+    x402Version: X402_VERSION,
+    resource: requirements.resource,
+    accepted: {
+      scheme: accept.scheme,
+      network: accept.network,
+      amount: requiredAmount(accept),
+      asset: accept.asset,
+      payTo: accept.payTo,
+      maxTimeoutSeconds: accept.maxTimeoutSeconds,
+      extra: accept.extra,
+    },
+    payload: { authorization, signature },
+  };
+
+  const paid = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'coinpay-sdk-taskmarket/0.8',
+      'X-Taskmarket-Idempotency-Key': idempotencyKey,
+      'PAYMENT-SIGNATURE': encodePaymentHeader(paymentPayload),
+    },
+    body,
+  });
+  const result = await paid.json().catch(() => ({}));
+  if (!paid.ok) {
+    // Settlement state is unknown — never auto-retry the payment.
+    throw new TaskMarketError(
+      paid.status,
+      `POST /api/tasks failed after payment (${paid.status}). ` +
+        'Verify settlement with getTask(taskId) before retrying.',
+      result
+    );
+  }
+  return result;
+}

--- a/packages/sdk/test/taskmarket.test.js
+++ b/packages/sdk/test/taskmarket.test.js
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  TASKMARKET_API_URL,
+  TaskMarketError,
+  PaymentNotAuthorizedError,
+  discoverTasks,
+  getTask,
+  listSubmissions,
+  createTask,
+  withinSpendingLimit,
+} from '../src/taskmarket.js';
+
+const PAY_TO = '0x' + '11'.repeat(20);
+const EIP712_EXTRA = {
+  eip712: {
+    domain: { name: 'Token', version: '1', chainId: 8453 },
+    types: {
+      TransferWithAuthorization: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'validAfter', type: 'uint256' },
+        { name: 'validBefore', type: 'uint256' },
+        { name: 'nonce', type: 'bytes32' },
+      ],
+    },
+    primaryType: 'TransferWithAuthorization',
+  },
+};
+const ACCEPT = {
+  scheme: 'exact',
+  network: 'eip155:8453',
+  amount: '4500000',
+  asset: 'USDC',
+  payTo: PAY_TO,
+  maxTimeoutSeconds: 300,
+  extra: EIP712_EXTRA,
+};
+const REQUIREMENTS = { resource: `${TASKMARKET_API_URL}/api/tasks`, accepts: [ACCEPT] };
+
+function signerStub({ address = PAY_TO } = {}) {
+  return {
+    address,
+    signTypedData: vi.fn(async ({ message }) => '0x' + 'ab'.repeat(65)),
+  };
+}
+
+function jsonResponse(status, payload, ok = status < 400) {
+  return {
+    ok,
+    status,
+    json: vi.fn(async () => payload),
+  };
+}
+
+describe('taskmarket module', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes the TaskMarket API base URL', () => {
+    expect(TASKMARKET_API_URL).toMatch(/^https?:\/\//);
+  });
+
+  it('discoverTasks parses the {data:{tasks}} envelope and query params', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, { data: { tasks: [{ id: '0xabc', status: 'open' }] } })
+    );
+    const tasks = await discoverTasks({ status: 'open', limit: 25, mode: 'bounty' });
+    expect(tasks).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/tasks?');
+    expect(url).toContain('status=open');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('mode=bounty');
+  });
+
+  it('discoverTasks surfaces HTTP errors as TaskMarketError', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(500, { error: 'boom' }));
+    await expect(discoverTasks()).rejects.toMatchObject({ name: 'TaskMarketError', status: 500 });
+  });
+
+  it('getTask unwraps a bare task payload', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { id: '0xabc', phase: 'active' }));
+    const task = await getTask('0xabc');
+    expect(task.phase).toBe('active');
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/tasks/0xabc');
+  });
+
+  it('listSubmissions returns the raw array', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, [{ id: 's1', workerAddress: '0x1' }]));
+    const subs = await listSubmissions('0xabc');
+    expect(subs).toHaveLength(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('/submissions');
+  });
+
+  it('createTask posts with an idempotency key and returns taskId on direct 2xx', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { taskId: '0xcreated' }));
+    const out = await createTask(
+      { title: 'T', description: 'D', reward: 1000000 },
+      { signer: signerStub() }
+    );
+    expect(out.taskId).toBe('0xcreated');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${TASKMARKET_API_URL}/api/tasks`);
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Taskmarket-Idempotency-Key']).toBeTruthy();
+    expect(init.body).toContain('"reward":1000000');
+  });
+
+  it('createTask follows the 402 flow with spending limit and explicit authorize', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(402, REQUIREMENTS))
+      .mockResolvedValueOnce(jsonResponse(200, { taskId: '0xpaid' }));
+    const authorize = vi.fn(async () => true);
+    const signer = signerStub();
+
+    const out = await createTask(
+      { title: 'T', description: 'D', reward: 4500000 },
+      { signer, spendingLimitUsd: 10, authorize, idempotencyKey: 'k-1' }
+    );
+
+    expect(out.taskId).toBe('0xpaid');
+    expect(authorize).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: 'USDC', amount: '4500000', payTo: PAY_TO })
+    );
+    expect(signer.signTypedData).toHaveBeenCalledTimes(1);
+    const signed = signer.signTypedData.mock.calls[0][0];
+    expect(signed.message).toMatchObject({ from: PAY_TO, to: PAY_TO, value: '4500000' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, init2] = fetchMock.mock.calls[1];
+    expect(init2.headers['X-Taskmarket-Idempotency-Key']).toBe('k-1');
+    const header = init2.headers['PAYMENT-SIGNATURE'];
+    expect(header).toBeTruthy();
+    const decoded = JSON.parse(Buffer.from(header, 'base64').toString('utf-8'));
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.resource).toBe(REQUIREMENTS.resource);
+    expect(decoded.accepted).toMatchObject({ network: 'eip155:8453', asset: 'USDC' });
+    expect(decoded.payload.signature).toBe('0x' + 'ab'.repeat(65));
+    expect(decoded.payload.authorization.value).toBe('4500000');
+  });
+
+  it('createTask refuses when the quoted amount exceeds spendingLimitUsd', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(402, REQUIREMENTS));
+    await expect(
+      createTask({ title: 'T', description: 'D', reward: 4500000 }, { signer: signerStub(), spendingLimitUsd: 1 })
+    ).rejects.toMatchObject({ name: 'TaskMarketError', status: 402 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('createTask refuses when authorize() declines', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(402, REQUIREMENTS));
+    await expect(
+      createTask(
+        { title: 'T', description: 'D', reward: 4500000 },
+        { signer: signerStub(), authorize: async () => false }
+      )
+    ).rejects.toBeInstanceOf(PaymentNotAuthorizedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(signerStub().signTypedData).not.toHaveBeenCalled();
+  });
+
+  it('createTask refuses to pay blind when the asset decimals are unknown', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(402, { resource: 'r', accepts: [{ ...ACCEPT, asset: 'MATICX' }] })
+    );
+    await expect(
+      createTask({ title: 'T', description: 'D', reward: 4500000 }, { signer: signerStub(), spendingLimitUsd: 10 })
+    ).rejects.toMatchObject({ name: 'TaskMarketError' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('withinSpendingLimit compares in base units', () => {
+    expect(withinSpendingLimit({ amount: '5000000', asset: 'USDC' }, 5)).toBe(true);
+    expect(withinSpendingLimit({ amount: '5000001', asset: 'USDC' }, 5)).toBe(false);
+    expect(withinSpendingLimit({ amount: '1000000000000000000', asset: 'ETH' }, 1)).toBe(true);
+    expect(withinSpendingLimit(undefined, undefined)).toBe(true);
+  });
+
+  it('createTask errors clearly when the 402 carries no payment methods', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(402, { resource: 'r', accepts: [] }));
+    await expect(
+      createTask({ title: 'T', description: 'D', reward: 4500000 }, { signer: signerStub() })
+    ).rejects.toMatchObject({ name: 'TaskMarketError', status: 402 });
+  });
+
+  it('createTask never auto-retries after an unknown payment settlement', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(402, REQUIREMENTS))
+      .mockResolvedValueOnce(jsonResponse(500, { error: 'timeout' }));
+    await expect(
+      createTask({ title: 'T', description: 'D', reward: 4500000 }, { signer: signerStub(), authorize: async () => true })
+    ).rejects.toMatchObject({ name: 'TaskMarketError', status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // exactly one payment attempt
+  });
+});


### PR DESCRIPTION
## What

New `@profullstack/coinpay/taskmarket` SDK module: **create and fund a TaskMarket task from inside a CoinPay-powered app**, bridging CoinPayPortal's x402 v2 rails to TaskMarket's HTTP API — plus read-side helpers to browse open work, fetch live task status, and list submissions for human review.

Addresses the TaskMarket integration bounty (task `0x8e416ba0`): discovers/creates TaskMarket work with explicit authorization, connects the wallet/payment flow with spending limits and user control.

## Why this project

CoinPayPortal is a non-custodial payment platform for AI agents (x402, web wallets); TaskMarket is a Base-native task market. They are natural counterparts: an agent that can take payments should also be able to *delegate* work and fund it, staying inside one signing environment. TaskMarket is **not** integrated anywhere in this SDK today (verified: no `taskmarket` references in the repo), and no other submission to the task above targets coinpayportal.

## Safety (mirrors the bounty rules)

- **No secrets**: the module never sees a private key/seed/token — a caller-supplied `signer` (`{address, signTypedData}`) signs the EIP-712 transfer authorization.
- **Fresh explicit authorization**: `authorize({resource, amount, asset, payTo, maxTimeoutSeconds})` must return `true` per payment.
- **Spending limit**: `spendingLimitUsd` is enforced against the quoted 402 amount in base units (USDC/USDT 1e6, ETH/POL 1e18, SOL 1e9); unknown-decimal assets **refuse** to proceed rather than pay blind.
- **No blind retries**: payment POST happens exactly once; a failed/unsettled payment raises an error that tells the caller to verify with `getTask` before retrying.
- **Human review loop**: `getTask`/`listSubmissions` exist; the module never auto-accepts/rejects work.

## Flow implemented (matches TaskMarket CLI's x402 v2 handshake)

1. `POST /api/tasks` with `X-Taskmarket-Idempotency-Key` → server answers `402 Payment Required` with `accepts[]` + `resource`.
2. `selectAcceptEntry` picks a rail the caller's wallet can sign; `withinSpendingLimit` gates the amount; `authorize()` gates the spend.
3. EIP-712 `TransferWithAuthorization` is built (`buildAuthorization` + `signTypedData`) and posted once as the base64 `PAYMENT-SIGNATURE` header with `x402Version: 2`.

## Tests / CI

- `packages/sdk/test/taskmarket.test.js` — **13 tests, all passing** (discover/envelope parsing, 402 handshake, spending-limit refusal, authorize-decline, unknown-asset refusal, no-retry-on-unknown-settlement, idempotency header, base64 payload shape).
- Full SDK suite on this branch: 642 passed / 6 failed — all 6 failures reproduce on `master` untouched (5 in `cli-invoice.test.js`, 1 timing-sensitive in `cli-swap.test.js`); this change touches none of those files.
- No secrets, no network calls in tests (fetch is mocked).

## Demo

```js
import { createTask, discoverTasks, getTask, listSubmissions } from '@profullstack/coinpay/taskmarket';

const open = await discoverTasks({ status: 'open', limit: 25, mode: 'bounty' });

const { taskId } = await createTask(
  { title: 'Fix my parser bug', description: 'Repro in linked issue.', reward: 2500000 },
  {
    signer: wallet,                       // { address, signTypedData(...) }
    capabilities: ['eip155:8453'],
    spendingLimitUsd: 10,                 // hard cap
    authorize: async (d) => confirm(`Send ${d.amount} ${d.asset} to ${d.payTo}?`),
  }
);

const live = await getTask(taskId);      // poll status
const subs = await listSubmissions(taskId); // present for human review
```

Reproduction: `cd packages/sdk && npm install && npx vitest run test/taskmarket.test.js`