### PR TITLE
security: audit rounds 2-3 — 55 findings across money safety, identity, and silent failure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,14 @@ npm-debug.log
 README.md
 .next
 .git
+
+# F5-L2-03: keep secrets out of the image.
+#
+# The root Dockerfile does `COPY . .`, so any .env present in the working tree
+# is baked into a layer and travels with the image — .env.prod in particular
+# holds live credentials. Railway builds from git, where these are gitignored,
+# so the documented deployment path was never affected; a local or CI build from
+# a developer's tree was.
+.env
+.env.*
+!.env.example

--- a/.github/workflows/deploy-lnbits-droplet.yml
+++ b/.github/workflows/deploy-lnbits-droplet.yml
@@ -46,6 +46,22 @@ jobs:
           fi
 
           # Export KEY=VALUE lines into job env (ignore comments/blank lines)
+          #
+          # F5-L2-01: every value extracted here is registered with the runner's
+          # log masker as it is parsed.
+          #
+          # GitHub masks the `ENV_FILE` secret as a single blob. It does NOT know
+          # that the LNbits admin key, the droplet SSH key and everything else
+          # inside it are secrets in their own right, so any later step that
+          # echoed one — a `set -x`, a curl trace, a failing command printing its
+          # arguments — wrote it to the job log in the clear. Job logs outlive
+          # the credentials in them.
+          #
+          # `::add-mask::` matches literal strings only, so a multi-line value
+          # (an SSH private key) has to be masked line by line. Values shorter
+          # than 8 characters are skipped: masking something like `true` or a
+          # port number would replace every incidental occurrence of it and make
+          # the log unreadable without protecting anything.
           while IFS= read -r line; do
             [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
             key="${line%%=*}"
@@ -53,6 +69,18 @@ jobs:
             key="${key#"${key%%[![:space:]]*}"}"
             key="${key%"${key##*[![:space:]]}"}"
             [[ -z "$key" ]] && continue
+
+            # Strip one layer of surrounding quotes so the masked string is what
+            # a consumer actually sees, not the quoted form.
+            unquoted="$value"
+            if [[ "$unquoted" == \"*\" || "$unquoted" == \'*\' ]]; then
+              unquoted="${unquoted:1:${#unquoted}-2}"
+            fi
+
+            while IFS= read -r masked_line; do
+              [[ ${#masked_line} -ge 8 ]] && echo "::add-mask::$masked_line"
+            done <<< "$unquoted"
+
             {
               echo "$key<<__EOF__"
               echo "$value"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,23 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
 # Copy the whole repo before install: the root package.json depends on the
 # workspace package @profullstack/coinpay (packages/*), so pnpm needs those
-# manifests present at install time. Coinpay's Railway build uses
-# --no-frozen-lockfile (the lockfile drifts); match it.
+# manifests present at install time.
 COPY . .
-RUN pnpm install --no-frozen-lockfile
+
+# L-03: installs from the lockfile, not around it.
+#
+# This was `--no-frozen-lockfile`, justified by a comment saying the lockfile
+# drifts. That flag lets pnpm resolve versions the lockfile does not record, so
+# two builds of the same commit can ship different dependency trees and a
+# changed — or compromised — transitive dependency reaches production without
+# appearing in any diff. For a payments platform that is the whole supply-chain
+# argument for having a lockfile at all.
+#
+# The premise was also out of date: `pnpm install --frozen-lockfile` passes
+# against the current tree, checked before making this change. If it drifts
+# again the build now fails loudly, which is the point — a drifted lockfile is
+# something to fix in a commit, not to route around on every deploy.
+RUN pnpm install --frozen-lockfile
 RUN pnpm build
 
 # Runtime env

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -200,6 +200,12 @@ rather than four copies. `F-1.3-12` still to convert.
 Batch eleven: `F-1.3-04`, `INV-01`, `H-R-04` `FIXED`. Migration
 `20260819180000_stripe_webhook_idempotency` applied to production and verified.
 
+Batch twelve: `NEW-L5-1`, `G-1.2-04`, `H-R-09` `FIXED`. `R3-DIN-03`
+`ALREADY-FIXED` — confirmed live: `settle_failed` is now in
+`escrows_status_check`. Migration
+`20260819190000_collection_blockchain_check_token_variants` applied and
+validated (18 chains, matching `SUPPORTED_BLOCKCHAINS`).
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -288,6 +288,67 @@ fired. All 6 wallets holding an LNbits admin key hold their own — they have bo
 `ln_wallet_adminkey` and `ln_wallet_inkey`, and the fallback path writes only
 the former (`adminkey_only = 0`). The fix is preventive, not remedial.
 
+## Priority 5 verification sweep (2026-08-19)
+
+142 findings across `5a` (35), `5b` (25) and `5c` (82). The audit's own framing
+is that these produce no business impact **only because of a stated condition**.
+The agreed treatment was verification with evidence rather than pretending a
+code change happened, so this records what was actually checked.
+
+### Checked, and the gate holds
+
+- **Dead-code claims** (`F1.4-L1-NEW-02`, `IA-004`). Tested by reference search
+  rather than trusted. `clearSensitiveString`: one definition, zero callers —
+  confirmed. `initSecrets`: the two apparent callers are both inside the
+  module's own doc comment, so zero real call sites — confirmed, though it is
+  worth noting the module documents a usage pattern nothing follows.
+- **`V-05` / `CP-P4`** — `monthly_transaction_limit` is NULL on both plans.
+- **`NUEVO-F2-01` / `L4-NEW-01`** — no `FOR ALL USING(true)` reachable by
+  `anon` on `ln_nodes`/`ln_offers`/`ln_payments`/`swaps`.
+- **`IA-002`** — the RLS gap is **not a live data exposure**, and the scary
+  reading of it is wrong. Every table in `public` has RLS enabled. Every
+  `{public}` INSERT policy carries a real `with_check` predicate — none is
+  unconditional, so there is no anonymous-write hole. `qual` reads as null on
+  those rows because INSERT policies keep their predicate in `with_check`;
+  reading the wrong column is what makes this look alarming.
+
+### Found while sweeping, and fixed
+
+**`reputation_receipts` was one `GRANT` away from publishing everything.** It
+carries `SELECT ... USING (true)` for `anon, authenticated` — which reads as
+world-readable — and is unreadable today *only* because neither role holds a
+SELECT grant. RLS is evaluated after the grant check, so a permissive policy on
+an ungranted table is inert.
+
+That is a trap, not a control. `GRANT SELECT ON ALL TABLES IN SCHEMA public TO
+anon` is a routine Supabase incantation, and running it once would have
+published **14,346 receipts carrying `agent_did`, `buyer_did`, `escrow_tx` and
+amounts totalling $1,050,924** — the platform's entire transaction history by
+counterparty and value — with no other change and no warning.
+
+Migration `20260819200000` scopes the policy to `service_role`, matching what
+the grants already enforce. Nothing reads the table through PostgREST (the
+application uses the service role, which bypasses RLS), so this cannot break a
+working path. Applied to production and verified.
+
+The sibling tables are deliberately untouched: `mutual_attestations`,
+`reputation_credentials` and `reputation_revocations` *are* granted to `anon`
+and are the public, verifiable trust graph — that is the product working as
+designed, and they hold 1, 1 and 0 rows respectively. `blog_posts` and
+`referral_codes` are likewise intended public reads.
+
+### Not verifiable from here
+
+The remainder of `5a` is gated on prior compromise (`IA-015`, `NEW-03`,
+`W-02`, `REC-03`, …) or on environment variables not observable from the
+repository. Those gates are structural: "requires an already-stolen session" is
+not something a code change closes, and the audit rates them accordingly. The
+bulk of `5b` is root causes of findings already fixed individually
+(`IA-005` → `CP-024`/`L-04`, `F-1.1-10` → `F-1.1-07`, `CP-013` → `NEW-01`), and
+races the audit itself confirms are compensated by a downstream CAS
+(`F-1.1-09`, `IA-001`, `WW-06`) — those CAS guards are the ones added in this
+work.
+
 ## Priority 5 — Technical debt (60)
 
 Detail in `docs/findings/05_TECHNICAL_DEBT/`. Not urgent. Note that 5a reverts to

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -218,6 +218,8 @@ Batch fifteen: `IA-010`, `L-03`, `F4-03` `FIXED`.
 
 Batch sixteen: `IA-008`, `N-03` `FIXED`.
 
+Batch seventeen: `NEW-F1A-P-02` `FIXED`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -222,6 +222,8 @@ Batch seventeen: `NEW-F1A-P-02` `FIXED`.
 
 Batch eighteen: `ESC-NEW-14` `FIXED`.
 
+Batch nineteen: `SUB-02` `FIXED`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -169,8 +169,9 @@ audit than whether its bespoke ownership query is correct.
 
 All `UNVERIFIED`. Detail in `docs/findings/03_SILENT_OPERATIONAL/`. Standouts:
 
-- `BL-02`, `CP-025`, `F-1.1-01` — escrow stuck at expiry, unilateral depositor
-  refund, and the monitor marking funded multisig escrows `refunded`.
+- `BL-02`, `CP-025`, `F-1.1-01` — **all three `FIXED`.** Escrow stuck at
+  expiry, unilateral depositor refund, and the monitor marking funded multisig
+  escrows `refunded`. See the batch-eight note below.
 - `V-01` + `L8-01` + `REC-D-02` — **`FIXED`.** Three independent reasons
   `webhook_logs` inserts fail. Confirmed against production: the table held
   **zero rows** — the delivery audit trail had never recorded a single attempt,
@@ -179,9 +180,11 @@ All `UNVERIFIED`. Detail in `docs/findings/03_SILENT_OPERATIONAL/`. Standouts:
 - `R3-DIN-03` — `settle_failed` written to `escrows.status` is rejected by the
   production CHECK constraint. This matches known prod drift: `escrows_status_check`
   is `NOT VALID`, so read escrow statuses from the data, not the constraint.
-- `F5-L1-06` — `scripts/sweep-balances.mjs` is truncated and fails `node --check`,
-  and has been since December 2025. The documented emergency fund-recovery
-  procedure has never worked.
+- `F5-L1-06` — **`PARTIAL`.** `scripts/sweep-balances.mjs` was truncated and
+  failed `node --check`, and had been since December 2025. It now parses, and
+  the discovery half (find stranded balances) works and is wired to
+  `pnpm sweep-balances`. `--execute` deliberately refuses: broadcasting sweeps
+  would be new untested multi-chain fund-moving code.
 
 ## Priority 4 — Conditional (26)
 

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -270,7 +270,7 @@ from Stripe's own record rather than the self-declared payload amount (round 1).
 The `SIGNATURE_BOUND_NETWORKS` constant the finding cites no longer exists;
 dispatch is by `network` via `SCHEMES_BY_NETWORK`.
 
-Also `FIXED`: `E-04`, `F-1.3-06`.
+Also `FIXED`: `E-04`, `F-1.3-06`, `F4-02`, `ESC-NEW-06`.
 
 `IA-006` `ALREADY-FIXED` — the "sequential settlement commission leak" is the
 split-ordering bug in `secure-forwarding`: the merchant leg (99%+) went out

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -214,6 +214,8 @@ Batch fourteen: `F-1.3-10`, `NEW-F1A-P-01`, `R4-DIN-07` `FIXED`. Invoice
 numbering now has one implementation, `lib/invoices/numbering.ts`, used by all
 four call sites — three of which were wrong while the fourth was right.
 
+Batch fifteen: `IA-010`, `L-03`, `F4-03` `FIXED`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -155,8 +155,11 @@ audit than whether its bespoke ownership query is correct.
   `NEW-07` `FIXED`, `NEW-09` `FIXED`, `NEW-20` `FIXED`, `NEW-23` `FIXED`,
   `NEW-WW34-01` `FIXED`. Still open: `NEW-11`.
 - **Payment and settlement integrity** — `B-03` `FIXED`, `F-1.1-07` `FIXED`,
-  `F-1.1-16` `FIXED`, `F-1.3-02` `FIXED`, `V-04` `FIXED`. Still open:
-  `IA-016`, `WW-01`, `WW-03`, `NEW-14`, `F5-L2-01`, `F5-L4-02`.
+  `F-1.1-16` `FIXED`, `F-1.3-02` `FIXED`, `V-04` `FIXED`, `IA-016` `FIXED`,
+  `WW-01` `FIXED`, `WW-03` `PARTIAL` (recipient bound on every chain; amount
+  still unbound on BCH and Solana — see the batch-5 log), `NEW-14`
+  `ALREADY-FIXED` (`resolveBusinessScope`). Still open: `F5-L2-01`,
+  `F5-L4-02`.
 
 ## Priority 3 — Silent operational loss (39)
 

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -152,9 +152,11 @@ audit than whether its bespoke ownership query is correct.
   `F5-L1-07`, `L6B-05`, `REC-04`, `REC-01`.
 - **Rate limit / enumeration (§2.6)** — `NEW-06` `FIXED`, `WW-02` `FIXED`,
   `REC-C-04` `FIXED`, `REC-C-05` `FIXED`, `L7A-03` `FIXED`. Still open:
-  `NEW-07`, `NEW-09`, `NEW-11`, `NEW-20`, `NEW-23`. `NEW-WW34-01` `FIXED`.
-- **Payment and settlement integrity** — `B-03`, `F-1.1-07`, `F-1.1-16`,
-  `F-1.3-02`, `IA-016`, `WW-01`, `WW-03`, `NEW-14`, `F5-L2-01`, `F5-L4-02`, `V-04`.
+  `NEW-07` `FIXED`, `NEW-09` `FIXED`, `NEW-20` `FIXED`, `NEW-23` `FIXED`,
+  `NEW-WW34-01` `FIXED`. Still open: `NEW-11`.
+- **Payment and settlement integrity** — `B-03` `FIXED`, `F-1.1-07` `FIXED`,
+  `F-1.1-16` `FIXED`, `F-1.3-02` `FIXED`, `V-04` `FIXED`. Still open:
+  `IA-016`, `WW-01`, `WW-03`, `NEW-14`, `F5-L2-01`, `F5-L4-02`.
 
 ## Priority 3 — Silent operational loss (39)
 
@@ -341,3 +343,122 @@ amount, because the charge recurs and its amount can change. Also hardens
 the shared `isSufficientPayment`. Both now use the helper. A test named "marks
 invoice as paid with 1% tolerance" encoded the leak as intended behaviour and is
 now inverted, with a companion test proving the 1e-9 float epsilon still works.
+
+### 2026-08-19 — fourth batch: seed transmission, sibling gaps, unproved claims
+
+**`NEW-20` — the seed on the wire**. `POST /api/lightning/nodes` required a
+valid BIP-39 mnemonic, validated it, and never used it. The wallet being
+provisioned is a **custodial LNbits wallet** — no signer, nothing to derive — so
+the field bought nothing at all, while making every client transmit the master
+seed for the entire wallet into request logs. The seed reconstructs every key on
+every chain; it is the one secret that must never leave the device. Callers were
+already proving possession properly, via `authorizeWalletRequest`'s signature
+over the request body.
+
+Removed from the route, the two SDKs, the React component and the CLI. The web
+call site was the worst of them: `asset/[chain]/page.tsx` called
+`wallet.getMnemonic()` and handed the live seed to `LightningSetup` as a prop.
+The CLI was second: `coinpay lightning enable` **prompted for the passphrase and
+decrypted the stored seed** purely so it could post it. Older clients that still
+send the field are accepted and the value discarded, with a warning naming the
+wallet — rejecting them would break provisioning for anyone who has not
+upgraded.
+
+**`F-1.1-07` — a scope enforced nowhere**. `payouts:create` is offered to
+merchants when they mint a scoped key, so a merchant can deliberately create a
+key *without* it. `POST /api/payouts/create` is the only route the scope
+governs, and it never looked: a key restricted to reading could still send money
+out of the business's wallet. Its sibling `/api/payments/create` has checked its
+own scope all along — §2.3 exactly.
+
+**`NEW-07` — WebAuthn challenges keyed on the victim**. `login-options` stored
+the challenge under the merchant's own id whenever the supplied email resolved.
+The store holds one challenge per key and the route is public, so anyone who
+knew a merchant's email could overwrite that merchant's pending challenge at
+will: the victim's authenticator signs the challenge it was handed, verify
+consumes whatever the attacker wrote last, they never match, and the account
+cannot be logged into for as long as the attacker keeps posting. It also broke
+two honest logins from two devices.
+
+The key is only a lookup handle — the client echoes it back and `login-verify`
+derives the user from the stored credential, never from this value — so it does
+not need to identify anyone. It is now 32 random bytes per request.
+`register-options` uses the same store keyed by user id, but it is authenticated
+and self-keyed, so there is no cross-user reach; left as is.
+
+**`NEW-09` and `V-04` — claims nobody checked**. Two halves of the same shape.
+
+`importWallet` verified proof of ownership inside `if (public_key_secp256k1)`,
+and the schema requires only **one** of the two keys. Submitting just
+`public_key_ed25519` skipped verification entirely: `proof_of_ownership` was
+still mandatory, but no part of it was ever read and any string passed.
+
+`createWallet` asked for no proof of anything — an unauthenticated caller could
+declare a public key that was not theirs and, more damagingly, a list of
+on-chain addresses that were not theirs. `wallet_addresses` is **globally unique
+on `(address, chain)`**, so whoever registers an address first holds it and the
+rightful owner can never register it at all.
+
+Both now go through one `verifyKeyOwnership` helper, deliberately shared so the
+two cannot drift apart again — the whole class of bug here is one sibling
+checking what the other does not. Every key presented must be proved: with a
+secp256k1 key, `signature` must verify against it; without one, the ed25519 key
+is the only identity claimed and `signature_ed25519` must verify against it.
+Demanding *both* signatures would break every client in the field to close a gap
+that only exists when secp256k1 is absent. `initial_addresses` is also capped —
+it was unbounded, so one request could claim thousands of addresses permanently.
+
+Proof is checked after the format validation (so a malformed key still gets a
+useful error) and before the first write (so nothing is persisted on an unproved
+claim).
+
+> **Breaking for old npm SDK builds.** `/api/web-wallet/create` now requires a
+> signature. `packages/sdk` and the in-repo SDK both send one as of this commit;
+> a published SDK older than this will fail to create wallets. The browser
+> extension is unaffected — it registers via `/import`, which has always
+> required proof.
+
+**An unlisted bug found while wiring that.** `packages/sdk`'s `signMessage`
+signed `sha256(message)`, but the server verifies by passing the **raw** encoded
+message to `secp256k1.verify`. Confirmed against the repo's own noble build:
+sign-hash/verify-raw returns `false`. So every proof of ownership the published
+SDK produced was rejected, meaning `WalletClient.fromSeed()` **could not import
+a wallet at all**. Now signs raw bytes, matching the server and the in-repo SDK.
+
+**`F-1.1-16` — overwriting the pending PayPal order**. `create-order` is public
+and wrote `invoices.paypal_order_id` unconditionally; that single column was the
+only thing `capture` checked. Anyone who knew an invoice id could overwrite it
+after the real payer had been handed their order — the payer approves order A,
+capture sees B, rejects it as "Order does not match this invoice", and the
+invoice can never be paid while the attacker keeps posting. Across open invoices
+that is a denial of payment for the platform.
+
+"First write wins" would be no better; it just lets the attacker lock the slot
+earlier. And an invoice legitimately has several orders over its life — an
+abandoned attempt, a retry, two people on one pay link. Each issued order is now
+its own row in `paypal_transactions` bound to the invoice, and capture accepts
+any order bound to the invoice it is settling. `paypal_order_id` is unique on
+that table, so rows cannot collide or be repointed. Orders already in flight at
+deploy time fall back to the legacy column. No migration needed — the table and
+its unique constraint already existed.
+
+**`B-03` — a sync that never rotated**. `syncLnbitsPayments` selected wallets
+with `.limit(100)` and **no `.order()`**. Postgres may return rows in any order
+and in practice returns a stable physical one, so past 100 Lightning wallets the
+same hundred were synced every run and the rest never at all. Their incoming
+payments never reached `ln_payments` — which is what the dashboard reads, and
+what x402 Lightning settlement now *requires* as proof after the round-1 fix, so
+those wallets would silently lose the ability to prove they had been paid. Now
+ordered by id and walked by keyset through the whole table, with the cap as a
+runaway guard rather than a working set, and a warning if it is ever hit.
+
+**`NEW-23` — SSRF by hostname**. The `Signature-Agent` key-directory fetch was
+guarded by literal matching — `127.x`, `10.x`, `fc00::/7` — which does nothing
+about a hostname whose A record points at `169.254.169.254`. The function's own
+comment admitted it. Now goes through `safeFetch`, which resolves the host,
+rejects on the resolved address, and re-validates every redirect hop. The
+literal checks stay: they reject the obvious cases before any DNS lookup and
+enforce the https-only rule the spec requires.
+
+Suite green at 317 files / 4455 tests, `tsc --noEmit` clean. 14 findings; 129 of
+338 fixed.

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -263,7 +263,7 @@ Verified against live production, no code change needed:
   (`cryptocurrency`, `is_active`) were a chained `merchant_wallets` query inside
   the same `Promise.all`, not `stripe_accounts` references.
 
-`FIXED`: `ESC-NEW-05`, `H-R-03`, `F5-L2-03`.
+`FIXED`: `ESC-NEW-05`, `H-R-03`, `F5-L2-03`, `F-1.3-14`.
 
 ## Priority 5 — Technical debt (60)
 

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -270,6 +270,24 @@ from Stripe's own record rather than the self-declared payload amount (round 1).
 The `SIGNATURE_BOUND_NETWORKS` constant the finding cites no longer exists;
 dispatch is by `network` via `SCHEMES_BY_NETWORK`.
 
+Also `FIXED`: `E-04`, `F-1.3-06`.
+
+`IA-006` `ALREADY-FIXED` — the "sequential settlement commission leak" is the
+split-ordering bug in `secure-forwarding`: the merchant leg (99%+) went out
+first, drained the address, and the platform-fee leg then failed for
+insufficient funds. The split is now computed from the actual balance and both
+legs are submitted as a single split transaction, so one cannot starve the
+other.
+
+`REC-D-07` `DECISION` — webhook delivery retries three times in-process but has
+no durable queue or dead-letter. That is a feature to build, not a defect to
+patch, and it is Anthony's call whether it is worth it.
+
+`F-1.3-06` verified against production before and after: the fallback has never
+fired. All 6 wallets holding an LNbits admin key hold their own — they have both
+`ln_wallet_adminkey` and `ln_wallet_inkey`, and the fallback path writes only
+the former (`adminkey_only = 0`). The fix is preventive, not remedial.
+
 ## Priority 5 — Technical debt (60)
 
 Detail in `docs/findings/05_TECHNICAL_DEBT/`. Not urgent. Note that 5a reverts to

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -144,8 +144,9 @@ audit than whether its bespoke ownership query is correct.
 | `SUB-01` | `FIXED` | `subscriptions/status` DELETE has no `hasScope`. |
 | `REC-D-01` | `FIXED` by `NEW-04` + `platformMayManageMerchant` | Extends `NEW-04`; likely closed by that fix — re-verify. |
 | `REC-C-03` | `FIXED` | x402 ignores API key scopes. |
-- **Identity / DID abuse** — `L7A-02`, `V-02`, `REP-F1A-02`, `G-1.2-10`,
-  `R4-ID-OAUTH`, `R3-ID-02`, `R4-ID-RESET`.
+- **Identity / DID abuse** — `L7A-02` `FIXED`, `V-02` `FIXED`,
+  `REP-F1A-02` `FIXED`, `G-1.2-10` `FIXED`, `R4-ID-OAUTH` `FIXED`,
+  `R3-ID-02` `FIXED`, `R4-ID-RESET` `FIXED`.
 - **Multisig escrow** — `F-1.1-02`, `F-1.1-03`, `F-1.1-04`. Latent while
   `MULTISIG_ESCROW_ENABLED` is off. Fix before that flag is ever turned on.
 - **Wallet and key handling** — `F-L7-01`, `F-L7-02`, `F5-L1-02`, `F5-L1-05`,
@@ -153,7 +154,7 @@ audit than whether its bespoke ownership query is correct.
 - **Rate limit / enumeration (§2.6)** — `NEW-06` `FIXED`, `WW-02` `FIXED`,
   `REC-C-04` `FIXED`, `REC-C-05` `FIXED`, `L7A-03` `FIXED`. Still open:
   `NEW-07` `FIXED`, `NEW-09` `FIXED`, `NEW-20` `FIXED`, `NEW-23` `FIXED`,
-  `NEW-WW34-01` `FIXED`. Still open: `NEW-11`.
+  `NEW-WW34-01` `FIXED`, `NEW-11` `FIXED`.
 - **Payment and settlement integrity** — `B-03` `FIXED`, `F-1.1-07` `FIXED`,
   `F-1.1-16` `FIXED`, `F-1.3-02` `FIXED`, `V-04` `FIXED`, `IA-016` `FIXED`,
   `WW-01` `FIXED`, `WW-03` `PARTIAL` (recipient bound on every chain; amount

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -220,6 +220,8 @@ Batch sixteen: `IA-008`, `N-03` `FIXED`.
 
 Batch seventeen: `NEW-F1A-P-02` `FIXED`.
 
+Batch eighteen: `ESC-NEW-14` `FIXED`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -206,6 +206,10 @@ Batch twelve: `NEW-L5-1`, `G-1.2-04`, `H-R-09` `FIXED`. `R3-DIN-03`
 `20260819190000_collection_blockchain_check_token_variants` applied and
 validated (18 chains, matching `SUPPORTED_BLOCKCHAINS`).
 
+Batch thirteen: `F-1.3-12`, `F3-L5-02` `FIXED`. `F-1.1-06` `ALREADY-FIXED` —
+both settle paths now share `processEscrowSettlement`, so they share its retry
+cap. The unordered-sweep family is now fully converted to `lib/db/keyset.ts`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -197,6 +197,9 @@ Batch ten: `A-05`, `F-1.3-08`, `W-08`, `F-1.3-09`, `H-R-05` `FIXED`, plus
 (`B-03`/`F-1.3-09`/`F-1.3-12`/`H-R-05`) now has one helper, `lib/db/keyset.ts`,
 rather than four copies. `F-1.3-12` still to convert.
 
+Batch eleven: `F-1.3-04`, `INV-01`, `H-R-04` `FIXED`. Migration
+`20260819180000_stripe_webhook_idempotency` applied to production and verified.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -263,7 +263,12 @@ Verified against live production, no code change needed:
   (`cryptocurrency`, `is_active`) were a chained `merchant_wallets` query inside
   the same `Promise.all`, not `stripe_accounts` references.
 
-`FIXED`: `ESC-NEW-05`, `H-R-03`, `F5-L2-03`, `F-1.3-14`.
+`FIXED`: `ESC-NEW-05`, `H-R-03`, `F5-L2-03`, `F-1.3-14`, `F-1.3-03`.
+
+`R3-X1` `ALREADY-FIXED` — the Stripe x402 branch compares `pi.amount_received`
+from Stripe's own record rather than the self-declared payload amount (round 1).
+The `SIGNATURE_BOUND_NETWORKS` constant the finding cites no longer exists;
+dispatch is by `network` via `SCHEMES_BY_NETWORK`.
 
 ## Priority 5 — Technical debt (60)
 

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -159,8 +159,11 @@ audit than whether its bespoke ownership query is correct.
   `F-1.1-16` `FIXED`, `F-1.3-02` `FIXED`, `V-04` `FIXED`, `IA-016` `FIXED`,
   `WW-01` `FIXED`, `WW-03` `PARTIAL` (recipient bound on every chain; amount
   still unbound on BCH and Solana — see the batch-5 log), `NEW-14`
-  `ALREADY-FIXED` (`resolveBusinessScope`). Still open: `F5-L2-01`,
-  `F5-L4-02`.
+  `ALREADY-FIXED` (`resolveBusinessScope`), `F5-L2-01` `FIXED`,
+  `F5-L4-02` `ALREADY-FIXED` (both HTML paths escape; the raw interpolations
+  the finding cites are the plain-text body, where escaping would be wrong).
+
+**Priority 2 is complete.**
 
 ## Priority 3 — Silent operational loss (39)
 

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -224,6 +224,14 @@ Batch eighteen: `ESC-NEW-14` `FIXED`.
 
 Batch nineteen: `SUB-02` `FIXED`.
 
+Batch twenty: `F-1.3-15` `FIXED` (the BTC-throws half and the missing gas
+reserve; the quote still does not add a network fee on top, so the merchant
+receives amount-minus-fee — a pricing decision, not a bug fix, and left for
+Anthony). `IA-006` and `REC-D-07` remain: `IA-006` has no location in the
+findings beyond "sequential settlement — commission leak" and needs Eduardo to
+point at the code; `REC-D-07` is marked [Inferred] and asks for a durable
+retry queue, which is a design change rather than a patch.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -210,6 +210,10 @@ Batch thirteen: `F-1.3-12`, `F3-L5-02` `FIXED`. `F-1.1-06` `ALREADY-FIXED` —
 both settle paths now share `processEscrowSettlement`, so they share its retry
 cap. The unordered-sweep family is now fully converted to `lib/db/keyset.ts`.
 
+Batch fourteen: `F-1.3-10`, `NEW-F1A-P-01`, `R4-DIN-07` `FIXED`. Invoice
+numbering now has one implementation, `lib/invoices/numbering.ts`, used by all
+four call sites — three of which were wrong while the fourth was right.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -314,17 +314,24 @@ code change happened, so this records what was actually checked.
 
 ### Found while sweeping, and fixed
 
-**`reputation_receipts` was one `GRANT` away from publishing everything.** It
-carries `SELECT ... USING (true)` for `anon, authenticated` — which reads as
+**`reputation_receipts` was protected only by a missing grant.** It carries
+`SELECT ... USING (true)` for `anon, authenticated` — which reads as
 world-readable — and is unreadable today *only* because neither role holds a
 SELECT grant. RLS is evaluated after the grant check, so a permissive policy on
 an ungranted table is inert.
 
-That is a trap, not a control. `GRANT SELECT ON ALL TABLES IN SCHEMA public TO
-anon` is a routine Supabase incantation, and running it once would have
-published **14,346 receipts carrying `agent_did`, `buyer_did`, `escrow_tx` and
-amounts totalling $1,050,924** — the platform's entire transaction history by
-counterparty and value — with no other change and no warning.
+That is a trap rather than a control: `GRANT SELECT ON ALL TABLES IN SCHEMA
+public TO anon` is a routine Supabase incantation, and running it once would
+expose the table with no other change and no warning.
+
+**Scale, stated accurately.** The table holds 14,346 rows, of which 14,333 are
+`did:web:ugig.net` reputation receipts totalling **$921.03**. A first pass
+summed the `amount` column and reported $1,050,924; that figure is
+meaningless — $1,050,002 of it is six rows with round test values (1000001,
+50001) and no `platform_did`. These are also ugig.net *reputation receipts*, not
+CoinPay payment records; CoinPay's payments live in `payments` and were never
+part of this. The fix is worth keeping because the policy should say what the
+grants enforce, not because anything valuable was at risk.
 
 Migration `20260819200000` scopes the policy to `service_role`, matching what
 the grants already enforce. Nothing reads the table through PostgREST (the

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -245,6 +245,26 @@ spending effort on any of these.
 | `CP-019`, `NEW-16`, `G-1.2-08`, `G-R-09` | **`FIXED`** | Were conditional on a production env var. Rather than verify one value, the conditionality is removed in code — see the batch-twenty-two note. `NEW-05` closed alongside `G-1.2-08`. |
 | `NUEVO-F2-01` | `DECISION` | Historically closed, but `gl_creds`/`gl_rune` were readable by the anon key for five days in February. Rotate regardless of the code being fixed. |
 
+### Priority 4 progress (batch twenty-one)
+
+Verified against live production, no code change needed:
+
+- `V-05` / `CP-P4` — `NEUTRALIZED`, confirmed: `monthly_transaction_limit` is
+  NULL on both plans (Starter, Professional). Re-activates the moment any plan
+  gets a non-null limit.
+- `NUEVO-F2-01` / `L4-NEW-01` — `CONFIRMED REMEDIATED`: every policy on
+  `ln_nodes`/`ln_offers`/`ln_payments`/`swaps` is now scoped to `service_role`
+  or to `authenticated` with a merchant predicate. No `FOR ALL USING(true)`
+  reachable by `anon`. **Rotation of `gl_creds`/`gl_rune` is still warranted**
+  and remains Anthony's decision — the code is fixed, the exposure window
+  happened.
+- `V-06` — `RESOLVED`: cross-checked every column the code touches on
+  `stripe_accounts` against the live schema. All 11 exist. Two apparent misses
+  (`cryptocurrency`, `is_active`) were a chained `merchant_wallets` query inside
+  the same `Promise.all`, not `stripe_accounts` references.
+
+`FIXED`: `ESC-NEW-05`, `H-R-03`, `F5-L2-03`.
+
 ## Priority 5 — Technical debt (60)
 
 Detail in `docs/findings/05_TECHNICAL_DEBT/`. Not urgent. Note that 5a reverts to

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -186,6 +186,12 @@ All `UNVERIFIED`. Detail in `docs/findings/03_SILENT_OPERATIONAL/`. Standouts:
   `pnpm sweep-balances`. `--execute` deliberately refuses: broadcasting sweeps
   would be new untested multi-chain fund-moving code.
 
+### Priority 3 progress (batch nine)
+
+`BL-02`, `CP-025`, `F-1.1-01` `FIXED` (see batch eight). `B-04`, `L7A-04`,
+`L5-02` `FIXED`. `F5-L1-06` `PARTIAL`. `V-01`/`L8-01`/`REC-D-02` were already
+`FIXED`. All verified against the live production schema, not inferred.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -192,6 +192,11 @@ All `UNVERIFIED`. Detail in `docs/findings/03_SILENT_OPERATIONAL/`. Standouts:
 `L5-02` `FIXED`. `F5-L1-06` `PARTIAL`. `V-01`/`L8-01`/`REC-D-02` were already
 `FIXED`. All verified against the live production schema, not inferred.
 
+Batch ten: `A-05`, `F-1.3-08`, `W-08`, `F-1.3-09`, `H-R-05` `FIXED`, plus
+`B-03` refactored onto the shared pager. The unordered-sweep family
+(`B-03`/`F-1.3-09`/`F-1.3-12`/`H-R-05`) now has one helper, `lib/db/keyset.ts`,
+rather than four copies. `F-1.3-12` still to convert.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -216,6 +216,8 @@ four call sites — three of which were wrong while the fourth was right.
 
 Batch fifteen: `IA-010`, `L-03`, `F4-03` `FIXED`.
 
+Batch sixteen: `IA-008`, `N-03` `FIXED`.
+
 ## Priority 4 — Conditional (26)
 
 Detail in `docs/findings/04_CONDITIONAL_LOW/`. Verify the condition before

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -5,3 +5,14 @@ npm-debug.log
 README.md
 .next
 .git
+
+# F5-L2-03: keep secrets out of the image.
+#
+# The root Dockerfile does `COPY . .`, so any .env present in the working tree
+# is baked into a layer and travels with the image — .env.prod in particular
+# holds live credentials. Railway builds from git, where these are gitignored,
+# so the documented deployment path was never affected; a local or CI build from
+# a developer's tree was.
+.env
+.env.*
+!.env.example

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "type-check": "tsc --noEmit",
+    "sweep-balances": "node scripts/sweep-balances.mjs",
     "precommit": "pnpm pre-commit",
     "pre-commit": "vitest run",
     "generate-wallet": "node scripts/generate-hd-wallets.mjs",

--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -3736,10 +3736,12 @@ async function handleLightning(subcommand, args, flags) {
         console.error(colors.red + 'Error: --wallet-id required' + colors.reset);
         process.exit(1);
       }
-      const mnemonic = await getDecryptedMnemonic(flags);
+      // NEW-20: this used to decrypt the stored seed — prompting for the
+      // passphrase — purely to post it to the server, which validated it and
+      // threw it away. Provisioning is a custodial LNbits wallet, so nothing
+      // is derived or signed here. The seed never leaves the machine now.
       const result = await client.lightning.enableWallet({
         wallet_id: walletId,
-        mnemonic,
         business_id: flags['business-id'],
       });
       console.log(colors.green + '⚡ Lightning wallet enabled!' + colors.reset);

--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -24,7 +24,7 @@ import {
   updateInvoice,
   InvoiceStatus,
 } from '../src/invoices.js';
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, unlinkSync, chmodSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { homedir, hostname } from 'os';
@@ -679,7 +679,39 @@ function hasGpg() {
 /**
  * Encrypt mnemonic with GPG and save to file
  */
+
+/**
+ * Minimum strength for a passphrase that protects an exported wallet.
+ *
+ * F5-L1-07 / L6B-05: there was no minimum at all here, while the sibling
+ * `generate-hd-wallets` backup asks for eight characters and the web wallet's
+ * create/import flow requires length >= 8 AND a strength score. A one-character
+ * passphrase was accepted on the path that produces a file an attacker can walk
+ * away with — and GPG's default KDF is far cheaper to attack on a GPU than the
+ * scrypt used by the other backup, so the passphrase is doing most of the work.
+ */
+function assertStrongPassphrase(password) {
+  const problems = [];
+  if (!password || password.length < 12) {
+    problems.push('at least 12 characters');
+  }
+  if (!/[a-z]/.test(password ?? '') || !/[A-Z]/.test(password ?? '')) {
+    problems.push('both upper and lower case');
+  }
+  if (!/\d/.test(password ?? '') && !/[^A-Za-z0-9]/.test(password ?? '')) {
+    problems.push('a digit or a symbol');
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      'Passphrase too weak — this is the only thing protecting your wallet file. ' +
+      'It needs ' + problems.join(', ') + '.'
+    );
+  }
+}
+
 async function saveEncryptedWallet(mnemonic, walletId, password, walletFile) {
+  assertStrongPassphrase(password);
+
   if (!hasGpg()) {
     throw new Error('GPG is required for wallet encryption. Install: apt install gnupg');
   }
@@ -705,6 +737,22 @@ async function saveEncryptedWallet(mnemonic, walletId, password, walletFile) {
     ],
     { stdinData: content, passphrase: password }
   );
+
+  // Restrict the file gpg just created (F-L7-01 / F5-L1-02).
+  //
+  // `--output` means GPG creates the file itself, at the process umask — so it
+  // typically lands world-readable, and every other local user can copy an
+  // encrypted wallet at their leisure and attack the passphrase offline.
+  // Sibling writes in this same CLI pass `{ mode: 0o600 }`, but that option
+  // only applies when Node does the writing.
+  try {
+    chmodSync(walletFile, 0o600);
+  } catch (err) {
+    console.warn(
+      `Warning: could not restrict permissions on ${walletFile} — ` +
+      'other local users may be able to read it. ' + (err?.message ?? err)
+    );
+  }
 
   return true;
 }

--- a/packages/sdk/bin/coinpay.js
+++ b/packages/sdk/bin/coinpay.js
@@ -3619,13 +3619,19 @@ async function handleLogin() {
     process.exit(1);
   }
 
+  // G-1.2-10: there is no pre-filled approval link any more. A link that filled
+  // in the code turned a phishing message into one-click account takeover —
+  // anyone could start a device authorization and send the resulting link to a
+  // signed-in merchant. Entering the code by hand is what ties the approval to
+  // a terminal the person is actually sitting at.
   print.info('');
-  console.log('  To log in, open this URL on any device (e.g. your desktop) and approve:');
+  console.log('  To log in, open this URL on any device (e.g. your desktop):');
   console.log('');
-  console.log('    ' + colors.cyan + start.verification_uri_complete + colors.reset);
+  console.log('    ' + colors.cyan + start.verification_uri + colors.reset);
   console.log('');
-  console.log('  …or go to ' + colors.cyan + start.verification_uri + colors.reset +
-    ' and enter code ' + colors.bright + start.user_code + colors.reset);
+  console.log('  and enter this code: ' + colors.bright + start.user_code + colors.reset);
+  console.log('');
+  console.log(colors.yellow + '  Only enter a code your own terminal printed.' + colors.reset);
   console.log('');
   print.info('Waiting for approval… (Ctrl-C to cancel)');
 

--- a/packages/sdk/src/lightning.js
+++ b/packages/sdk/src/lightning.js
@@ -26,16 +26,21 @@ export class LightningClient {
 
   /**
    * Enable Lightning for a wallet (provisions an LNbits custodial wallet).
+   *
    * @param {Object} params
    * @param {string} params.wallet_id - Wallet UUID
-   * @param {string} params.mnemonic - BIP39 mnemonic
+   * @param {string} [params.mnemonic] - **Deprecated and ignored.** The server
+   *   required a BIP39 mnemonic here, validated it, and never used it: the
+   *   provisioned wallet is custodial, so there is no signer and nothing to
+   *   derive (NEW-20). The seed reconstructs every key on every chain, and it
+   *   is no longer sent. Stop passing it.
    * @param {string} [params.business_id] - Optional business UUID
    * @returns {Promise<Object>} The provisioned node record
    */
-  async enableWallet({ wallet_id, mnemonic, business_id }) {
+  async enableWallet({ wallet_id, business_id }) {
     return this.#client.request('/lightning/nodes', {
       method: 'POST',
-      body: JSON.stringify({ wallet_id, mnemonic, business_id }),
+      body: JSON.stringify({ wallet_id, business_id }),
     });
   }
 

--- a/packages/sdk/src/swap.js
+++ b/packages/sdk/src/swap.js
@@ -238,11 +238,42 @@ export class SwapClient {
     
     const startTime = Date.now();
     let lastStatus = null;
-    
+
+    // F3-L5-02: a failed poll must not end the watch.
+    //
+    // `getSwapStatus` was awaited bare inside this loop, so one 502, 504 or
+    // socket timeout from the provider threw straight out of `waitForSwap`.
+    // The swap itself is unaffected — it is still in flight at the provider —
+    // but the caller has lost all visibility of it, and the natural reaction to
+    // "the call threw" is to assume the swap failed. A transient blip on a
+    // poll that runs for up to an hour is expected, not exceptional.
+    //
+    // Consecutive failures are what matter: an isolated blip is retried on the
+    // next tick, while a provider that is genuinely gone stops the loop rather
+    // than spinning silently until the timeout.
+    const maxConsecutiveErrors = options.maxConsecutiveErrors ?? 5;
+    let consecutiveErrors = 0;
+
     while (Date.now() - startTime < timeout) {
-      const result = await this.getSwapStatus(swapId);
+      let result;
+      try {
+        result = await this.getSwapStatus(swapId);
+        consecutiveErrors = 0;
+      } catch (err) {
+        consecutiveErrors++;
+        if (consecutiveErrors >= maxConsecutiveErrors) {
+          throw new Error(
+            `Lost contact with the swap provider after ${consecutiveErrors} consecutive failures ` +
+            `while tracking ${swapId}. The swap may still be in progress — check its status directly. ` +
+            `Last error: ${err.message}`
+          );
+        }
+        await new Promise(resolve => setTimeout(resolve, interval));
+        continue;
+      }
+
       const currentStatus = result.swap?.status;
-      
+
       // Notify on status change
       if (currentStatus !== lastStatus) {
         if (onStatusChange && lastStatus !== null) {
@@ -250,12 +281,12 @@ export class SwapClient {
         }
         lastStatus = currentStatus;
       }
-      
+
       // Check if we've reached a target status
       if (targetStatuses.includes(currentStatus)) {
         return result;
       }
-      
+
       // Wait before next poll
       await new Promise(resolve => setTimeout(resolve, interval));
     }

--- a/packages/sdk/src/wallet.js
+++ b/packages/sdk/src/wallet.js
@@ -407,8 +407,17 @@ function getSecp256k1PublicKey(seed) {
  * @private
  */
 function signMessage(message, privateKey) {
-  const messageHash = sha256(new TextEncoder().encode(message));
-  const signature = secp256k1.sign(messageHash, privateKey);
+  // Signed over the RAW message bytes, not sha256(message).
+  //
+  // This used to hash first. The server verifies proofs by passing the raw
+  // encoded message straight to `secp256k1.verify` (see
+  // web-wallet/auth.ts::verifySecp256k1Signature), and noble treats that
+  // argument as the thing that was signed — so a signature over the digest
+  // verifies false against the message. Every proof of ownership this SDK
+  // produced was rejected, which meant `WalletClient.fromSeed()` could not
+  // import a wallet at all. Found while wiring the same proof into
+  // `create()` for V-04.
+  const signature = secp256k1.sign(new TextEncoder().encode(message), privateKey);
   // Handle different noble-curves versions:
   // v1.x returns Signature object with toCompactHex()
   // v2.x returns raw Uint8Array directly
@@ -672,11 +681,24 @@ export class WalletClient {
       };
     });
     
+    // V-04: /create accepted a public key and a list of on-chain addresses
+    // from anyone, with no proof that either was theirs, while /import required
+    // a signature for the same write. `wallet_addresses` is globally unique on
+    // (address, chain), so an unproved registration permanently denies an
+    // address to whoever actually owns it.
+    const proofMessage = `CoinPay Wallet Create: ${Date.now()}`;
+    const { privateKey: proofKey } = deriveKeyPair(seed, 'ETH', 0);
+    const proofSignature = signMessage(proofMessage, proofKey);
+
     const result = await client.#request('/web-wallet/create', {
       method: 'POST',
       body: JSON.stringify({
         public_key_secp256k1: publicKeySecp256k1,
         initial_addresses: initialAddresses,
+        proof_of_ownership: {
+          message: proofMessage,
+          signature: proofSignature,
+        },
       }),
     });
     

--- a/packages/sdk/test/lightning.test.js
+++ b/packages/sdk/test/lightning.test.js
@@ -30,7 +30,6 @@ describe('LightningClient (via CoinPayClient)', () => {
     it('should POST to /lightning/nodes', async () => {
       await client.lightning.enableWallet({
         wallet_id: 'w-1',
-        mnemonic: 'test words',
         business_id: 'b-1',
       });
 
@@ -38,10 +37,25 @@ describe('LightningClient (via CoinPayClient)', () => {
         method: 'POST',
         body: JSON.stringify({
           wallet_id: 'w-1',
-          mnemonic: 'test words',
           business_id: 'b-1',
         }),
       });
+    });
+
+    it('never transmits the seed, even when a caller still passes one', async () => {
+      // NEW-20: the server required a BIP-39 mnemonic here, validated it and
+      // discarded it — the provisioned wallet is custodial, so nothing is
+      // derived or signed. The seed reconstructs every key on every chain, so
+      // a caller on an old integration passing it must not have it forwarded.
+      await client.lightning.enableWallet({
+        wallet_id: 'w-1',
+        mnemonic: 'abandon abandon abandon',
+        business_id: 'b-1',
+      });
+
+      const [, options] = client.request.mock.calls.at(-1);
+      expect(options.body).not.toContain('mnemonic');
+      expect(options.body).not.toContain('abandon');
     });
   });
 

--- a/plugins/fossbilling/library/Payment/Adapter/CoinPayPortal.php
+++ b/plugins/fossbilling/library/Payment/Adapter/CoinPayPortal.php
@@ -303,6 +303,41 @@ class Payment_Adapter_CoinPayPortal
             $paidAsset = $eventData['paid_asset'] ?? '';
             $paidCrypto = $eventData['paid_amount'] ?? '';
 
+            // F4-02: refuse a payment already recorded.
+            //
+            // The only guard was `if ($invoice['status'] === 'paid') return;`,
+            // which is a check-then-act with a gap in the middle. Two
+            // deliveries of the same event — and CoinPayPortal retries, as does
+            // every webhook sender — both read a status that is not yet 'paid',
+            // both create a transaction and both mark the invoice paid. The
+            // merchant's books then show the invoice settled twice.
+            //
+            // `txid` is the payment id, so it is stable across retries and is
+            // the natural idempotency key. Wrapped defensively: if this
+            // FOSSBilling build does not expose the listing call, the behaviour
+            // degrades to what it was rather than breaking payment capture
+            // outright.
+            try {
+                $existing = $api_admin->invoice->transaction_get_list([
+                    'txid'       => $paymentId,
+                    'gateway_id' => $gateway_id,
+                    'per_page'   => 1,
+                ]);
+                $alreadyRecorded = !empty($existing['list']) || (is_array($existing) && !empty($existing[0]));
+
+                if ($alreadyRecorded) {
+                    $this->log(sprintf(
+                        'Payment %s already recorded against invoice %s, ignoring duplicate delivery',
+                        $paymentId,
+                        $invoiceId
+                    ));
+                    http_response_code(200);
+                    return;
+                }
+            } catch (\Throwable $e) {
+                $this->log('Could not check for a duplicate transaction: ' . $e->getMessage());
+            }
+
             try {
                 $api_admin->invoice->transaction_create([
                     'invoice_id' => (int)$invoiceId,

--- a/plugins/fossbilling/library/Payment/Adapter/CoinPayPortal.php
+++ b/plugins/fossbilling/library/Payment/Adapter/CoinPayPortal.php
@@ -51,6 +51,24 @@ class Payment_Adapter_CoinPayPortal
                     'required'    => true,
                     'description' => 'Secret used to verify incoming webhook signatures from CoinPayPortal.',
                 ],
+                // F4-03: the webhook URL was documented but never shown here.
+                //
+                // Nothing registers it automatically, so a merchant who
+                // configures the gateway from this screen alone ends up with a
+                // working checkout and no callback: payments are taken and the
+                // invoice is never marked paid. The failure is silent and looks
+                // like CoinPayPortal not paying out, because everything on this
+                // page appears correctly filled in.
+                //
+                // Read-only, because it is an instruction rather than a setting.
+                'webhook_url_display' => [
+                    'label'       => 'Webhook URL (register this in CoinPayPortal)',
+                    'type'        => 'text',
+                    'required'    => false,
+                    'readonly'    => true,
+                    'default'     => '/ipn/CoinPayPortal',
+                    'description' => 'Copy this path onto the end of your store URL — https://your-domain.com/ipn/CoinPayPortal — and add it as the webhook endpoint in your CoinPayPortal dashboard under Settings → Webhooks. Without it, invoices are never marked paid automatically.',
+                ],
                 'api_url' => [
                     'label'       => 'API Base URL',
                     'type'        => 'text',

--- a/scripts/ensure-platform-stripe-webhook.ts
+++ b/scripts/ensure-platform-stripe-webhook.ts
@@ -25,11 +25,28 @@ const COINPAY_HOST = 'coinpayportal.com';
 const COINPAY_WEBHOOK_URL = `https://${COINPAY_HOST}/api/stripe/webhook`;
 
 // Every event the handler at src/app/api/stripe/webhook/route.ts switches on.
+/**
+ * Every event `src/app/api/stripe/webhook/route.ts` actually handles.
+ *
+ * E-04: this list had 7 of the 10, omitting `charge.dispute.updated`,
+ * `charge.dispute.closed` and `charge.refunded` — and `--apply` reconciles the
+ * live endpoint to this list, so running it *unsubscribed* dispute resolution
+ * and refunds. The handlers stayed in the code and simply stopped being called:
+ * disputes would be recorded on creation and then never updated or closed, and
+ * refunds would never be recorded at all, while the dashboard kept showing the
+ * stale state as if it were current.
+ *
+ * Keep in step with the switch in the webhook route. A handler that is not
+ * listed here is a handler that `--apply` will turn off.
+ */
 const REQUIRED_EVENTS: Stripe.WebhookEndpointCreateParams.EnabledEvent[] = [
   'checkout.session.completed',
   'payment_intent.succeeded',
   'payment_intent.payment_failed',
   'charge.dispute.created',
+  'charge.dispute.updated',
+  'charge.dispute.closed',
+  'charge.refunded',
   'payout.created',
   'payout.paid',
   'account.updated',

--- a/scripts/sweep-balances.mjs
+++ b/scripts/sweep-balances.mjs
@@ -17,16 +17,12 @@
  *   pnpm sweep-balances --crypto BCH # Only sweep BCH addresses
  */
 
-import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
-import { HDKey } from '@scure/bip32';
 import * as bitcoin from 'bitcoinjs-lib';
 import { ethers } from 'ethers';
-import { createHmac } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import axios from 'axios';
 import { config } from 'dotenv';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { join } from 'path';
 
 // Load environment variables
@@ -89,7 +85,13 @@ function base58Encode(bytes) {
 }
 
 /**
- * Convert hex private key to WIF format for BCH
+ * Convert hex private key to WIF format for BCH.
+ *
+ * Retained (and completed) because exporting a key in WIF is what an operator
+ * needs to sweep an address by hand once this tool has found it. Verified
+ * against the canonical Bitcoin test vector: private key 0C28FC…AA1D encodes to
+ * 5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ uncompressed, and to a
+ * K/L-prefixed key compressed.
  */
 function hexToWIF(hexPrivateKey, compressed = true) {
   if (!/^[0-9a-fA-F]{64}$/.test(hexPrivateKey)) {
@@ -116,5 +118,175 @@ function hexToWIF(hexPrivateKey, compressed = true) {
   const checksum = bitcoin.crypto.hash256(payload).subarray(0, 4);
   const wifBytes = Buffer.concat([payload, checksum]);
   
-  const digits = [0];
-  for (let i = 0; i < wifBytes.length; i++) {
+  // The file was truncated here, mid-way through a second, inline base58
+  // implementation — even though `base58Encode` is defined above. That is why
+  // `node --check` has failed since the script was introduced: the documented
+  // emergency fund-recovery procedure has never been runnable (F5-L1-06).
+  return base58Encode(wifBytes);
+}
+
+/**
+ * Ask a chain how much is sitting at an address.
+ *
+ * Deliberately mirrors `src/lib/payments/monitor-balance.ts`, including its
+ * environment-variable overrides, so this reports the same numbers production
+ * does. Returns `null` — never 0 — when the balance could not be read, because
+ * "the node did not answer" and "the address is empty" must not look alike to
+ * an operator hunting for stranded funds.
+ */
+const RPC = {
+  BTC: process.env.BITCOIN_RPC_URL || 'https://blockstream.info/api',
+  BCH: process.env.BCH_RPC_URL || 'https://api.blockchair.com/bitcoin-cash',
+  ETH: process.env.ETHEREUM_RPC_URL || 'https://eth.llamarpc.com',
+  POL: process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
+  SOL: process.env.NEXT_PUBLIC_SOLANA_RPC_URL || process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com',
+};
+
+async function readBalance(crypto, address) {
+  try {
+    if (crypto === 'BTC') {
+      const { data } = await axios.get(`${RPC.BTC}/address/${address}`, { timeout: 15000 });
+      const sats =
+        (data.chain_stats?.funded_txo_sum ?? 0) - (data.chain_stats?.spent_txo_sum ?? 0);
+      return sats / 1e8;
+    }
+
+    if (crypto === 'BCH') {
+      const { data } = await axios.get(
+        `${RPC.BCH}/dashboards/address/${address}`,
+        { timeout: 15000 }
+      );
+      const sats = data?.data?.[address]?.address?.balance;
+      return typeof sats === 'number' ? sats / 1e8 : null;
+    }
+
+    if (crypto === 'ETH' || crypto === 'POL') {
+      const { data } = await axios.post(
+        RPC[crypto],
+        { jsonrpc: '2.0', id: 1, method: 'eth_getBalance', params: [address, 'latest'] },
+        { timeout: 15000 }
+      );
+      if (!data?.result) return null;
+      return Number(ethers.formatEther(BigInt(data.result)));
+    }
+
+    if (crypto === 'SOL') {
+      const { data } = await axios.post(
+        RPC.SOL,
+        { jsonrpc: '2.0', id: 1, method: 'getBalance', params: [address] },
+        { timeout: 15000 }
+      );
+      const lamports = data?.result?.value;
+      return typeof lamports === 'number' ? lamports / 1e9 : null;
+    }
+
+    return null;
+  } catch (err) {
+    console.error(`    ! ${crypto} ${address}: ${err.message}`);
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { execute: false, crypto: null, limit: 500 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--execute') args.execute = true;
+    else if (argv[i] === '--crypto') args.crypto = (argv[++i] || '').toUpperCase();
+    else if (argv[i] === '--limit') args.limit = Math.max(1, Number(argv[++i]) || 500);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.crypto && !SUPPORTED_CRYPTOS.includes(args.crypto)) {
+    console.error(`Unsupported --crypto ${args.crypto}. Supported: ${SUPPORTED_CRYPTOS.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (args.execute) {
+    // Refusing rather than pretending.
+    //
+    // Restoring this script (F5-L1-06) restores the half that can be verified:
+    // finding the money. Broadcasting sweeps is new, untested, multi-chain
+    // fund-moving code, and shipping that unexercised is how funds get sent
+    // somewhere unrecoverable — a worse outcome than the stranded dust it is
+    // meant to recover. Discovery output below feeds the existing, exercised
+    // forwarding path.
+    console.error('--execute is not implemented.');
+    console.error('');
+    console.error('This tool reports stranded balances; it does not move them.');
+    console.error('To move funds, use the reviewed forwarding path');
+    console.error('(src/lib/wallets/secure-forwarding.ts) against the specific payment,');
+    console.error('or sweep manually with the derived key for the address.');
+    process.exit(2);
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.');
+    process.exit(1);
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  let query = supabase
+    .from('payment_addresses')
+    .select('id, address, cryptocurrency, payment_id, forwarded_at, created_at')
+    .order('created_at', { ascending: false })
+    .limit(args.limit);
+  if (args.crypto) query = query.eq('cryptocurrency', args.crypto);
+
+  const { data: addresses, error } = await query;
+  if (error) {
+    console.error(`Could not read payment_addresses: ${error.message}`);
+    process.exit(1);
+  }
+  if (!addresses?.length) {
+    console.log('No payment addresses to scan.');
+    return;
+  }
+
+  console.log(`Scanning ${addresses.length} payment address(es)${args.crypto ? ` (${args.crypto})` : ''}…`);
+  console.log('');
+
+  const stranded = [];
+  let unreadable = 0;
+
+  for (const row of addresses) {
+    const crypto = (row.cryptocurrency || '').toUpperCase();
+    if (!SUPPORTED_CRYPTOS.includes(crypto)) continue;
+
+    const balance = await readBalance(crypto, row.address);
+    if (balance === null) {
+      unreadable++;
+      continue;
+    }
+
+    const threshold = MIN_BALANCE_THRESHOLDS[crypto] ?? 0;
+    if (balance > threshold) {
+      stranded.push({ ...row, crypto, balance });
+      console.log(`  ${crypto.padEnd(4)} ${row.address}  ${balance}  (payment ${row.payment_id}${row.forwarded_at ? ', already forwarded' : ''})`);
+    }
+  }
+
+  console.log('');
+  console.log(`Above dust: ${stranded.length}`);
+  // An address we could not read is not an address we know is empty. Saying so
+  // is the difference between "nothing stranded" and "nothing found *yet*".
+  if (unreadable > 0) {
+    console.log(`Could not read: ${unreadable} — these were NOT checked and may hold funds.`);
+  }
+
+  const byCrypto = {};
+  for (const s of stranded) byCrypto[s.crypto] = (byCrypto[s.crypto] || 0) + s.balance;
+  for (const [crypto, total] of Object.entries(byCrypto)) {
+    console.log(`  ${crypto}: ${total}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -16,8 +16,11 @@ const schema = z.object({
  */
 export async function POST(request: NextRequest) {
   try {
+    // Per-IP first: this is the ATTACKER's bucket, and the one that should cost
+    // them something. It reused `merchant_login`, which is a different budget
+    // for a different action.
     const clientIp = getClientIp(request);
-    const ipRateCheck = await checkRateLimitAsync(clientIp, 'merchant_login');
+    const ipRateCheck = await checkRateLimitAsync(clientIp, 'password_reset_ip');
     if (!ipRateCheck.allowed) {
       return NextResponse.json(
         { success: false, error: 'Too many requests. Please try again later.' },
@@ -32,9 +35,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true });
     }
 
-    // Rate limit: max 3 reset requests per email per 15 min
+    // Then per-email (R4-ID-RESET). This is the VICTIM's bucket: an attacker
+    // spending it on someone else's address locks that person out of their own
+    // reset flow, and each request also replaces any reset token already in
+    // flight. The per-IP limit above is what bounds that, which is why it is
+    // checked first and is the tighter constraint in practice.
+    //
+    // Both categories are now dedicated. This one used `merchant_login` — 5 per
+    // 5 minutes — while the comment described 3 per 15, so neither the budget
+    // nor the window was what it claimed.
     const emailKey = `password_reset:${validation.data.email.toLowerCase()}`;
-    const emailRateCheck = await checkRateLimitAsync(emailKey, 'merchant_login');
+    const emailRateCheck = await checkRateLimitAsync(emailKey, 'password_reset_email');
     if (!emailRateCheck.allowed) {
       // Still return success to not leak info, but log it
       console.log(`[Forgot Password] Rate limited for ${validation.data.email}`);

--- a/src/app/api/auth/webauthn/login-options/route.test.ts
+++ b/src/app/api/auth/webauthn/login-options/route.test.ts
@@ -86,6 +86,29 @@ describe('WebAuthn Login Options', () => {
 
     expect(res.status).toBe(200);
     expect(data.success).toBe(true);
-    expect(data._challengeKey).toBe('user-123');
+
+    // NEW-07: the key used to be the merchant's own id. The challenge store
+    // holds one entry per key and this route is public, so anyone who knew a
+    // merchant's email could overwrite that merchant's pending challenge and
+    // lock them out of their own account for as long as they kept posting.
+    // The key is only a lookup handle — login-verify derives the user from the
+    // stored credential, never from this value — so it must not identify
+    // anyone, and two requests must never collide.
+    expect(data._challengeKey).not.toBe('user-123');
+    expect(data._challengeKey).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('issues a distinct challenge key per request for the same email', async () => {
+    const call = async () => {
+      const req = new NextRequest('http://localhost/api/auth/webauthn/login-options', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'test@example.com' }),
+      });
+      return (await (await POST(req)).json())._challengeKey;
+    };
+
+    // Two honest logins from two devices used to share one slot and break each
+    // other; this is the same property that denies the attack above.
+    expect(await call()).not.toBe(await call());
   });
 });

--- a/src/app/api/auth/webauthn/login-options/route.ts
+++ b/src/app/api/auth/webauthn/login-options/route.ts
@@ -5,6 +5,7 @@
  */
 import { checkRateLimitAsync } from '@/lib/web-wallet/rate-limit';
 import { getClientIp } from '@/lib/web-wallet/client-ip';
+import { randomBytes } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { generateAuthenticationOptions } from '@simplewebauthn/server';
@@ -42,7 +43,6 @@ export async function POST(request: NextRequest) {
   const rpID = getRpId(request);
 
   let allowCredentials: { id: string; transports?: AuthenticatorTransport[] }[] = [];
-  let userId: string | null = null;
 
   if (email) {
     // Find user by email
@@ -53,7 +53,6 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (merchant) {
-      userId = merchant.id;
       const { data: creds } = await supabase
         .from('webauthn_credentials')
         .select('credential_id, transports')
@@ -72,8 +71,19 @@ export async function POST(request: NextRequest) {
     userVerification: 'preferred',
   });
 
-  // Store challenge — use a session key based on email or a special "anonymous" key
-  const challengeKey = userId || `anon_${options.challenge.slice(0, 16)}`;
+  // NEW-07: the key used to be the merchant's own id whenever the email
+  // resolved. The store holds one challenge per key, and this route is public,
+  // so anyone who knew a merchant's email could overwrite that merchant's
+  // pending challenge at will: the victim's authenticator signs the challenge
+  // it was handed, login-verify consumes whatever the attacker wrote last, the
+  // two never match, and the account cannot be logged into for as long as the
+  // attacker keeps posting. It also broke two honest logins from two devices.
+  //
+  // The key is only a lookup handle — the client echoes it back, and
+  // login-verify derives the user from the stored credential, never from this
+  // value — so it does not need to identify anyone. Making it unguessable and
+  // unique per request removes the shared slot the attack depended on.
+  const challengeKey = randomBytes(32).toString('base64url');
   storeChallenge(challengeKey, options.challenge);
 
   return NextResponse.json({

--- a/src/app/api/businesses/[id]/payouts/[payoutId]/route.ts
+++ b/src/app/api/businesses/[id]/payouts/[payoutId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
-import { getPayout, retryPayout } from '@/lib/payouts/service';
+import { getPayout, retryPayout, resolveIndeterminatePayout } from '@/lib/payouts/service';
 
 /**
  * Verify JWT auth and extract merchant ID.
@@ -106,6 +106,44 @@ export async function PATCH(
     const owns = await verifyBusinessOwnership(supabase, id, auth.merchantId!);
     if (!owns) {
       return NextResponse.json({ success: false, error: 'Business not found or access denied' }, { status: 404 });
+    }
+
+    // N-03: `indeterminate` had no exit at all.
+    //
+    // A payout lands there when the broadcast outcome is unknown — a timeout
+    // after the node may already have accepted the transaction — and
+    // `retryPayout` refuses to touch one, correctly, because re-sending could
+    // pay the recipient twice. Its error told the operator to mark the payout
+    // completed with its tx_hash, or failed and retry, and there was no way to
+    // do either. The state described a procedure nobody could carry out.
+    //
+    // `{ resolution: 'completed' | 'failed' }` in the body is that transition.
+    // It stays manual: only someone who has looked at the chain can say which
+    // way it went, and a wrong automatic answer either pays twice or strands a
+    // real payment.
+    const body = await request.json().catch(() => ({}));
+    const resolution = body?.resolution;
+
+    if (resolution === 'completed' || resolution === 'failed') {
+      const resolved = await resolveIndeterminatePayout(
+        supabase,
+        id,
+        payoutId,
+        resolution,
+        typeof body?.tx_hash === 'string' ? body.tx_hash : undefined
+      );
+
+      if (!resolved.success) {
+        return NextResponse.json({ success: false, error: resolved.error }, { status: 400 });
+      }
+      return NextResponse.json({ success: true, payout: resolved.payout });
+    }
+
+    if (resolution !== undefined) {
+      return NextResponse.json(
+        { success: false, error: "resolution must be 'completed' or 'failed'" },
+        { status: 400 }
+      );
     }
 
     const result = await retryPayout(supabase, id, payoutId);

--- a/src/app/api/cli-auth/poll/route.ts
+++ b/src/app/api/cli-auth/poll/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { generateToken } from '@/lib/auth/jwt';
 import { getJwtSecret } from '@/lib/secrets';
+import { checkRateLimitAsync } from '@/lib/web-wallet/rate-limit';
+import { getClientIp } from '@/lib/web-wallet/client-ip';
 
 // Headless CLI login — step 3. The CLI polls here with its device_code. While
 // pending it gets 202 authorization_pending. Once the merchant has approved it in
@@ -15,6 +17,27 @@ export async function POST(request: NextRequest) {
     const deviceCode = body?.device_code;
     if (!deviceCode || typeof deviceCode !== 'string') {
       return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+    }
+
+    // NEW-11: unauthenticated, and unlimited. `start` was rate limited but this
+    // was not, so a caller could hammer it freely — and the answers are
+    // distinguishable (`invalid_grant` / `authorization_pending` / `denied` /
+    // `expired_token`), which makes it a status oracle for any device code.
+    //
+    // A device code is 32 random bytes, so guessing one is not the concern;
+    // the cost of answering millions of polls is. `start` already declares the
+    // interval clients should use, and this enforces it rather than trusting
+    // it. The budget is generous relative to that interval so a legitimate CLI
+    // polling every 5s for the full 10-minute window never trips it.
+    const rate = await checkRateLimitAsync(getClientIp(request), 'cli_auth_poll');
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { error: 'slow_down', error_description: 'Polling too frequently' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.max(1, rate.resetAt - Math.floor(Date.now() / 1000))) },
+        }
+      );
     }
 
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/app/api/cli-auth/start/route.ts
+++ b/src/app/api/cli-auth/start/route.ts
@@ -65,11 +65,26 @@ export async function POST(request: NextRequest) {
 
     const base = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL || 'https://coinpayportal.com';
     const verificationUri = `${base}/cli-auth`;
+
+    // G-1.2-10: `verification_uri_complete` is deliberately not returned.
+    //
+    // Anyone could start a device authorization — it has to be unauthenticated,
+    // the CLI has no credential yet — and get back a link that pre-fills the
+    // approval form. Send that link to a signed-in merchant and one click hands
+    // the *attacker's* CLI a 7-day session JWT for the victim's account. It is
+    // full account takeover with a single click, and the attacker also chooses
+    // the `client_name` shown on the page, so it can read as something the
+    // victim trusts.
+    //
+    // The defence is that the merchant must type the code their own terminal
+    // printed. An attacker can still send someone to /cli-auth, but they cannot
+    // make the victim's screen show the attacker's code. RFC 8628 makes this
+    // field optional precisely because it trades this risk for convenience on
+    // input-constrained devices; a CLI on a real keyboard is not that case.
     return NextResponse.json({
       device_code: deviceCode,
       user_code: userCode,
       verification_uri: verificationUri,
-      verification_uri_complete: `${verificationUri}?code=${encodeURIComponent(userCode)}`,
       expires_in: EXPIRES_IN,
       interval: INTERVAL,
     });

--- a/src/app/api/cron/monitor-payments/balance-checkers.ts
+++ b/src/app/api/cron/monitor-payments/balance-checkers.ts
@@ -529,6 +529,48 @@ export async function checkADABalance(address: string, rpcUrl: string): Promise<
 }
 
 /**
+ * Check a Dogecoin address balance.
+ *
+ * F-1.3-04: this case was `console.log('not yet implemented'); return 0`, and
+ * this is the oracle `secure-forwarding.ts` reads. A DOGE payment is *confirmed*
+ * by a different oracle (`payments/monitor-balance.ts`) which has always had a
+ * real implementation — so the two disagreed by construction. A confirmed DOGE
+ * payment reached forwarding, was told the address held nothing, and was pushed
+ * back to `confirmed`; on every subsequent run, the same. The funds would sit at
+ * the intermediary address permanently while the payment looked healthy.
+ *
+ * Deliberately the same two sources, in the same order, as the confirmation-side
+ * checker. Two oracles that disagree about the same address is the actual
+ * defect; a second, differently-sourced implementation would only hide it.
+ *
+ * Production has never confirmed a DOGE payment (all four are `expired`), so
+ * nothing is stranded today — this closes the trap before it is walked into.
+ */
+async function checkDOGEBalance(address: string): Promise<number> {
+  try {
+    const response = await fetch(`https://api.blockcypher.com/v1/doge/main/addrs/${address}/balance`);
+    if (response.ok) {
+      const data = await response.json();
+      return (data.balance || 0) / 1e8;
+    }
+
+    const fallbackResponse = await fetch(`https://dogechain.info/api/v1/address/balance/${address}`);
+    if (fallbackResponse.ok) {
+      const data = await fallbackResponse.json();
+      if (data.success === 1) {
+        return parseFloat(data.balance || '0');
+      }
+    }
+
+    console.error(`[Monitor DOGE] Both balance sources failed for ${address}`);
+    return 0;
+  } catch (error) {
+    console.error(`[Monitor DOGE] Error checking balance for ${address}:`, error);
+    return 0;
+  }
+}
+
+/**
  * Check balance for any supported blockchain
  */
 export async function checkBalance(address: string, blockchain: string): Promise<number> {
@@ -562,8 +604,7 @@ export async function checkBalance(address: string, blockchain: string): Promise
     case 'BNB':
       return checkEVMBalance(address, RPC_ENDPOINTS.BNB);
     case 'DOGE':
-      console.log(`DOGE balance check not yet implemented for ${address}`);
-      return 0;
+      return checkDOGEBalance(address);
     case 'XRP':
       return checkXRPBalance(address, RPC_ENDPOINTS.XRP);
     case 'ADA':

--- a/src/app/api/cron/monitor-payments/balance-checkers.ts
+++ b/src/app/api/cron/monitor-payments/balance-checkers.ts
@@ -6,6 +6,7 @@
  */
 
 import * as bitcoin from 'bitcoinjs-lib';
+import { fetchWithTimeout } from '@/lib/http/fetch-timeout';
 
 /**
  * CashAddr charset for decoding
@@ -149,7 +150,7 @@ const CRYPTO_APIS_KEY = process.env.CRYPTO_APIS_KEY || '';
  */
 export async function checkBitcoinBalance(address: string): Promise<number> {
   try {
-    const response = await fetch(`https://blockstream.info/api/address/${address}`);
+    const response = await fetchWithTimeout(`https://blockstream.info/api/address/${address}`);
     if (!response.ok) {
       console.error(`Failed to fetch BTC balance for ${address}: ${response.status}`);
       return 0;
@@ -181,7 +182,7 @@ export async function checkBCHBalance(address: string): Promise<number> {
         const tatumUrl = `https://api.tatum.io/v3/bcash/address/balance/${legacyAddress}`;
         console.log(`[Monitor BCH] Tatum URL: ${tatumUrl}`);
         
-        const response = await fetch(tatumUrl, {
+        const response = await fetchWithTimeout(tatumUrl, {
           method: 'GET',
           headers: { 'x-api-key': tatumApiKey },
         });
@@ -215,7 +216,7 @@ export async function checkBCHBalance(address: string): Promise<number> {
         const url = `https://rest.cryptoapis.io/addresses-latest/utxo/bitcoin-cash/mainnet/${cashAddrShort}/balance`;
         console.log(`[Monitor BCH] CryptoAPIs URL: ${url}`);
         
-        const response = await fetch(url, {
+        const response = await fetchWithTimeout(url, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
@@ -240,7 +241,7 @@ export async function checkBCHBalance(address: string): Promise<number> {
     // Fallback to fullstack.cash
     try {
       const fullstackUrl = `https://api.fullstack.cash/v5/electrumx/balance/${address}`;
-      const fullstackResponse = await fetch(fullstackUrl);
+      const fullstackResponse = await fetchWithTimeout(fullstackUrl);
       
       if (fullstackResponse.ok) {
         const fullstackData = await fullstackResponse.json();
@@ -256,7 +257,7 @@ export async function checkBCHBalance(address: string): Promise<number> {
     // Fallback to Blockchair
     try {
       const blockchairUrl = `https://api.blockchair.com/bitcoin-cash/dashboards/address/${legacyAddress}`;
-      const blockchairResponse = await fetch(blockchairUrl);
+      const blockchairResponse = await fetchWithTimeout(blockchairUrl);
       
       if (blockchairResponse.ok) {
         const blockchairData = await blockchairResponse.json();
@@ -280,7 +281,7 @@ export async function checkBCHBalance(address: string): Promise<number> {
  */
 export async function checkEVMBalance(address: string, rpcUrl: string): Promise<number> {
   try {
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -323,7 +324,7 @@ export async function checkEVMTokenBalance(
     const paddedAddress = address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
     const callData = `${ERC20_BALANCE_OF_SELECTOR}${paddedAddress}`;
 
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -360,7 +361,7 @@ export async function checkSolanaBalance(address: string, rpcUrl: string): Promi
   try {
     console.log(`Checking Solana balance for ${address} using ${rpcUrl}`);
     
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -405,7 +406,7 @@ export async function checkSolanaTokenBalance(
   decimals: number = 6
 ): Promise<number> {
   try {
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -460,7 +461,7 @@ export async function checkSolanaTokenBalance(
  */
 export async function checkXRPBalance(address: string, rpcUrl: string): Promise<number> {
   try {
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -504,7 +505,7 @@ export async function checkADABalance(address: string, rpcUrl: string): Promise<
       return 0;
     }
 
-    const response = await fetch(`${rpcUrl}/addresses/${address}`, {
+    const response = await fetchWithTimeout(`${rpcUrl}/addresses/${address}`, {
       method: 'GET',
       headers: { 'project_id': apiKey },
     });
@@ -548,13 +549,13 @@ export async function checkADABalance(address: string, rpcUrl: string): Promise<
  */
 async function checkDOGEBalance(address: string): Promise<number> {
   try {
-    const response = await fetch(`https://api.blockcypher.com/v1/doge/main/addrs/${address}/balance`);
+    const response = await fetchWithTimeout(`https://api.blockcypher.com/v1/doge/main/addrs/${address}/balance`);
     if (response.ok) {
       const data = await response.json();
       return (data.balance || 0) / 1e8;
     }
 
-    const fallbackResponse = await fetch(`https://dogechain.info/api/v1/address/balance/${address}`);
+    const fallbackResponse = await fetchWithTimeout(`https://dogechain.info/api/v1/address/balance/${address}`);
     if (fallbackResponse.ok) {
       const data = await fallbackResponse.json();
       if (data.success === 1) {

--- a/src/app/api/cron/monitor-payments/email-monitor.test.ts
+++ b/src/app/api/cron/monitor-payments/email-monitor.test.ts
@@ -22,6 +22,11 @@ function buildSupabase(
       chain.not = vi.fn().mockReturnValue(chain);
       chain.or = vi.fn().mockReturnValue(chain);
       chain.in = vi.fn().mockReturnValue(chain);
+      // H-R-05: the status-change sweep now pages by keyset, so its chain is
+      // .in().order().limit() and, on later pages, .gt(). The first page
+      // returns everything here, so the walk terminates on a short page.
+      chain.order = vi.fn().mockReturnValue(chain);
+      chain.gt = vi.fn().mockReturnValue(chain);
       chain.limit = vi.fn().mockImplementation(() => {
         const allResults = [pendingRows, settledRows, statusRows];
         const data = allResults[limitCallCount] || [];

--- a/src/app/api/cron/monitor-payments/email-monitor.ts
+++ b/src/app/api/cron/monitor-payments/email-monitor.ts
@@ -9,6 +9,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { sendEmail } from '@/lib/email';
+import { fetchAllKeyset } from '@/lib/db/keyset';
 
 export interface EmailStats {
   reminders_sent: number;
@@ -153,13 +154,36 @@ async function sendStatusChangeNotifications(
   supabase: SupabaseClient,
   stats: EmailStats
 ): Promise<void> {
-  const { data: escrows, error } = await supabase
-    .from('escrows')
-    .select('id, status, depositor_email, beneficiary_email, amount, chain, escrow_address, dispute_reason, settlement_tx_hash, status_emails_sent')
-    .in('status', NOTIFIABLE_STATUSES)
-    .limit(200);
+  // H-R-05: this was `.limit(200)` with no `.order()` and no filter on what had
+  // already been sent. All five notifiable statuses are terminal, so an escrow
+  // that reaches one stays in this set permanently — and every row in the batch
+  // is then skipped by the `alreadySent` check below. Once 200 terminal escrows
+  // have accumulated, the batch is entirely made of them and no escrow ever
+  // receives a status email again. The job reports success having sent nothing.
+  //
+  // Walking the whole set means a newly-notifiable escrow is always reached,
+  // whatever is ahead of it. The per-row skip stays as the idempotency guard.
+  const { rows: escrows, truncated, error } = await fetchAllKeyset<any>(
+    (cursor, pageSize) => {
+      let q = supabase
+        .from('escrows')
+        .select('id, status, depositor_email, beneficiary_email, amount, chain, escrow_address, dispute_reason, settlement_tx_hash, status_emails_sent')
+        .in('status', NOTIFIABLE_STATUSES)
+        .order('id', { ascending: true })
+        .limit(pageSize);
+      if (cursor) q = q.gt('id', cursor);
+      return q as unknown as Promise<{ data: any[] | null; error: { message: string } | null }>;
+    }
+  );
 
-  if (error || !escrows) return;
+  if (error) {
+    console.error('[Email] Status-change sweep page failed:', error);
+    stats.errors++;
+  }
+  if (truncated) {
+    console.warn('[Email] Status-change sweep hit its row ceiling; the tail was not notified this run');
+  }
+  if (!escrows.length) return;
 
   for (const escrow of escrows) {
     const alreadySent: string[] = escrow.status_emails_sent || [];

--- a/src/app/api/cron/monitor-payments/lightning-monitor.ts
+++ b/src/app/api/cron/monitor-payments/lightning-monitor.ts
@@ -144,14 +144,53 @@ export async function syncLnbitsPayments(
   const stats = { synced: 0, errors: 0 };
 
   try {
-    // Find wallets with LNbits keys
-    const { data: wallets, error: wErr } = await supabase
-      .from('wallets')
-      .select('id, ln_wallet_inkey, ln_wallet_adminkey')
-      .or('ln_wallet_inkey.not.is.null,ln_wallet_adminkey.not.is.null')
-      .limit(100);
+    // Find wallets with LNbits keys.
+    //
+    // B-03: this was a bare `.limit(100)` with no `.order()`. Postgres is free
+    // to return rows in any order, and in practice returns them in a stable
+    // physical order — so past 100 Lightning wallets the same hundred were
+    // synced on every run and the rest were never synced at all. Their incoming
+    // payments never reached `ln_payments`, which is what the dashboard reads
+    // and what x402 Lightning settlement now requires as proof, so those
+    // wallets would silently stop being able to prove they had been paid.
+    //
+    // Ordering by id makes the page deterministic, and the loop walks the whole
+    // table by keyset rather than stopping at the first page. The cap is a
+    // runaway guard, not a working set.
+    const PAGE_SIZE = 100;
+    const MAX_WALLETS_PER_RUN = 5_000;
+    const wallets: { id: string; ln_wallet_inkey: string | null; ln_wallet_adminkey: string | null }[] = [];
+    let cursor = '';
 
-    if (wErr || !wallets?.length) return stats;
+    while (wallets.length < MAX_WALLETS_PER_RUN) {
+      let query = supabase
+        .from('wallets')
+        .select('id, ln_wallet_inkey, ln_wallet_adminkey')
+        .or('ln_wallet_inkey.not.is.null,ln_wallet_adminkey.not.is.null')
+        .order('id', { ascending: true })
+        .limit(PAGE_SIZE);
+      if (cursor) query = query.gt('id', cursor);
+
+      const { data: page, error: wErr } = await query;
+      if (wErr) {
+        console.error('[Lightning] wallet page fetch failed:', wErr);
+        stats.errors++;
+        break;
+      }
+      if (!page?.length) break;
+
+      wallets.push(...page);
+      cursor = page[page.length - 1].id;
+      if (page.length < PAGE_SIZE) break;
+    }
+
+    if (wallets.length >= MAX_WALLETS_PER_RUN) {
+      console.warn(
+        `[Lightning] wallet sync hit the ${MAX_WALLETS_PER_RUN} ceiling; the tail of the table was not synced this run`
+      );
+    }
+
+    if (!wallets.length) return stats;
 
     // Lazy import LNbits
     const { listPayments } = await import('@/lib/lightning/lnbits');

--- a/src/app/api/cron/monitor-payments/lightning-monitor.ts
+++ b/src/app/api/cron/monitor-payments/lightning-monitor.ts
@@ -11,6 +11,7 @@ import { decryptLnKey } from '@/lib/lightning/key-encryption';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { sendWebhook } from './webhook';
+import { fetchAllKeyset } from '@/lib/db/keyset';
 
 export interface LightningMonitorStats {
   nodes_checked: number;
@@ -157,37 +158,27 @@ export async function syncLnbitsPayments(
     // Ordering by id makes the page deterministic, and the loop walks the whole
     // table by keyset rather than stopping at the first page. The cap is a
     // runaway guard, not a working set.
-    const PAGE_SIZE = 100;
-    const MAX_WALLETS_PER_RUN = 5_000;
-    const wallets: { id: string; ln_wallet_inkey: string | null; ln_wallet_adminkey: string | null }[] = [];
-    let cursor = '';
-
-    while (wallets.length < MAX_WALLETS_PER_RUN) {
-      let query = supabase
+    const { rows: wallets, truncated, error: wErr } = await fetchAllKeyset<{
+      id: string;
+      ln_wallet_inkey: string | null;
+      ln_wallet_adminkey: string | null;
+    }>((cursor, pageSize) => {
+      let q = supabase
         .from('wallets')
         .select('id, ln_wallet_inkey, ln_wallet_adminkey')
         .or('ln_wallet_inkey.not.is.null,ln_wallet_adminkey.not.is.null')
         .order('id', { ascending: true })
-        .limit(PAGE_SIZE);
-      if (cursor) query = query.gt('id', cursor);
+        .limit(pageSize);
+      if (cursor) q = q.gt('id', cursor);
+      return q as unknown as Promise<{ data: any[] | null; error: { message: string } | null }>;
+    });
 
-      const { data: page, error: wErr } = await query;
-      if (wErr) {
-        console.error('[Lightning] wallet page fetch failed:', wErr);
-        stats.errors++;
-        break;
-      }
-      if (!page?.length) break;
-
-      wallets.push(...page);
-      cursor = page[page.length - 1].id;
-      if (page.length < PAGE_SIZE) break;
+    if (wErr) {
+      console.error('[Lightning] wallet page fetch failed:', wErr);
+      stats.errors++;
     }
-
-    if (wallets.length >= MAX_WALLETS_PER_RUN) {
-      console.warn(
-        `[Lightning] wallet sync hit the ${MAX_WALLETS_PER_RUN} ceiling; the tail of the table was not synced this run`
-      );
+    if (truncated) {
+      console.warn('[Lightning] wallet sync hit its row ceiling; the tail of the table was not synced this run');
     }
 
     if (!wallets.length) return stats;

--- a/src/app/api/cron/monitor-payments/series-monitor.test.ts
+++ b/src/app/api/cron/monitor-payments/series-monitor.test.ts
@@ -13,8 +13,28 @@ vi.mock('@/lib/entitlements/service', () => ({
 
 import { createEscrow } from '@/lib/escrow';
 
+/**
+ * H-R-04: the period is now claimed with a compare-and-swap before anything is
+ * created for it, so the update chain is `.eq(id).eq(periods_completed)
+ * .eq(next_charge_at).select()` rather than a single `.eq(id)`. The default
+ * mock answers a successful claim (one row).
+ *
+ * The old shape stopped at one `.eq`, which is exactly the missing condition
+ * the finding is about: two overlapping runs both read the same
+ * periods_completed, both created an escrow for it, and both wrote the same
+ * next period — the subscriber billed twice, the counter advanced once.
+ */
+function claimChain(rows: any[] = [{ id: 'claimed' }]) {
+  const chain: any = {};
+  chain.eq = vi.fn(() => chain);
+  chain.select = vi.fn().mockResolvedValue({ data: rows, error: null });
+  // Terminal await for the non-claiming updates (status: 'completed', revert).
+  chain.then = (resolve: any) => resolve({ data: rows, error: null });
+  return chain;
+}
+
 function mockSupabase(seriesRows: any[] = [], updateFn?: ReturnType<typeof vi.fn>) {
-  const _update = updateFn || vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) });
+  const _update = updateFn || vi.fn(() => claimChain());
 
   const supabase: any = {
     from: vi.fn().mockReturnValue({
@@ -34,6 +54,75 @@ function mockSupabase(seriesRows: any[] = [], updateFn?: ReturnType<typeof vi.fn
 describe('monitorSeries', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('does not charge a period another run already claimed (H-R-04)', async () => {
+    // The finding: `periods_completed`/`next_charge_at` were written with only
+    // `.eq('id', ...)`, after the escrow had already been created. Two
+    // overlapping cron runs both read the same period, both created an escrow
+    // for it, and both wrote the same next period — the subscriber is billed
+    // twice and the counter advances once, so nothing downstream records that
+    // it happened. A slow run overlapping the next tick is all it takes.
+    //
+    // Zero rows updated means another run got there first.
+    const series = {
+      id: 'ser_race',
+      status: 'active',
+      payment_method: 'crypto',
+      coin: 'USDC_POL',
+      amount: 25,
+      interval: 'monthly',
+      max_periods: null,
+      periods_completed: 2,
+      merchant_id: 'biz_1',
+      depositor_address: '0xdep',
+      beneficiary_address: '0xben',
+      next_charge_at: '2026-01-01T00:00:00Z',
+    };
+
+    const lostClaim = vi.fn(() => claimChain([]));
+    const { supabase } = mockSupabase([series], lostClaim);
+
+    const stats = await monitorSeries(supabase, new Date('2026-01-02'));
+
+    // The important assertion: nothing was created for the contested period.
+    expect(createEscrow).not.toHaveBeenCalled();
+    expect(stats.created).toBe(0);
+  });
+
+  it('claims the period before creating the escrow (H-R-04)', async () => {
+    // Ordering matters as much as the condition: claiming afterwards means the
+    // duplicate escrow already exists by the time the race is detected.
+    const series = {
+      id: 'ser_order',
+      status: 'active',
+      payment_method: 'crypto',
+      coin: 'USDC_POL',
+      amount: 25,
+      interval: 'monthly',
+      max_periods: null,
+      periods_completed: 4,
+      merchant_id: 'biz_1',
+      depositor_address: '0xdep',
+      beneficiary_address: '0xben',
+      next_charge_at: '2026-01-01T00:00:00Z',
+    };
+
+    const order: string[] = [];
+    const claimingUpdate = vi.fn(() => {
+      order.push('claim');
+      return claimChain();
+    });
+    vi.mocked(createEscrow).mockImplementation(async () => {
+      order.push('createEscrow');
+      return { success: true, escrow: { id: 'esc_1' } } as any;
+    });
+
+    const { supabase } = mockSupabase([series], claimingUpdate);
+    await monitorSeries(supabase, new Date('2026-01-02'));
+
+    expect(order[0]).toBe('claim');
+    expect(order).toContain('createEscrow');
   });
 
   it('returns zero stats when no series are due', async () => {
@@ -94,9 +183,7 @@ describe('monitorSeries', () => {
       next_charge_at: '2026-01-01T00:00:00Z',
     };
 
-    const updateMock = vi.fn().mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
-    });
+    const updateMock = vi.fn(() => claimChain());
     const { supabase } = mockSupabase([series], updateMock);
 
     const stats = await monitorSeries(supabase, new Date('2026-01-02'));

--- a/src/app/api/cron/monitor-payments/series-monitor.ts
+++ b/src/app/api/cron/monitor-payments/series-monitor.ts
@@ -71,6 +71,39 @@ export async function monitorSeries(
           continue;
         }
 
+        // H-R-04: claim the period BEFORE creating anything for it.
+        //
+        // This used to create the escrow first and then write
+        // `periods_completed`/`next_charge_at` with only `.eq('id', ...)` — no
+        // compare-and-swap against the state it had read. Two overlapping cron
+        // runs therefore both read the same `periods_completed`, both created an
+        // escrow for the same period, and both wrote the same next period: the
+        // subscriber is billed twice and the counter advances once, so nothing
+        // downstream shows that it happened. Overlapping runs are not
+        // hypothetical — a slow run and the next tick is all it takes.
+        //
+        // Conditioning the write on the values that were read makes the row
+        // itself the lock. The loser sees zero rows updated and skips the
+        // period rather than duplicating it.
+        const nextChargeAt = advanceNextCharge(new Date(series.next_charge_at), series.interval);
+
+        const { data: claimed } = await supabase
+          .from('escrow_series')
+          .update({
+            periods_completed: nextPeriod,
+            next_charge_at: nextChargeAt.toISOString(),
+            updated_at: now.toISOString(),
+          })
+          .eq('id', series.id)
+          .eq('periods_completed', series.periods_completed ?? 0)
+          .eq('next_charge_at', series.next_charge_at)
+          .select('id');
+
+        if (!claimed || claimed.length === 0) {
+          console.log(`[Series] ${series.id} period ${nextPeriod} already claimed by another run — skipping`);
+          continue;
+        }
+
         const isPaidTier = await isBusinessPaidTier(supabase, series.merchant_id).catch(() => false);
 
         const expiresMap: Record<string, number> = { weekly: 168, biweekly: 336, monthly: 720 };
@@ -91,21 +124,31 @@ export async function monitorSeries(
         }, isPaidTier);
 
         if (escrowResult.success) {
-          const nextChargeAt = advanceNextCharge(new Date(series.next_charge_at), series.interval);
-
-          await supabase
-            .from('escrow_series')
-            .update({
-              periods_completed: nextPeriod,
-              next_charge_at: nextChargeAt.toISOString(),
-              updated_at: now.toISOString(),
-            })
-            .eq('id', series.id);
-
           stats.created++;
           console.log(`[Series] ${series.id} period ${nextPeriod} escrow created, next charge: ${nextChargeAt.toISOString()}`);
         } else {
+          // The period was claimed but nothing was created for it, so give it
+          // back. Conditioned on the values this run wrote, so a concurrent
+          // run that has since moved the series on is not rolled backwards.
           console.error(`[Series] ${series.id} failed to create escrow: ${escrowResult.error}`);
+          const { error: revertError } = await supabase
+            .from('escrow_series')
+            .update({
+              periods_completed: series.periods_completed ?? 0,
+              next_charge_at: series.next_charge_at,
+              updated_at: now.toISOString(),
+            })
+            .eq('id', series.id)
+            .eq('periods_completed', nextPeriod)
+            .eq('next_charge_at', nextChargeAt.toISOString());
+
+          if (revertError) {
+            console.error(
+              `[Series] ${series.id}: escrow creation failed AND the period claim could not be released — ` +
+                `period ${nextPeriod} will be skipped:`,
+              revertError
+            );
+          }
           stats.errors++;
         }
       } catch (seriesError) {

--- a/src/app/api/cron/monitor-payments/webhook.ts
+++ b/src/app/api/cron/monitor-payments/webhook.ts
@@ -8,6 +8,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { resolveWebhookSecret } from '@/lib/webhooks/secret';
 import type { Payment } from './types';
+import { safeFetch } from '@/lib/security/ssrf';
 
 /**
  * Send webhook notification for payment status change
@@ -76,7 +77,15 @@ export async function sendWebhook(
       signature = `t=${timestamp},v1=${signatureHex}`;
     }
     
-    const response = await fetch(business.webhook_url, {
+    // H-R-03: the destination is merchant-supplied, so this is a request-forgery
+    // primitive — a merchant can point `webhook_url` at anything the cron's
+    // network can reach, including cloud metadata endpoints, and the platform
+    // will POST to it on a schedule with no user interaction at all.
+    //
+    // `safeFetch` resolves the host and refuses blocked ranges, re-validating
+    // every redirect hop. Legitimate external webhooks are unaffected; that is
+    // the entire set of destinations this is supposed to reach.
+    const fetched = await safeFetch(business.webhook_url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -84,7 +93,27 @@ export async function sendWebhook(
         'User-Agent': 'CoinPay-Webhook/1.0',
       },
       body: payloadString,
+      timeoutMs: 15_000,
     });
+
+    if (!fetched.ok) {
+      await supabase.from('webhook_logs').insert({
+        business_id: payment.business_id,
+        payment_id: payment.id,
+        event,
+        webhook_url: business.webhook_url,
+        success: false,
+        status_code: 0,
+        error_message: `Refused: ${fetched.reason}`,
+        attempt_number: 1,
+        response_time_ms: 0,
+        created_at: now.toISOString(),
+      });
+      console.error(`[Webhook] Refused delivery to ${business.webhook_url}: ${fetched.reason}`);
+      return;
+    }
+
+    const response = fetched.response;
     
     // Log webhook delivery
     await supabase.from('webhook_logs').insert({

--- a/src/app/api/escrow/multisig/[id]/dispute/route.ts
+++ b/src/app/api/escrow/multisig/[id]/dispute/route.ts
@@ -47,6 +47,7 @@ export async function POST(
       escrowId,
       parsed.data.signer_pubkey,
       parsed.data.reason,
+      parsed.data.signature,
     );
 
     if (!result.success) {

--- a/src/app/api/escrow/multisig/[id]/prepare/route.ts
+++ b/src/app/api/escrow/multisig/[id]/prepare/route.ts
@@ -45,6 +45,7 @@ export async function POST(
       parsed.data.proposal_type,
       parsed.data.to_address,
       parsed.data.signer_pubkey,
+      parsed.data.signature,
     );
 
     if (!result.success) {

--- a/src/app/api/escrow/multisig/[id]/propose/route.test.ts
+++ b/src/app/api/escrow/multisig/[id]/propose/route.test.ts
@@ -18,6 +18,10 @@ vi.mock('@/lib/multisig', () => ({
         proposal_type: 'release',
         to_address: '0x2222222222222222222222222222222222222222',
         signer_pubkey: '0x1111111111111111111111111111111111111111',
+        // F-1.1-02: a signature over the proposal's own terms is now required,
+        // because a pubkey is public and matching one proved nothing. The
+        // signature is verified in the engine; this route only forwards it.
+        signature: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       },
     }),
   },
@@ -42,6 +46,10 @@ function makeRequest(headers: Record<string, string> = {}) {
         proposal_type: 'release',
         to_address: '0x2222222222222222222222222222222222222222',
         signer_pubkey: '0x1111111111111111111111111111111111111111',
+        // F-1.1-02: a signature over the proposal's own terms is now required,
+        // because a pubkey is public and matching one proved nothing. The
+        // signature is verified in the engine; this route only forwards it.
+        signature: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       }),
     },
   );
@@ -72,7 +80,12 @@ describe('POST /api/escrow/multisig/:id/propose', () => {
   });
 
   it('creates a prepared proposal for authenticated callers', async () => {
-    mockRequireMultisigAuth.mockResolvedValue({ ok: true });
+    mockRequireMultisigAuth.mockResolvedValue({
+      ok: true,
+      // F-1.1-04: the helper used to discard the identity it resolved, so
+      // routes had nothing to scope by.
+      context: { type: 'merchant', merchantId: 'm-1', email: 'm@example.com' },
+    });
     mockProposeTransaction.mockResolvedValue({
       success: true,
       proposal: { id: 'prop_1' },
@@ -90,6 +103,7 @@ describe('POST /api/escrow/multisig/:id/propose', () => {
       'release',
       '0x2222222222222222222222222222222222222222',
       '0x1111111111111111111111111111111111111111',
+      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
     );
     expect(await response.json()).toEqual({
       proposal: { id: 'prop_1' },

--- a/src/app/api/escrow/multisig/[id]/propose/route.ts
+++ b/src/app/api/escrow/multisig/[id]/propose/route.ts
@@ -47,6 +47,7 @@ export async function POST(
       parsed.data.proposal_type,
       parsed.data.to_address,
       parsed.data.signer_pubkey,
+      parsed.data.signature,
     );
 
     if (!result.success) {

--- a/src/app/api/escrow/multisig/auth.ts
+++ b/src/app/api/escrow/multisig/auth.ts
@@ -9,8 +9,17 @@ function getSupabase() {
   return createClient(url, key);
 }
 
+/**
+ * F-1.1-04: this resolved the caller and then returned `{ ok: true }`, throwing
+ * the identity away. A route that cannot see who is calling cannot scope
+ * anything to them — which is why `createMultisigEscrow` persisted the
+ * `business_id` from the request body with no ownership check at all.
+ *
+ * The context now comes back, and callers are expected to use it.
+ */
 export async function requireMultisigAuth(request: NextRequest): Promise<{
   ok: true;
+  context: NonNullable<Awaited<ReturnType<typeof authenticateRequest>>['context']>;
 } | {
   ok: false;
   response: NextResponse;
@@ -42,5 +51,12 @@ export async function requireMultisigAuth(request: NextRequest): Promise<{
     };
   }
 
-  return { ok: true };
+  if (!authResult.context) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid authentication context' }, { status: 401 }),
+    };
+  }
+
+  return { ok: true, context: authResult.context };
 }

--- a/src/app/api/escrow/multisig/route.ts
+++ b/src/app/api/escrow/multisig/route.ts
@@ -15,6 +15,8 @@ import {
   isMultisigEnabled,
 } from '@/lib/multisig';
 import { requireMultisigAuth } from './auth';
+import { verifyBusinessAccess } from '@/lib/wallets/supported-coins';
+import { callerOwnsEscrow } from '@/lib/escrow/access';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -51,6 +53,30 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // The body's `business_id` is a claim, not an authorization. Check the
+    // caller can act on it before it is persisted (F-1.1-04).
+    const requestedBusinessId = (parsed.data as { business_id?: string }).business_id;
+    if (requestedBusinessId) {
+      if (auth.context.type === 'business') {
+        if (auth.context.businessId !== requestedBusinessId) {
+          return NextResponse.json(
+            { error: 'This API key cannot create an escrow for that business' },
+            { status: 403 },
+          );
+        }
+      } else {
+        const access = await verifyBusinessAccess(
+          supabase,
+          requestedBusinessId,
+          auth.context.merchantId,
+          'escrow.write',
+        );
+        if (!access.ok) {
+          return NextResponse.json({ error: access.error }, { status: access.status ?? 403 });
+        }
+      }
+    }
+
     const result = await createMultisigEscrow(supabase, parsed.data);
 
     if (!result.success) {
@@ -73,6 +99,12 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
+    // F-1.1-03: this was unauthenticated, so possession of an escrow id — which
+    // is handed to counterparties and echoed in URLs — exposed both parties'
+    // pubkeys, the amount, the lockup address and the owning business_id.
+    const auth = await requireMultisigAuth(request);
+    if (!auth.ok) return auth.response;
+
     const supabase = getSupabase();
     const { searchParams } = new URL(request.url);
     const escrowId = searchParams.get('id');
@@ -88,6 +120,13 @@ export async function GET(request: NextRequest) {
 
     if (!result.success) {
       return NextResponse.json({ error: result.error }, { status: 404 });
+    }
+
+    // Holding a credential is not the same as owning this escrow. 404 rather
+    // than 403 so the endpoint is not an existence oracle for escrow ids.
+    const allowed = await callerOwnsEscrow(supabase, auth.context, result.escrow as never);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Escrow not found' }, { status: 404 });
     }
 
     return NextResponse.json(result.escrow);

--- a/src/app/api/escrow/platform-arbiter/route.ts
+++ b/src/app/api/escrow/platform-arbiter/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getMnemonic } from '@/lib/secrets';
 import { deriveKeyForChain } from '@/lib/web-wallet/keys';
+import { PLATFORM_ARBITER_DERIVATION_INDEX } from '@/lib/wallets/derivation-family';
 
 function getSystemMnemonic(chain: string): string | undefined {
   // Try exact chain first (e.g. SYSTEM_MNEMONIC_USDC_ETH), then fall back to COINPAY_MNEMONIC
@@ -14,7 +15,13 @@ function getSystemMnemonic(chain: string): string | undefined {
  * GET /api/escrow/platform-arbiter?chain=ETH
  *
  * Returns CoinPay's platform arbiter public key for the given chain.
- * Uses derivation index 0 from the system mnemonic for that chain.
+ *
+ * ESC-NEW-14: the index is now a named reservation rather than a bare `0`.
+ * It is the same system mnemonic the payment and escrow addresses derive from,
+ * and the family counter used to start at 0 on an empty chain — so the first
+ * payment address ever created derived the very key the arbiter signs disputes
+ * with. `acquireFamilyIndex` now skips this index, so the two key spaces cannot
+ * meet.
  */
 export async function GET(request: NextRequest) {
   const chain = request.nextUrl.searchParams.get('chain');
@@ -29,7 +36,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const key = await deriveKeyForChain(mnemonic, chain as any, 0);
+    const key = await deriveKeyForChain(mnemonic, chain as any, PLATFORM_ARBITER_DERIVATION_INDEX);
     return NextResponse.json({
       success: true,
       chain,

--- a/src/app/api/escrow/route.ts
+++ b/src/app/api/escrow/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { isMultisigDefault, isMultisigEnabled } from '@/lib/multisig/engine';
 import { createClient } from '@supabase/supabase-js';
 import { createEscrow, listEscrows } from '@/lib/escrow';
 import { authenticateRequest, isMerchantAuth, type AuthContext } from '@/lib/auth/middleware';
@@ -92,6 +93,28 @@ export async function POST(request: NextRequest) {
           code: 'MULTISIG_WRONG_ENDPOINT',
         },
         { status: 400 },
+      );
+    }
+
+    // ESC-NEW-05: when the deployment advertises multisig as its default and
+    // the caller omitted `escrow_model`, say what they are getting.
+    //
+    // `GET /api/escrow/model-availability` reports `multisig_default`, and only
+    // the browser acted on it — the create page pre-selects multisig. An API
+    // caller that omits the field gets a custodial escrow, meaning CoinPay
+    // holds the funds, on a deployment that advertises the opposite. That is
+    // the same silent-custody failure the explicit-request branch above was
+    // fixed for, just reached by omission instead.
+    //
+    // Refusing would break every integration that has always omitted the
+    // field, so the escrow is still created and the response says so.
+    const multisigIsDefault = isMultisigEnabled() && isMultisigDefault();
+    const defaultedToCustodial = multisigIsDefault && !body.escrow_model;
+
+    if (defaultedToCustodial) {
+      console.warn(
+        '[Escrow] Created a custodial escrow while MULTISIG_DEFAULT is on — ' +
+          'the caller omitted escrow_model. Pass it explicitly to remove the ambiguity.',
       );
     }
 
@@ -189,7 +212,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
 
-    return NextResponse.json(result.escrow, { status: 201 });
+    return NextResponse.json(
+      defaultedToCustodial
+        ? {
+            ...result.escrow,
+            // ESC-NEW-05: the deployment advertises multisig as its default and
+            // this caller did not choose, so name the custody model rather than
+            // leaving them to assume they got the advertised one.
+            escrow_model: 'custodial',
+            notice:
+              'This deployment defaults to multisig, but escrow_model was not supplied and this ' +
+              'endpoint creates custodial escrows only — CoinPay holds these funds. For a 2-of-3 ' +
+              'escrow use POST /api/escrow/multisig.',
+          }
+        : result.escrow,
+      { status: 201 },
+    );
   } catch (error) {
     console.error('Failed to create escrow:', error);
     return NextResponse.json(

--- a/src/app/api/invoices/[id]/paypal/capture/route.ts
+++ b/src/app/api/invoices/[id]/paypal/capture/route.ts
@@ -39,9 +39,30 @@ export async function POST(
     if (!orderId) {
       return NextResponse.json({ success: false, error: 'orderId is required' }, { status: 400 });
     }
-    // The order id must match the one we created for this invoice — this stops
-    // an arbitrary order from being captured against someone else's invoice.
-    if (invoice.paypal_order_id && invoice.paypal_order_id !== orderId) {
+    // The order must be one we created for this invoice — this stops an
+    // arbitrary order from being captured against someone else's invoice.
+    //
+    // F-1.1-16: this used to compare against `invoices.paypal_order_id`, a
+    // single column that the public create-order route overwrote on every
+    // call. An attacker could therefore replace the pending order id after the
+    // real payer had been handed theirs, and the honest capture would be
+    // rejected here. Orders are now recorded as their own rows bound to the
+    // invoice, so an invoice can legitimately have several (an abandoned
+    // attempt, a retry, two people on the same pay link) and none of them can
+    // displace another.
+    const { data: boundOrder } = await supabase
+      .from('paypal_transactions')
+      .select('id')
+      .eq('paypal_order_id', orderId)
+      .eq('invoice_id', id)
+      .maybeSingle();
+
+    // Orders created before this binding existed have no row, so fall back to
+    // the legacy column for them rather than refusing to settle an invoice
+    // that was already in flight at deploy time.
+    const legacyMatch = !boundOrder && invoice.paypal_order_id === orderId;
+
+    if (!boundOrder && !legacyMatch) {
       return NextResponse.json({ success: false, error: 'Order does not match this invoice' }, { status: 400 });
     }
 

--- a/src/app/api/invoices/[id]/paypal/create-order/route.ts
+++ b/src/app/api/invoices/[id]/paypal/create-order/route.ts
@@ -47,7 +47,46 @@ export async function POST(
       );
     }
 
-    // Record the order id so the capture callback can be validated against it.
+    // Record the order so the capture callback can be validated against it.
+    //
+    // F-1.1-16: this used to write `invoices.paypal_order_id` unconditionally,
+    // and the route is public. That single column is the only thing capture
+    // checked, so anyone who knew an invoice id could call this endpoint and
+    // overwrite it — including after the real payer had already been handed
+    // their order. The payer then approves order A, capture sees B, rejects it
+    // as "Order does not match this invoice", and the invoice can never be
+    // paid for as long as the attacker keeps posting. Repeating it across open
+    // invoices is a denial of payment for the whole platform.
+    //
+    // An invoice legitimately has more than one order over its life — a payer
+    // abandons the PayPal flow and starts again, or two people open the same
+    // pay link — so the fix is not "first write wins", which would let an
+    // attacker lock the slot even earlier. Each order we issue is recorded as
+    // its own row, bound to this invoice, and capture accepts any order bound
+    // to the invoice it is settling. `paypal_order_id` is unique on that
+    // table, so rows cannot collide or be rewritten to point elsewhere.
+    const { error: bindError } = await supabase.from('paypal_transactions').insert({
+      business_id: invoice.business_id,
+      invoice_id: invoice.id,
+      paypal_order_id: order.orderId,
+      amount: Number(invoice.amount),
+      currency: invoice.currency || 'USD',
+      status: 'created',
+    });
+
+    if (bindError) {
+      // Without the binding row, capture cannot confirm this order belongs to
+      // this invoice. Handing the payer an approval URL we will later refuse to
+      // capture is worse than failing here.
+      console.error('PayPal order binding insert failed:', bindError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to create PayPal order' },
+        { status: 500 }
+      );
+    }
+
+    // Kept in step for the dashboard and for older rows, but it is no longer
+    // what authorises a capture.
     await supabase
       .from('invoices')
       .update({ paypal_order_id: order.orderId, updated_at: new Date().toISOString() })

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -5,6 +5,7 @@ import { isBusinessPaidTier } from '@/lib/entitlements/service';
 import { resolveMerchant } from '@/lib/auth/merchant';
 import { authorizeBusiness, listAccessibleBusinessIds } from '@/lib/auth/authz';
 import { resolvePayee } from '@/lib/payments/payee';
+import { insertWithInvoiceNumber } from '@/lib/invoices/numbering';
 
 /**
  * GET /api/invoices
@@ -233,40 +234,17 @@ export async function POST(request: NextRequest) {
     // Ordering by created_at was also wrong for the lookup — it returns the
     // most RECENTLY CREATED number, which is not the highest once any invoice
     // is deleted or backdated. Ordering by the parsed number is what was meant.
-    const nextInvoiceNumber = async (): Promise<string> => {
-      const { data: rows } = await supabase
-        .from('invoices')
-        .select('invoice_number')
-        .eq('business_id', resolvedBusinessId)
-        .not('invoice_number', 'is', null);
-
-      let highest = 0;
-      for (const row of rows || []) {
-        const match = String(row.invoice_number).match(/INV-(\d+)/);
-        if (match) {
-          const n = parseInt(match[1], 10);
-          if (Number.isFinite(n) && n > highest) highest = n;
-        }
-      }
-      return `INV-${String(highest + 1).padStart(3, '0')}`;
-    };
-
-    let invoiceNumber = await nextInvoiceNumber();
-
     // Determine fee rate
     const isPaidTier = await isBusinessPaidTier(supabase, resolvedBusinessId);
     const feeRate = getFeePercentage(isPaidTier);
 
-    // Insert, retrying on the unique (business_id, invoice_number) violation
-    // that a concurrent create produces. Each retry re-reads the maximum, so
-    // two racing requests end up with consecutive numbers rather than one
-    // silently overwriting the other's.
-    const MAX_NUMBER_ATTEMPTS = 5;
-    let invoice: any = null;
-    let error: { message: string; code?: string } | null = null;
-
-    for (let attempt = 0; attempt < MAX_NUMBER_ATTEMPTS; attempt++) {
-      const result = await supabase
+    // Numbering and the 23505 retry both live in the shared helper now. This
+    // route already had them right; the other three sites did not, and keeping
+    // four copies is how they diverged in the first place.
+    const { data: invoice, error } = await insertWithInvoiceNumber<any>(
+      supabase,
+      resolvedBusinessId,
+      (invoiceNumber) => supabase
         .from('invoices')
         .insert({
           user_id: invoiceOwnerId,
@@ -289,16 +267,8 @@ export async function POST(request: NextRequest) {
           clients (id, name, email, company_name),
           businesses (id, name)
         `)
-        .single();
-
-      invoice = result.data;
-      error = result.error;
-
-      // 23505 = unique_violation. Anything else is a real failure.
-      if (!error || error.code !== '23505') break;
-
-      invoiceNumber = await nextInvoiceNumber();
-    }
+        .single()
+    );
 
     if (error) {
       console.error('Create invoice error:', error);

--- a/src/app/api/lightning/address/route.ts
+++ b/src/app/api/lightning/address/route.ts
@@ -58,14 +58,28 @@ async function ensureLightningAddressBackend(supabase: ReturnType<typeof getSupa
       const fallbackAdmin = process.env.LNBITS_ADMIN_KEY;
       if (!fallbackAdmin) throw error;
 
+      // F-1.3-06: used for this request, never written to the wallet row.
+      //
+      // This is the PLATFORM's LNbits admin key — it controls every wallet on
+      // the instance, not this one. Persisting it into
+      // `wallets.ln_wallet_adminkey` handed that authority to a single user's
+      // record, and four call sites read that column as "this wallet's key":
+      // `POST /api/lightning/payments` passes it straight to `payInvoice`, so
+      // the affected user could pay Lightning invoices out of the platform's
+      // own LNbits balance.
+      //
+      // The fallback exists so a username claim still works when the instance
+      // requires user-token auth for wallet creation, and creating the LNURLp
+      // pay link is all it is needed for. That use is transient and stays.
+      // Nothing is stored, so the wallet keeps no spending authority it did not
+      // earn — it simply has no LNbits wallet of its own yet, which is the
+      // truth.
       adminKey = fallbackAdmin;
 
-      await supabase
-        .from('wallets')
-        .update({
-          ln_wallet_adminkey: encryptLnKey(fallbackAdmin),
-        })
-        .eq('id', walletId);
+      console.warn(
+        `[Lightning] Wallet ${walletId} could not be provisioned on LNbits; using the platform key ` +
+          'for this pay-link creation only. The wallet has no LNbits wallet of its own and cannot send.'
+      );
     }
   };
 

--- a/src/app/api/lightning/lightning-routes.test.ts
+++ b/src/app/api/lightning/lightning-routes.test.ts
@@ -135,8 +135,30 @@ describe('Lightning Route Handlers', () => {
       expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
-    it('should return 400 if mnemonic invalid', async () => {
+    it('no longer asks for the seed, and ignores one that is sent', async () => {
+      // NEW-20: this route used to require a valid BIP-39 mnemonic and reject
+      // the request without one — then never use it. Provisioning creates a
+      // custodial LNbits wallet, so there is no signer and nothing to derive;
+      // the only effect was to make every client transmit the master seed for
+      // the whole wallet. It is accepted and discarded for older clients, so
+      // an invalid one must no longer be a rejection.
       const { POST } = await import('./nodes/route');
+
+      mockChain.maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+      mockSingle.mockResolvedValueOnce({ data: { id: 'w-1', name: 'Test Wallet' }, error: null });
+      mockCreateUserWallet.mockResolvedValue({
+        id: 'lnbits-wallet-1',
+        name: 'Test Wallet',
+        adminkey: 'admin-key-123',
+        inkey: 'invoice-key-456',
+        balance: 0,
+      });
+      mockChain.update = vi.fn().mockReturnValue(mockChain);
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'node-1', status: 'active', wallet_id: 'w-1' },
+        error: null,
+      });
+
       const req = makeRequest('http://localhost:3000/api/lightning/nodes', {
         method: 'POST',
         body: JSON.stringify({ wallet_id: 'w-1', mnemonic: 'bad' }),
@@ -145,8 +167,8 @@ describe('Lightning Route Handlers', () => {
       const res = await POST(req);
       const body = await res.json();
 
-      expect(res.status).toBe(400);
-      expect(body.success).toBe(false);
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
     });
 
     it('should provision node via LNbits on valid input', async () => {

--- a/src/app/api/lightning/nodes/route.ts
+++ b/src/app/api/lightning/nodes/route.ts
@@ -3,7 +3,6 @@ import { NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { walletSuccess, WalletErrors } from '@/lib/web-wallet/response';
 import { createUserWallet, waitForExtensions } from '@/lib/lightning/lnbits';
-import { isValidMnemonic } from '@/lib/web-wallet/keys';
 import { authorizeWalletRequest } from '../wallet-auth';
 
 function getSupabase() {
@@ -61,13 +60,32 @@ export async function POST(request: NextRequest) {
   try {
     const rawBody = await request.text();
     const body = JSON.parse(rawBody);
-    const { wallet_id, business_id, mnemonic } = body;
+    const { wallet_id, business_id } = body;
 
     if (!wallet_id) {
       return WalletErrors.badRequest('VALIDATION_ERROR', 'wallet_id is required');
     }
-    if (!mnemonic || !isValidMnemonic(mnemonic)) {
-      return WalletErrors.badRequest('VALIDATION_ERROR', 'Valid mnemonic is required');
+
+    // NEW-20: this route used to require a valid BIP-39 mnemonic, validate it,
+    // and then never use it. Provisioning is a custodial LNbits wallet — there
+    // is no signer here and nothing to derive — so the only effect was to make
+    // every client transmit the master seed for the whole wallet, over the
+    // wire, into request logs, to buy nothing. The seed reconstructs every key
+    // on every chain; it is the one secret that must never leave the device.
+    //
+    // Callers are already authenticated by `authorizeWalletRequest`, which
+    // verifies a signature over the request body — proof of possession without
+    // disclosure, which is what was wanted in the first place.
+    //
+    // Older SDK builds still send the field. Rejecting them would break
+    // provisioning for anyone who has not upgraded, so it is accepted and
+    // discarded, with a warning naming the wallet so the stragglers are
+    // visible.
+    if (body.mnemonic !== undefined) {
+      console.warn(
+        `[Lightning] POST /nodes received a deprecated 'mnemonic' field for wallet ${wallet_id}; ` +
+          'it is ignored. Upgrade the client — the seed must not be transmitted.'
+      );
     }
 
     const supabase = getSupabase();

--- a/src/app/api/oauth/authorize/route.test.ts
+++ b/src/app/api/oauth/authorize/route.test.ts
@@ -101,11 +101,45 @@ describe('GET /api/oauth/authorize', () => {
     });
     (verifyToken as any).mockImplementation(() => { throw new Error('invalid'); });
 
-    const req = makeRequest('https://coinpay.dev/api/oauth/authorize?response_type=code&client_id=cp_test&redirect_uri=https://example.com/cb&scope=openid');
+    // R4-ID-OAUTH: an authorization request must now carry `state` or PKCE.
+    const req = makeRequest('https://coinpay.dev/api/oauth/authorize?response_type=code&client_id=cp_test&redirect_uri=https://example.com/cb&scope=openid&state=xyz');
     const res = await GET(req);
     expect(res.status).toBe(302);
     const location = res.headers.get('location');
     expect(location).toContain('/login');
+  });
+
+  it('refuses an authorization request bound by neither state nor PKCE', async () => {
+    // R4-ID-OAUTH: the session cookie is sameSite=lax, so it rides along on a
+    // top-level GET navigation. With nothing binding the request to the browser
+    // that started it, a crafted link turns a victim's single click into a
+    // completed authorization they never began — login-CSRF.
+    (validateClient as any).mockResolvedValue({
+      valid: true,
+      client: { client_id: 'cp_test', name: 'Test', redirect_uris: ['https://example.com/cb'] },
+    });
+
+    const req = makeRequest('https://coinpay.dev/api/oauth/authorize?response_type=code&client_id=cp_test&redirect_uri=https://example.com/cb&scope=openid');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('accepts a request bound by PKCE alone', async () => {
+    // Most live clients send PKCE and no state; they must keep working.
+    (validateClient as any).mockResolvedValue({
+      valid: true,
+      client: { client_id: 'cp_test', name: 'Test', redirect_uris: ['https://example.com/cb'] },
+    });
+    (verifyToken as any).mockImplementation(() => { throw new Error('invalid'); });
+
+    const req = makeRequest('https://coinpay.dev/api/oauth/authorize?response_type=code&client_id=cp_test&redirect_uri=https://example.com/cb&scope=openid&code_challenge=abc123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login');
   });
 
   it('should redirect to consent for new client', async () => {

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -110,6 +110,30 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // R4-ID-OAUTH: an authorization request must be bound to the browser that
+  // started it, by `state` or by PKCE.
+  //
+  // Both were optional. The session cookie is `sameSite=lax`, which is sent on
+  // a top-level GET navigation, so an attacker could craft an authorize URL and
+  // have a victim's click complete a flow the victim never began — classic
+  // login-CSRF. `state` defends by binding the callback to the browser that
+  // issued it; `code_challenge` defends by binding the code to a verifier only
+  // the initiating client holds. Either is sufficient. Neither is not.
+  //
+  // Returned as a direct 400 rather than a redirect: with nothing binding the
+  // request there is nothing to safely redirect back to. Most live clients
+  // already send PKCE, so this rejects the unprotected minority, not everybody.
+  if (!state && !codeChallenge) {
+    return NextResponse.json(
+      {
+        error: 'invalid_request',
+        error_description:
+          'Either state or code_challenge (PKCE) is required to bind the authorization request',
+      },
+      { status: 400 }
+    );
+  }
+
   // Validate scopes against BOTH the global whitelist and this client's own
   // registration. Checking only the whitelist let any registered client request
   // every scope the platform defines, regardless of what it was approved for.

--- a/src/app/api/p2p/request/route.test.ts
+++ b/src/app/api/p2p/request/route.test.ts
@@ -90,6 +90,14 @@ function buildStub({ existingBusiness = false }: { existingBusiness?: boolean } 
       }),
       order: vi.fn(() => builder),
       limit: vi.fn(() => builder),
+      // Invoice numbering scans every numbered invoice for the business and
+      // takes the highest parsed value (NEW-F1A-P-01), so the chain now ends
+      // in `.not('invoice_number','is',null)` and is awaited directly.
+      not: vi.fn(() => builder),
+      then: (resolve: any, reject: any) =>
+        Promise.resolve(
+          table === 'invoices' ? { data: [{ invoice_number: 'INV-001' }], error: null } : response
+        ).then(resolve, reject),
       maybeSingle: vi.fn(async () => response),
       single: vi.fn(async () => response),
     };

--- a/src/app/api/p2p/request/route.ts
+++ b/src/app/api/p2p/request/route.ts
@@ -29,6 +29,7 @@ import { createPayment, type Blockchain } from '@/lib/payments/service';
 import { getStripe } from '@/lib/server/optional-deps';
 import { checkRateLimitAsync } from '@/lib/web-wallet/rate-limit';
 import { hashApiKey } from '@/lib/auth/scoped-keys';
+import { insertWithInvoiceNumber } from '@/lib/invoices/numbering';
 
 function getSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -175,21 +176,9 @@ export async function POST(request: NextRequest) {
       ?? (payout.kind === 'crypto' ? payout.cryptocurrency : undefined);
     const merchantWalletAddress = payout.kind === 'crypto' ? payout.address : null;
 
-    // Next invoice number for this business
-    const { data: maxInvoice } = await supabase
-      .from('invoices')
-      .select('invoice_number')
-      .eq('business_id', businessId)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single();
-    let nextNum = 1;
-    if (maxInvoice?.invoice_number) {
-      const match = maxInvoice.invoice_number.match(/INV-(\d+)/);
-      if (match) nextNum = parseInt(match[1], 10) + 1;
-    }
-    const invoiceNumber = `INV-${String(nextNum).padStart(3, '0')}`;
-
+    // Invoice numbering is handled by the shared helper (see the third
+    // instance of this bug, NEW-F1A-P-01): ordering by `created_at` does not
+    // give the highest number, and a concurrent create needs a 23505 retry.
     const isPaidTier = await isBusinessPaidTier(supabase, businessId);
     const feeRate = getFeePercentage(isPaidTier);
     const feeAmount = amount_usd * feeRate;
@@ -197,7 +186,10 @@ export async function POST(request: NextRequest) {
     let paymentAddress: string | null = null;
     let cryptoAmount: number | null = null;
 
-    const { data: invoice, error: insertErr } = await supabase
+    const { data: invoice, error: insertErr } = await insertWithInvoiceNumber<any>(
+      supabase,
+      businessId,
+      (invoiceNumber) => supabase
       .from('invoices')
       .insert({
         user_id: merchantId,
@@ -221,7 +213,8 @@ export async function POST(request: NextRequest) {
         },
       })
       .select('id, invoice_number')
-      .single();
+      .single()
+    );
 
     if (insertErr || !invoice) {
       return NextResponse.json({ success: false, error: insertErr?.message ?? 'Insert failed' }, { status: 500 });

--- a/src/app/api/payouts/create/route.ts
+++ b/src/app/api/payouts/create/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { authenticateRequest, isMerchantAuth, isBusinessAuth } from '@/lib/auth/middleware';
+import { authenticateRequest, isMerchantAuth, isBusinessAuth, hasScope } from '@/lib/auth/middleware';
 import { createPayout } from '@/lib/payouts/service';
 
 /**
@@ -43,6 +43,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
         { status: 401 }
+      );
+    }
+
+    // F-1.1-07: `payouts:create` is offered when a merchant mints a scoped key,
+    // so a merchant can create a key deliberately without it — and this, the
+    // only route the scope governs, never looked. A key restricted to reading
+    // could send money out of the business's wallet. The sibling
+    // /api/payments/create has checked its own scope all along; this is the
+    // asymmetry, not a new control. Legacy keys hold '*' and still pass.
+    if (!hasScope(authResult.context, 'payouts:create')) {
+      return NextResponse.json(
+        { success: false, error: 'API key missing required scope: payouts:create' },
+        { status: 403 }
       );
     }
 

--- a/src/app/api/realtime/payments/route.ts
+++ b/src/app/api/realtime/payments/route.ts
@@ -19,11 +19,37 @@ const connections = new Map<string, Set<ReadableStreamDefaultController>>();
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const businessId = searchParams.get('businessId');
-  const token = searchParams.get('token');
 
-  // Verify authentication
+  // G-1.2-04: the 7-day session JWT used to arrive only as `?token=`.
+  //
+  // A URL is the least private place to put a bearer credential: it lands in
+  // proxy and CDN access logs, in browser history, and in the `Referer` of any
+  // subsequent navigation. Anyone with log access holds week-long sessions for
+  // every merchant who opened a dashboard.
+  //
+  // The usual reason to do it is that `EventSource` cannot set request headers.
+  // It does, however, send cookies on a same-origin request — and this app's
+  // session cookie is already httpOnly — so the credential never has to appear
+  // in the URL at all.
+  //
+  // Order: Authorization header (non-browser clients), then the session cookie
+  // (the browser path), then the query parameter, which is kept only so a page
+  // served from a stale bundle keeps working and is logged when used.
+  const queryToken = searchParams.get('token');
+  const token =
+    extractBearerToken(request.headers.get('authorization')) ||
+    request.cookies.get('token')?.value ||
+    request.cookies.get('session')?.value ||
+    queryToken;
+
   if (!token) {
     return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (queryToken && token === queryToken) {
+    console.warn(
+      '[Realtime] Session token supplied in the query string — deprecated, and it leaks into logs and history. Upgrade the client.'
+    );
   }
 
   let merchantId: string;

--- a/src/app/api/reputation/agent/[did]/reputation/route.ts
+++ b/src/app/api/reputation/agent/[did]/reputation/route.ts
@@ -34,8 +34,12 @@ export async function GET(
         .maybeSingle(),
       supabase
         .from('reputation_credentials')
+        // B-04: the subject column is `agent_did`; `subject_did` belongs to
+        // `mutual_attestations`. The credential count silently came back null
+        // here rather than 500ing, so an agent's reputation page reported zero
+        // credentials however many they held.
         .select('id', { count: 'exact', head: true })
-        .eq('subject_did', agentDid),
+        .eq('agent_did', agentDid),
     ]);
 
     const tier = computeTrustTier(trustProfile.trust_vector);

--- a/src/app/api/reputation/check/route.ts
+++ b/src/app/api/reputation/check/route.ts
@@ -25,25 +25,36 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ verified: false, reason: 'Invalid or missing DID' }, { status: 400 });
     }
 
-    // Check if DID is registered
-    const { data: identity } = await supabase
-      .from('did_identities')
-      .select('did, user_id, created_at, revoked')
+    // L7A-04: this queried `did_identities`, which does not exist — confirmed
+    // against the live schema. PostgREST answers an unknown relation with an
+    // error, `identity` came back undefined, and every DID on the platform was
+    // reported "not registered", including legitimate ones. This endpoint is
+    // documented as the pre-transaction impersonation check, so it was
+    // answering "unverified" to every honest caller.
+    //
+    // The real registry is `merchant_dids`, which the sibling route
+    // /api/reputation/agent/[did]/reputation has been querying all along.
+    const { data: identity, error: identityError } = await supabase
+      .from('merchant_dids')
+      .select('did, merchant_id, created_at, verified')
       .eq('did', did)
-      .single();
+      .maybeSingle();
+
+    if (identityError) {
+      // A lookup failure is not an answer. Reporting `verified: false` on a
+      // database error is what made the original bug invisible: the caller
+      // cannot tell "this DID is not registered" from "we could not check".
+      console.error('[Reputation] DID lookup failed:', identityError);
+      return NextResponse.json(
+        { verified: false, reason: 'Could not verify DID registration', did },
+        { status: 503 }
+      );
+    }
 
     if (!identity) {
       return NextResponse.json({
         verified: false,
         reason: 'DID not registered',
-        did,
-      });
-    }
-
-    if (identity.revoked) {
-      return NextResponse.json({
-        verified: false,
-        reason: 'DID has been revoked',
         did,
       });
     }
@@ -59,6 +70,15 @@ export async function POST(request: NextRequest) {
       verified: true,
       did,
       registered_at: identity.created_at,
+      // The registry's own flag, reported rather than inferred.
+      registration_verified: Boolean(identity.verified),
+      // Said out loud rather than implied. The route used to test a `revoked`
+      // column; neither that column nor any revocation table exists, so DID
+      // revocation is not modelled anywhere in this system. A caller using this
+      // to decide whether to trust a counterparty must know that a compromised
+      // DID cannot currently be turned off — silently dropping the check would
+      // leave them believing it had passed.
+      revocation_checked: false,
       trust: {
         tier: tier.tier,
         score: tier.score,

--- a/src/app/api/reputation/credentials/route.ts
+++ b/src/app/api/reputation/credentials/route.ts
@@ -15,11 +15,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'Valid DID parameter required' }, { status: 400 });
     }
 
+    // B-04: this filtered on `subject_did` and ordered by `created_at`, and
+    // `reputation_credentials` has neither column — it keys the subject as
+    // `agent_did` and timestamps issuance as `issued_at`. PostgREST rejects an
+    // unknown column, so this route returned 500 for every DID ever asked
+    // about, including legitimate ones. Verified against the live schema.
+    //
+    // `subject_did` is a real column, but on `mutual_attestations`, which is
+    // presumably where it was copied from.
     const { data: credentials, error } = await supabase
       .from('reputation_credentials')
       .select('*')
-      .eq('subject_did', did)
-      .order('created_at', { ascending: false });
+      .eq('agent_did', did)
+      .order('issued_at', { ascending: false });
 
     if (error) {
       console.error('Credentials fetch error:', error);

--- a/src/app/api/reputation/did/register/register.test.ts
+++ b/src/app/api/reputation/did/register/register.test.ts
@@ -10,16 +10,22 @@ let mockPlatformAuth: { did: string; name: string } | null = {
 let mockExistingDid: unknown = null;
 let mockMerchant: unknown = null;
 let mockInsertError: unknown = null;
+// Whether the named merchant was provisioned by THIS platform. Null = not ours,
+// which is the case that must register the DID unlinked (L7A-02 / V-02).
+let mockPlatformLink: unknown = null;
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: (table: string) => {
       if (table === 'reputation_issuers') {
+        // Lookup is hash-first now, so the chain must terminate at
+        // `maybeSingle` as well as `single`.
         return {
           select: () => ({
             eq: () => ({
               eq: () => ({
                 single: () => Promise.resolve({ data: mockPlatformAuth, error: null }),
+                maybeSingle: () => Promise.resolve({ data: mockPlatformAuth, error: null }),
               }),
             }),
           }),
@@ -40,6 +46,21 @@ vi.mock('@supabase/supabase-js', () => ({
           select: () => ({
             eq: () => ({
               maybeSingle: () => Promise.resolve({ data: mockMerchant, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'businesses') {
+        // platformMayManageMerchant: is this merchant one THIS platform
+        // provisioned? Null means no, so the DID registers unlinked.
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: () => ({
+                  maybeSingle: () => Promise.resolve({ data: mockPlatformLink, error: null }),
+                }),
+              }),
             }),
           }),
         };
@@ -73,6 +94,7 @@ describe('POST /api/reputation/did/register', () => {
     mockExistingDid = null;
     mockMerchant = null;
     mockInsertError = null;
+    mockPlatformLink = null;
   });
 
   it('returns 401 with invalid API key', async () => {
@@ -113,13 +135,31 @@ describe('POST /api/reputation/did/register', () => {
     expect(json.registered).toBe(true);
   });
 
-  it('links merchant_id when email matches existing merchant', async () => {
-    mockMerchant = { id: 'merchant-456' };
+  it('does NOT link a merchant this platform did not provision', async () => {
+    // L7A-02 / V-02 / REP-F1A-02: an email match alone used to bind an
+    // arbitrary DID to that account with verified:true, letting a caller plant
+    // a hostile DID on a victim — ideally before the victim claimed their own,
+    // since the first registration wins. The DID still registers, unlinked.
+    mockMerchant = { id: 'merchant-456', auth_provider: 'self' };
+    mockPlatformLink = null;
     const { POST } = await import('./route');
     const res = await POST(
       makeRequest({
         did: 'did:key:z6MkLinked',
         email: 'merchant@test.com',
+      })
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it('links a merchant this platform did provision', async () => {
+    mockMerchant = { id: 'merchant-456', auth_provider: 'platform' };
+    mockPlatformLink = { id: 'biz-1' };
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({
+        did: 'did:key:z6MkOurUser',
+        email: 'ourusr@test.com',
       })
     );
     expect(res.status).toBe(201);

--- a/src/app/api/reputation/did/register/route.ts
+++ b/src/app/api/reputation/did/register/route.ts
@@ -13,6 +13,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { platformMayManageMerchant } from '@/lib/p2p/platform-ownership';
+import { hashApiKey } from '@/lib/auth/scoped-keys';
 import { createClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 
@@ -42,12 +44,23 @@ async function authenticatePlatform(
   if (!authHeader?.startsWith('Bearer ')) return null;
   const apiKey = authHeader.slice(7);
 
+  // Hash first, cleartext as a draining fallback — same contract as the other
+  // issuer-authenticated routes.
+  const { data: byHash } = await supabase
+    .from('reputation_issuers')
+    .select('did, name')
+    .eq('api_key_hash', hashApiKey(apiKey))
+    .eq('active', true)
+    .maybeSingle();
+
+  if (byHash) return byHash;
+
   const { data } = await supabase
     .from('reputation_issuers')
     .select('did, name')
     .eq('api_key', apiKey)
     .eq('active', true)
-    .single();
+    .maybeSingle();
 
   return data;
 }
@@ -83,8 +96,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ did, registered: false, message: 'DID already registered' });
     }
 
-    // Register the DID in merchant_dids (without merchant_id — platform-managed DID)
-    // If email is provided, check if a merchant already exists and link them
+    // Link by email ONLY to an account this platform provisioned.
+    //
+    // L7A-02 / V-02 / REP-F1A-02 are one mechanism: this looked a merchant up by
+    // email and bound an arbitrary DID to them with `verified: true`, on nothing
+    // but a valid issuer key. No proof of possession of the DID, and none of the
+    // email. That let a caller plant a hostile DID on a victim's account —
+    // ideally *before* the victim claimed their own, since the `existing` check
+    // above makes the first registration win and blocks the legitimate claim.
+    //
+    // A DID that cannot be linked is still registered, just unbound: it is
+    // usable for reputation on its own, and binding it to a real account is a
+    // decision only that account can make (via the authenticated `did/claim`).
     let merchantId: string | null = null;
     if (email) {
       const { data: merchant } = await supabase
@@ -92,8 +115,17 @@ export async function POST(request: NextRequest) {
         .select('id')
         .eq('email', email.toLowerCase())
         .maybeSingle();
+
       if (merchant) {
-        merchantId = merchant.id;
+        const owns = await platformMayManageMerchant(supabase, platform.name, merchant.id);
+        if (owns.ok) {
+          merchantId = merchant.id;
+        } else {
+          console.warn(
+            `[DID Register] ${platform.name} named ${email.toLowerCase()} — registering ${did} unlinked: ` +
+            owns.error
+          );
+        }
       }
     }
 
@@ -105,7 +137,10 @@ export async function POST(request: NextRequest) {
         platform: platformName || platform.name,
         email: email?.toLowerCase() || null,
         merchant_id: merchantId,
-        verified: true,
+        // `verified` means proof of possession, and nothing here proves any.
+        // It was set true unconditionally, so a planted DID looked exactly like
+        // one the account holder had actually proven control of.
+        verified: false,
       });
 
     if (insertError) {

--- a/src/app/api/stripe/disputes/route.ts
+++ b/src/app/api/stripe/disputes/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId, 'billing.manage');
 
     // Get query parameters for filtering and pagination
     const { searchParams } = new URL(request.url);

--- a/src/app/api/stripe/payouts/route.ts
+++ b/src/app/api/stripe/payouts/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId, 'billing.manage');
 
     // Get query parameters for filtering and pagination
     const { searchParams } = new URL(request.url);

--- a/src/app/api/stripe/subscriptions/route.ts
+++ b/src/app/api/stripe/subscriptions/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     const supabase = createClient(supabaseUrl, supabaseKey);
 
     // Team-aware: subscriptions of every business the caller can access.
-    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId);
+    const ownerMerchantIds = await listAccessibleOwnerMerchantIds(supabase, merchantId, 'billing.manage');
 
     let query = supabase
       .from('subscriptions')

--- a/src/app/api/stripe/transactions/[id]/refund/route.ts
+++ b/src/app/api/stripe/transactions/[id]/refund/route.ts
@@ -124,13 +124,32 @@ export async function POST(
     // Block refunds on charges with an open dispute — Stripe rejects these, and
     // the correct action is to accept/contest the dispute.
     if (transaction.stripe_charge_id) {
-      const { data: dispute } = await supabase
+      const { data: dispute, error: disputeError } = await supabase
         .from('stripe_disputes')
         .select('status')
         .eq('stripe_charge_id', transaction.stripe_charge_id)
         .order('created_at', { ascending: false })
         .limit(1)
         .maybeSingle();
+
+      // W-08: the error was discarded, so `dispute` came back null on any query
+      // failure and the guard concluded "no dispute" — the exact opposite of
+      // what a failed check means. A refund would then be attempted on a
+      // disputed charge, which Stripe rejects, and which is the wrong action
+      // anyway: the dispute should be accepted or contested.
+      //
+      // "Could not check" is not "nothing to find".
+      if (disputeError) {
+        console.error('[Stripe] Dispute lookup failed; refusing to refund:', disputeError);
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'Could not verify whether this charge is disputed. Please try again.',
+          },
+          { status: 503 }
+        );
+      }
+
       if (dispute && OPEN_DISPUTE_STATUSES.has(String(dispute.status))) {
         return NextResponse.json(
           {

--- a/src/app/api/stripe/webhook/checkout-session.test.ts
+++ b/src/app/api/stripe/webhook/checkout-session.test.ts
@@ -45,6 +45,15 @@ import { POST } from './route';
 
 function setupMockChain(overrides: Record<string, any> = {}) {
   const defaults: Record<string, any> = {
+    // INV-01: the handler claims `event.id` in stripe_webhook_events before
+    // dispatching, so a redelivery is recognised as a duplicate instead of
+    // re-running money-shaped handlers. A fresh insert succeeds.
+    stripe_webhook_events: {
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    },
     payments: {
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -39,6 +39,15 @@ import { POST } from './route';
 
 function mockFromChain(overrides: Record<string, any> = {}) {
   const defaults: Record<string, any> = {
+    // INV-01: the handler claims `event.id` in stripe_webhook_events before
+    // dispatching, so a redelivery is recognised as a duplicate instead of
+    // re-running money-shaped handlers. A fresh insert succeeds.
+    stripe_webhook_events: {
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    },
     stripe_transactions: {
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -87,6 +87,36 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Webhook signature verification failed' }, { status: 400 });
     }
 
+    // INV-01: claim the event before doing anything with it.
+    //
+    // The handler dispatched on `event.type` and never looked at `event.id`.
+    // Stripe redelivers whenever the endpoint times out or answers non-2xx, and
+    // may send duplicates regardless — so every handler below was re-runnable
+    // by a retry this platform does not control. `charge.refunded` and
+    // `payment_intent.succeeded` both write money-shaped records.
+    //
+    // The primary key does the work: a conflicting insert means someone already
+    // took this event, so we acknowledge and stop. Note this is also the reason
+    // the webhook must answer 200 rather than 409 — a non-2xx would ask Stripe
+    // to retry the very delivery we just declined as a duplicate.
+    const { error: claimError } = await supabase
+      .from('stripe_webhook_events')
+      .insert({ event_id: event.id, event_type: event.type });
+
+    if (claimError) {
+      // 23505 is the unique violation: already processed, nothing to do.
+      if ((claimError as { code?: string }).code === '23505') {
+        console.log(`[Stripe Webhook] Duplicate delivery of ${event.id} (${event.type}) — ignoring`);
+        return NextResponse.json({ received: true, duplicate: true });
+      }
+      // Any other failure means we cannot tell whether this is a duplicate.
+      // Processing anyway risks double-recording money; a non-2xx asks Stripe
+      // to retry, which is the recoverable direction.
+      console.error('[Stripe Webhook] Could not record event id; refusing to process:', claimError);
+      return NextResponse.json({ error: 'Could not verify event uniqueness' }, { status: 503 });
+    }
+
+    try {
     // Handle the event
     switch (event.type) {
       case 'payment_intent.succeeded':
@@ -128,6 +158,28 @@ export async function POST(request: NextRequest) {
 
       default:
         console.log(`Unhandled event type: ${event.type}`);
+    }
+    } catch (handlerError) {
+      // Release the claim so Stripe's retry can actually retry.
+      //
+      // Without this, a handler that threw would leave the event recorded as
+      // taken, and the redelivery would be dismissed as a duplicate — turning a
+      // transient failure into a permanently dropped event, which is a worse
+      // failure than the double-processing the claim exists to prevent.
+      const { error: releaseError } = await supabase
+        .from('stripe_webhook_events')
+        .delete()
+        .eq('event_id', event.id);
+
+      if (releaseError) {
+        console.error(
+          `[Stripe Webhook] Handler for ${event.id} failed AND the claim could not be released — ` +
+            'this event will not be reprocessed on retry:',
+          releaseError
+        );
+      }
+
+      throw handlerError;
     }
 
     return NextResponse.json({ received: true });

--- a/src/app/api/subscriptions/checkout/route.test.ts
+++ b/src/app/api/subscriptions/checkout/route.test.ts
@@ -5,7 +5,24 @@ import { authenticateRequest } from '@/lib/auth/middleware';
 import { createSubscriptionPayment } from '@/lib/subscriptions/service';
 
 vi.mock('@supabase/supabase-js', () => ({
-  createClient: vi.fn(() => ({ from: vi.fn() })),
+  // SUB-02: the route now counts a merchant's unpaid checkouts before creating
+  // another, so `from()` has to answer a head-count query.
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => {
+      const chain: any = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        then: (resolve: any) => resolve({ count: 0, error: null }),
+      };
+      return chain;
+    }),
+  })),
+}));
+
+// The per-merchant budget on subscription checkouts (SUB-02). Allowed here so
+// these tests keep exercising the checkout path rather than the limiter.
+vi.mock('@/lib/web-wallet/rate-limit', () => ({
+  checkRateLimitAsync: vi.fn().mockResolvedValue({ allowed: true, resetAt: 0, limit: 10 }),
 }));
 
 vi.mock('@/lib/auth/middleware', () => ({

--- a/src/app/api/subscriptions/checkout/route.ts
+++ b/src/app/api/subscriptions/checkout/route.ts
@@ -8,6 +8,16 @@ import {
   type BillingPeriod,
   type SupportedBlockchain,
 } from '@/lib/subscriptions/service';
+import { checkRateLimitAsync } from '@/lib/web-wallet/rate-limit';
+
+/**
+ * Unpaid subscription checkouts one merchant may hold at once.
+ *
+ * A merchant legitimately abandons a checkout and starts another — switching
+ * chain, or changing their mind on billing period — so this is generous. It
+ * exists to stop unbounded accumulation, not to police normal indecision.
+ */
+const MAX_PENDING_SUBSCRIPTION_CHECKOUTS = 10;
 
 /**
  * POST /api/subscriptions/checkout
@@ -94,6 +104,49 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: 'Unable to determine price for selected plan' },
         { status: 400 }
+      );
+    }
+
+    // SUB-02: bound how many of these one merchant can have open.
+    //
+    // The route was authenticated but otherwise unbounded, and every call
+    // derives an HD address, encrypts its private key and writes a
+    // `business_collection_payments` row. A merchant looping it accumulates
+    // rows and encrypted key material without limit and burns derivation
+    // indexes that are never reclaimed — none of which needs an attacker, just
+    // a retry loop in a client.
+    //
+    // Two bounds, because they catch different things: the rate limit stops a
+    // burst, and the pending cap stops a slow accumulation that would never
+    // trip a rate limit at all.
+    const rate = await checkRateLimitAsync(merchantId, 'subscription_checkout');
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { success: false, error: 'Too many subscription checkouts. Please try again shortly.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.max(1, rate.resetAt - Math.floor(Date.now() / 1000))) },
+        }
+      );
+    }
+
+    const { count: pendingCount, error: pendingError } = await supabase
+      .from('business_collection_payments')
+      .select('id', { count: 'exact', head: true })
+      .eq('merchant_id', merchantId)
+      .eq('status', 'pending');
+
+    if (pendingError) {
+      console.error('[Subscriptions] Could not count pending checkouts:', pendingError);
+    } else if ((pendingCount ?? 0) >= MAX_PENDING_SUBSCRIPTION_CHECKOUTS) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            `You already have ${pendingCount} unpaid subscription checkouts. ` +
+            'Complete or let one expire before starting another.',
+        },
+        { status: 409 }
       );
     }
 

--- a/src/app/api/swap/boltz/route.ts
+++ b/src/app/api/swap/boltz/route.ts
@@ -85,7 +85,33 @@ export async function POST(request: NextRequest) {
             refundPrivateKey: swap.refundPrivateKey,
           }),
         });
-        if (dbError) console.error('[Boltz] DB save failed:', dbError);
+        // A-05: this used to log and answer `success: true`.
+        //
+        // `refundPrivateKey` is the only thing that can reclaim the funds if the
+        // swap fails, and this row is the only place the platform keeps it. A
+        // failed insert therefore left a live Boltz swap whose refund key exists
+        // nowhere on our side — and told the user everything was fine, so they
+        // went ahead and deposited against it.
+        //
+        // The swap cannot be un-created at Boltz, so the honest answer is not a
+        // bare 500 either: that loses the key just as completely. The key is
+        // returned so the caller can save it — it is already in the `swap`
+        // object on the success path, so this exposes nothing new to the same
+        // authenticated caller — and the status code stops the client from
+        // treating this as a normal creation.
+        if (dbError) {
+          console.error('[Boltz] DB save failed — swap-in is live but untracked:', dbError);
+          return NextResponse.json(
+            {
+              success: false,
+              tracked: false,
+              error:
+                'The swap was created at Boltz but could not be recorded. SAVE THE REFUND KEY BELOW before depositing — it is the only way to reclaim your funds if the swap fails, and we were unable to store a copy.',
+              swap,
+            },
+            { status: 500 }
+          );
+        }
       }
 
       return NextResponse.json({ success: true, swap });
@@ -116,7 +142,22 @@ export async function POST(request: NextRequest) {
             claimPrivateKey: swap.claimPrivateKey,
           }),
         });
-        if (dbError) console.error('[Boltz] DB save failed:', dbError);
+        // A-05, reverse direction. `claimPrivateKey` is the only thing that can
+        // claim the on-chain side of a swap-out; losing it strands the funds in
+        // the lockup with no way to redeem them. Same reasoning as swap-in.
+        if (dbError) {
+          console.error('[Boltz] DB save failed — swap-out is live but untracked:', dbError);
+          return NextResponse.json(
+            {
+              success: false,
+              tracked: false,
+              error:
+                'The swap was created at Boltz but could not be recorded. SAVE THE CLAIM KEY BELOW — it is the only way to claim the on-chain funds, and we were unable to store a copy.',
+              swap,
+            },
+            { status: 500 }
+          );
+        }
       }
 
       return NextResponse.json({ success: true, swap });

--- a/src/app/api/swap/create/route.ts
+++ b/src/app/api/swap/create/route.ts
@@ -141,13 +141,29 @@ export async function POST(request: NextRequest) {
         },
       });
 
+    // F-1.3-08: the write error was logged and the response still said
+    // `success: true` with nothing to distinguish it, so a live ChangeNOW swap
+    // with no platform row looked identical to a healthy one. Nothing
+    // downstream could tell, and the swap simply never appeared in history.
+    //
+    // Unlike the Boltz routes there is no key to lose here — the deposit
+    // address in this response is all the user needs to proceed — so failing
+    // the request outright would be worse than useless: it would stop a
+    // perfectly usable swap. The swap is reported, and reported as untracked,
+    // which is the part that was missing.
     if (dbError) {
-      console.error('[Swap] DB save failed (swap still created):', dbError);
-      // Don't fail the request - swap was created successfully
+      console.error('[Swap] DB save failed — swap is live at ChangeNOW but untracked:', dbError);
     }
 
     return NextResponse.json({
       success: true,
+      tracked: !dbError,
+      ...(dbError
+        ? {
+            warning:
+              'This swap was created but could not be recorded, so it will not appear in your swap history. Save the deposit address.',
+          }
+        : {}),
       swap: {
         id: swap.id,
         from: fromUpper,

--- a/src/app/api/x402/verify/route.test.ts
+++ b/src/app/api/x402/verify/route.test.ts
@@ -792,6 +792,30 @@ describe('POST /api/x402/verify — audit regressions', () => {
     expect((await res.json()).error).toMatch(/asset mismatch/i);
   });
 
+  it('rejects an invented asset even when the merchant named none (F-1.3-03)', async () => {
+    // The gap the asset check left open: it only ran when `expected.asset` was
+    // set, so a price with no asset stated was satisfied by a proof denominated
+    // in any token at all. The payer picks that token — 1000 units of something
+    // they minted this morning costs nothing.
+    const { asset: _dropped, ...expectationWithoutAsset } = lightningExpectation as Record<string, unknown>;
+
+    const res = await POST(
+      makeRequest({
+        payment: lightningPayment({ asset: 'WORTHLESSCOIN' }),
+        expected: expectationWithoutAsset,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/asset mismatch/i);
+  });
+
+  // The accepting side of the allow-list is already covered: six tests in this
+  // file pay in real USDC with `expected.asset` unset and still pass, which is
+  // exactly the "merchant named none, asset is recognised" case. A Lightning
+  // fixture for it would need a matching ln_payments row and would be testing
+  // the settlement proof rather than the asset rule.
+
   it('rejects a Stripe proof whose PaymentIntent charged less than the price', async () => {
     process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
     // A real, succeeded, one-cent PaymentIntent — presented for a $50 resource.

--- a/src/app/api/x402/verify/route.ts
+++ b/src/app/api/x402/verify/route.ts
@@ -392,12 +392,36 @@ function enforcePriceBinding(payment: any, expected: any) {
   // What it was paid in. Optional, because a native-currency price has no asset
   // contract to name — but when the merchant does state one, a proof denominated
   // in some other (possibly worthless) token must not satisfy the price.
+  const paidAsset = payment.payload.asset || payment.payload.extra?.assetSymbol;
+
   if (expectedAsset) {
-    const paidAsset = payment.payload.asset || payment.payload.extra?.assetSymbol;
     if (String(paidAsset ?? '').toLowerCase() !== String(expectedAsset).toLowerCase()) {
       return {
         ok: false,
         error: `Asset mismatch: proof is denominated in ${paidAsset || '(none)'}, not ${expectedAsset}`,
+      };
+    }
+  } else {
+    // F-1.3-03: an unnamed asset must not mean "any asset will do".
+    //
+    // The check above only ran when the merchant named an asset, so a price
+    // with none stated was satisfied by a proof denominated in an arbitrary
+    // token. The payer chooses that token, and 1000 units of something they
+    // minted this morning costs nothing.
+    //
+    // Rejecting everything unnamed would break the integrations that quote a
+    // price and let the well-known stablecoin for the network be inferred, so
+    // the fallback is an allow-list rather than a refusal: native currency, or
+    // one of the stablecoins the platform itself settles. An invented token is
+    // in neither set.
+    const isNative = !paidAsset || String(paidAsset).toLowerCase() === ZERO_ADDRESS.toLowerCase();
+
+    if (!isNative && !isKnownSettlementAsset(paidAsset)) {
+      return {
+        ok: false,
+        error:
+          `Asset mismatch: the proof is denominated in ${paidAsset}, which is not a recognised ` +
+          'settlement asset. Name the asset in the payment requirements to accept it.',
       };
     }
   }
@@ -405,6 +429,37 @@ function enforcePriceBinding(payment: any, expected: any) {
   return { ok: true as const };
 }
 
+
+/**
+ * Assets this platform actually settles.
+ *
+ * F-1.3-03: used as the fallback when payment requirements name no asset, so an
+ * unnamed price still cannot be satisfied by a token the payer invented. These
+ * are the same contracts `secure-forwarding` knows how to move, by address and
+ * by symbol, matched case-insensitively.
+ */
+const KNOWN_SETTLEMENT_ASSETS = new Set(
+  [
+    // EVM stablecoins
+    '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT / USDT_ETH
+    '0xc2132D05D31c914a87C6611C10748AEb04B58e8F', // USDT_POL
+    '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC / USDC_ETH
+    '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359', // USDC_POL
+    '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC_BASE
+    // Solana mints
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', // USDT_SOL
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC_SOL
+    // Symbols, for rails that name an asset rather than an address.
+    'USDC',
+    'USDT',
+    'BTC',
+    'SATS',
+  ].map((a) => a.toLowerCase()),
+);
+
+function isKnownSettlementAsset(asset: unknown): boolean {
+  return KNOWN_SETTLEMENT_ASSETS.has(String(asset ?? '').toLowerCase());
+}
 
 /**
  * Store an audit copy of a payment proof WITHOUT the signature.

--- a/src/app/cli-auth/page.tsx
+++ b/src/app/cli-auth/page.tsx
@@ -1,25 +1,34 @@
 'use client';
 
 import { Suspense, useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 function CliAuthContent() {
-  const searchParams = useSearchParams();
-  const initialCode = (searchParams.get('code') || '').trim().toUpperCase();
-
-  const [code, setCode] = useState(initialCode);
+  // G-1.2-10: `?code=` is deliberately NOT read.
+  //
+  // Anyone could start a device authorization — it is unauthenticated by
+  // necessity, the CLI has no credential yet — and get a link that pre-filled
+  // this form. Sent to a signed-in merchant, one click handed the *attacker's*
+  // terminal a 7-day session JWT for the victim's account: full takeover, one
+  // click, and the attacker also chose the client name shown below.
+  //
+  // The merchant must type the code their own terminal printed. An attacker can
+  // still send someone here, but cannot make the victim's screen show the
+  // attacker's code.
+  const [code, setCode] = useState('');
   const [clientName, setClientName] = useState<string | null>(null);
   const [needsLogin, setNeedsLogin] = useState(false);
   const [reqStatus, setReqStatus] = useState<string>('');
   const [state, setState] = useState<'idle' | 'working' | 'approved' | 'denied' | 'error'>('idle');
   const [message, setMessage] = useState('');
 
-  // On load, look up the request (this also tells us if we're signed in).
+  // Look the request up once the typed code is complete. This also tells us
+  // whether the visitor is signed in.
+  const lookupCode = code.trim().toUpperCase();
   useEffect(() => {
-    if (!initialCode) return;
+    if (lookupCode.replace('-', '').length < 8) return;
     (async () => {
       try {
-        const res = await fetch(`/api/cli-auth/approve?code=${encodeURIComponent(initialCode)}`);
+        const res = await fetch(`/api/cli-auth/approve?code=${encodeURIComponent(lookupCode)}`);
         if (res.status === 401) {
           setNeedsLogin(true);
           return;
@@ -33,7 +42,7 @@ function CliAuthContent() {
         /* ignore — user can still submit */
       }
     })();
-  }, [initialCode]);
+  }, [lookupCode]);
 
   async function submit(action: 'approve' | 'deny') {
     const c = code.trim().toUpperCase();
@@ -68,7 +77,9 @@ function CliAuthContent() {
   }
 
   const card = 'bg-slate-800 rounded-lg shadow-lg p-8';
-  const loginHref = `/login?redirect=${encodeURIComponent(`/cli-auth?code=${code || initialCode}`)}`;
+  // No code in the redirect: it would survive the login round-trip and
+  // re-create the pre-filled form this fix removes.
+  const loginHref = `/login?redirect=${encodeURIComponent('/cli-auth')}`;
 
   return (
     <div className="min-h-[calc(100vh-200px)] flex items-center justify-center px-4 py-12">
@@ -101,9 +112,22 @@ function CliAuthContent() {
           ) : (
             <>
               <p className="text-slate-300">
-                A command-line client
-                {clientName ? ` on “${clientName}”` : ''} is asking to sign in to your CoinPay account.
+                A command-line client is asking to sign in to your CoinPay account.
               </p>
+
+              {/*
+                `client_name` is chosen by whoever started the request, so it is
+                a claim and not an identity — an attacker picks it as freely as
+                the real client does. Shown, because it helps a user recognise
+                their own machine, but labelled so it cannot be read as
+                verified by us.
+              */}
+              {clientName && (
+                <p className="mt-2 text-sm text-slate-400">
+                  It calls itself <span className="font-mono text-slate-300">“{clientName}”</span>{' '}
+                  <span className="text-slate-500">(self-reported, not verified)</span>.
+                </p>
+              )}
 
               {reqStatus === 'expired' && (
                 <p className="mt-3 rounded border border-red-700 bg-red-900/50 p-3 text-sm text-red-200">
@@ -147,7 +171,10 @@ function CliAuthContent() {
               </div>
 
               <p className="mt-4 text-xs text-slate-500">
-                Only approve this if you just ran <code>coinpay login</code> yourself.
+                Only approve this if you just ran <code>coinpay login</code> yourself, and
+                the code above matches the one in your own terminal. Never enter a
+                code someone else sent you — approving gives that person full
+                access to your account.
               </p>
             </>
           )}

--- a/src/app/docs/sdk/page.tsx
+++ b/src/app/docs/sdk/page.tsx
@@ -1280,9 +1280,10 @@ coinpay oauth delete <client-id>`}
             <h3 className="text-xl font-semibold text-white mb-4">Enable Lightning</h3>
             <CodeBlock title="Provision a Lightning wallet" language="javascript">
 {`// Enable Lightning for a wallet (provisions LNbits custodial wallet)
+// No mnemonic: the wallet is custodial, so nothing is derived or signed
+// here. Never send your seed phrase to an API.
 const result = await client.lightning.enableWallet({
   wallet_id: 'your-wallet-uuid',
-  mnemonic: 'your bip39 mnemonic words...',
 });
 
 console.log('Lightning enabled!', result);`}

--- a/src/app/web-wallet/asset/[chain]/page.tsx
+++ b/src/app/web-wallet/asset/[chain]/page.tsx
@@ -210,7 +210,6 @@ function LightningAssetView() {
         {!lnNode ? (
           <LightningSetup
             walletId={wallet?.walletId || ''}
-            mnemonic={wallet?.getMnemonic() || ''}
             onSetupComplete={(node) => setLnNode(node)}
           />
         ) : (

--- a/src/components/lightning/LightningSetup.tsx
+++ b/src/components/lightning/LightningSetup.tsx
@@ -7,7 +7,6 @@ import { useWebWallet } from '@/components/web-wallet/WalletContext';
 interface LightningSetupProps {
   walletId: string;
   businessId?: string;
-  mnemonic: string;
   onSetupComplete?: (node: LnNode) => void;
 }
 
@@ -18,7 +17,6 @@ interface LightningSetupProps {
 export function LightningSetup({
   walletId,
   businessId,
-  mnemonic,
   onSetupComplete,
 }: LightningSetupProps) {
   const { wallet } = useWebWallet();
@@ -32,7 +30,10 @@ export function LightningSetup({
 
     try {
       if (!wallet || wallet.walletId !== walletId) throw new Error('Wallet is locked');
-      const nextNode = await wallet.enableLightning(mnemonic, businessId);
+      // NEW-20: this took the seed phrase as a prop and posted it to the
+      // server, which validated it and discarded it. The provisioned wallet is
+      // custodial — nothing is derived here — so the prop is gone.
+      const nextNode = await wallet.enableLightning(undefined, businessId);
       setNode(nextNode as LnNode);
       onSetupComplete?.(nextNode as LnNode);
     } catch (err) {

--- a/src/components/lightning/__tests__/LightningSetup.test.tsx
+++ b/src/components/lightning/__tests__/LightningSetup.test.tsx
@@ -26,7 +26,6 @@ describe('LightningSetup', () => {
   const defaultProps = {
     walletId: 'w-1',
     businessId: 'b-1',
-    mnemonic: 'test mnemonic phrase',
   };
 
   it('should render the enable lightning button', () => {
@@ -112,7 +111,10 @@ describe('LightningSetup', () => {
     fireEvent.click(screen.getByText('Enable Lightning ⚡'));
 
     await waitFor(() => {
-      expect(mockEnableLightning).toHaveBeenCalledWith('test mnemonic phrase', 'b-1');
+      // NEW-20: the seed must not be passed. Asserting on `undefined` here is
+      // the regression guard — if a mnemonic is ever threaded back through,
+      // this fails.
+      expect(mockEnableLightning).toHaveBeenCalledWith(undefined, 'b-1');
     });
   });
 });

--- a/src/lib/auth/authz.ts
+++ b/src/lib/auth/authz.ts
@@ -206,11 +206,31 @@ export async function listAccessibleBusinessIds(
 export async function listAccessibleOwnerMerchantIds(
   supabase: SupabaseClient,
   userId: string,
+  capability: Capability,
 ): Promise<string[]> {
-  const ids = await listAccessibleBusinessIds(supabase, userId);
+  // `capability` is REQUIRED, and that is the fix for G-1.2-02.
+  //
+  // This used to widen from "businesses I can see" to "the merchant accounts
+  // that own them", with no capability check at all. Membership of one business
+  // at `readonly` therefore returned that owner's merchant id — and the callers
+  // query `stripe_payouts` / `stripe_disputes` / `subscriptions` by
+  // `.in('merchant_id', …)`, so the member read payout, dispute and
+  // subscription data for EVERY business that owner has, including ones they
+  // have no access to at all.
+  //
+  // Those Stripe tables are keyed only by `merchant_id` — there is no
+  // `business_id` to scope by — so tighter row filtering is not available. The
+  // control that is available is who may ask, and the answer is not `readonly`.
+  const roles = await getAccessibleBusinessRoles(supabase, userId);
+  const permitted = [...roles.entries()]
+    .filter(([, role]) => can(role, capability))
+    .map(([businessId]) => businessId);
+
+  // The caller always counts as an owner of their own merchant account.
   const owners = new Set<string>([userId]);
-  if (ids.length > 0) {
-    const { data } = await supabase.from('businesses').select('merchant_id').in('id', ids);
+
+  if (permitted.length > 0) {
+    const { data } = await supabase.from('businesses').select('merchant_id').in('id', permitted);
     for (const b of (data ?? []) as { merchant_id: string | null }[]) {
       if (b.merchant_id) owners.add(b.merchant_id);
     }

--- a/src/lib/auth/service.test.ts
+++ b/src/lib/auth/service.test.ts
@@ -120,7 +120,15 @@ describe('Auth Service', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('already');
+
+      // R3-ID-02: the message used to be "Email already exists", which told any
+      // unauthenticated caller whether an address belonged to a merchant —
+      // enumerable across the whole base, and exactly the input the email-keyed
+      // payout and DID-binding attacks needed. It is now identical to the
+      // route's other rejection paths.
+      expect(result.error).not.toContain('already');
+      expect(result.error).not.toContain('exists');
+      expect(result.error).toBe('Registration failed. Please try again later.');
     });
 
     it('should reject weak passwords', async () => {

--- a/src/lib/auth/service.ts
+++ b/src/lib/auth/service.ts
@@ -80,7 +80,15 @@ export async function register(
       };
     }
 
-    // Check if email already exists
+    // R3-ID-02: hash BEFORE the existence check, deliberately.
+    //
+    // The check used to come first and return immediately, so a registered
+    // address answered in milliseconds while an unregistered one paid for a
+    // bcrypt hash. That timing difference is an enumeration oracle on its own,
+    // and would survive any amount of care over the wording below. Hashing
+    // first makes both paths do the same work.
+    const passwordHash = await hashPassword(input.password);
+
     const { data: existingMerchant } = await supabase
       .from('merchants')
       .select('id')
@@ -88,14 +96,22 @@ export async function register(
       .single();
 
     if (existingMerchant) {
+      // The message is deliberately generic and identical to the route's other
+      // rejection paths. "Email already exists" told any unauthenticated caller
+      // whether an address belonged to a merchant, enumerable across the whole
+      // base — and an address confirmed this way is exactly the input the
+      // email-keyed payout and DID-binding attacks needed.
+      //
+      // The cost is that someone who has forgotten they have an account is sent
+      // to "try again" rather than "you already have one". Sign-in and password
+      // reset are where that belongs; neither can be made to confirm an address
+      // without the same leak.
+      console.info(`[Auth] Registration attempted for an address that already exists`);
       return {
         success: false,
-        error: 'Email already exists',
+        error: 'Registration failed. Please try again later.',
       };
     }
-
-    // Hash password
-    const passwordHash = await hashPassword(input.password);
 
     // Insert new merchant
     const { data: merchant, error } = await supabase

--- a/src/lib/blockchain/derivation-index.test.ts
+++ b/src/lib/blockchain/derivation-index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { hashStringToNumber } from './wallets';
+
+/**
+ * Regression tests for F-1.3-14 (2026-08-19 audit).
+ *
+ * The collection derivation index was a 32-bit string fold reduced modulo 10^6,
+ * and the addresses it derives hold customer money. A million slots means two
+ * different payments share an index — and therefore an address and a private
+ * key — with about even odds by the 1,180th one. When that happens one
+ * payment's funds land at another's address: the balance check confirms the
+ * wrong payment and the sweep sends the money to the wrong destination.
+ *
+ * No attacker is involved. It is the birthday bound.
+ */
+describe('hashStringToNumber', () => {
+  it('stays inside the non-hardened BIP32 range', () => {
+    for (const s of ['collection_abc', '', 'x'.repeat(500), 'collection_0']) {
+      const n = hashStringToNumber(s);
+      expect(Number.isInteger(n)).toBe(true);
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThan(0x7fffffff);
+    }
+  });
+
+  it('is deterministic', () => {
+    expect(hashStringToNumber('collection_abc')).toBe(hashStringToNumber('collection_abc'));
+  });
+
+  it('uses far more than the old million slots', () => {
+    // The old implementation could not return anything at or above 1e6, so a
+    // value above it is direct evidence the range actually widened rather than
+    // the hash merely changing.
+    const ids = Array.from({ length: 2_000 }, (_, i) => `collection_${i}`);
+    const above = ids.map(hashStringToNumber).filter((n) => n >= 1_000_000);
+    expect(above.length).toBeGreaterThan(1_900);
+  });
+
+  it('has no collisions across 20,000 payment ids', () => {
+    // At the old 10^6 range this set would collide with overwhelming
+    // probability — the even-odds point was around 1,180.
+    const ids = Array.from({ length: 20_000 }, (_, i) => `collection_${i}`);
+    const indexes = new Set(ids.map(hashStringToNumber));
+    expect(indexes.size).toBe(ids.length);
+  });
+
+  it('would have collided at the old range on the same input set', () => {
+    // Demonstrates the finding rather than the fix: reducing the same hash to
+    // 10^6 reintroduces collisions immediately, which is why the call site also
+    // checks the derived address for uniqueness instead of trusting the range.
+    const ids = Array.from({ length: 20_000 }, (_, i) => `collection_${i}`);
+    const narrowed = new Set(ids.map((s) => hashStringToNumber(s) % 1_000_000));
+    expect(narrowed.size).toBeLessThan(ids.length);
+  });
+});

--- a/src/lib/blockchain/providers.ts
+++ b/src/lib/blockchain/providers.ts
@@ -321,11 +321,32 @@ export class BitcoinProvider implements BlockchainProvider {
 
       console.log(`[BTC] Split: balance=${totalAvailable}, total=${totalToSend}, fee=${fee}`);
 
-      // Adjust amounts if needed
+      // IA-010: the adjustment may absorb the fee and nothing more.
+      //
+      // This used to scale every output down by whatever ratio made the
+      // transaction fit, log it at `console.log`, and carry on. The caller
+      // asked to send X, X-δ went out, and everything downstream recorded X:
+      // the merchant's ledger, the fee split and the webhook all described a
+      // payment that did not happen. δ was unbounded — a balance half the
+      // requested amount simply sent half, silently.
+      //
+      // Taking the miner fee out of the outputs is the intended behaviour and
+      // is kept. A balance that cannot cover the outputs *before* fees is a
+      // real deficit and something is wrong upstream, so that fails instead.
       if (totalToSend + fee > totalAvailable) {
+        if (totalToSend > totalAvailable) {
+          throw new Error(
+            `Insufficient balance: address holds ${totalAvailable} sats but ${totalToSend} sats were requested ` +
+            `(before a ${fee} sat fee). Refusing to silently send less than asked.`
+          );
+        }
+
         const ratio = (totalAvailable - fee) / totalToSend;
-        console.log(`[BTC] Adjusting split amounts by ratio ${ratio}`);
-        
+        console.warn(
+          `[BTC] Reducing outputs by ratio ${ratio} to cover the ${fee} sat fee ` +
+          `(balance ${totalAvailable}, requested ${totalToSend})`
+        );
+
         for (const output of outputs) {
           output.value = Math.floor(output.value * ratio);
         }
@@ -486,13 +507,29 @@ export class EthereumProvider implements BlockchainProvider {
       
       console.log(`[ETH] Balance: ${ethers.formatEther(balance)} ETH, requested: ${amount} ETH, gas cost: ${ethers.formatEther(gasCost)} ETH`);
       
-      // If requested amount + gas exceeds balance, adjust to send max possible
+      // IA-010: the adjustment may absorb gas and nothing more.
+      //
+      // This used to send whatever was left after gas, whatever the shortfall,
+      // and log it at `console.log`. The caller asked for X, X-δ went out, and
+      // everything downstream recorded X. A balance well below the requested
+      // amount quietly sent whatever it had.
+      //
+      // Gas coming out of a native transfer is unavoidable and is kept. A
+      // balance that cannot cover the amount *before* gas is a real deficit.
       if (valueToSend + gasCost > balance) {
+        if (valueToSend > balance) {
+          throw new Error(
+            `Insufficient balance. Have ${ethers.formatEther(balance)} ETH, ` +
+            `${amount} ETH was requested (before ${ethers.formatEther(gasCost)} ETH of gas). ` +
+            'Refusing to silently send less than asked.'
+          );
+        }
+
         const maxSendable = balance - gasCost;
         if (maxSendable <= BigInt(0)) {
           throw new Error(`Insufficient balance. Have ${ethers.formatEther(balance)} ETH, need at least ${ethers.formatEther(gasCost)} ETH for gas`);
         }
-        console.log(`[ETH] Adjusting amount from ${amount} to ${ethers.formatEther(maxSendable)} ETH (max sendable after gas)`);
+        console.warn(`[ETH] Reducing amount from ${amount} to ${ethers.formatEther(maxSendable)} ETH to cover gas`);
         valueToSend = maxSendable;
       }
       

--- a/src/lib/blockchain/wallets.ts
+++ b/src/lib/blockchain/wallets.ts
@@ -8,6 +8,7 @@ import { encrypt } from '../crypto/encryption';
 import { requireEncryptionKey, requireMasterMnemonic } from '../crypto/require-key';
 import type { BlockchainType } from './providers';
 import { secp256k1 } from '@noble/curves/secp256k1';
+import { createHash } from 'crypto';
 
 /**
  * Wallet interface
@@ -171,7 +172,15 @@ function generateSolanaWallet(
  */
 export async function generatePaymentAddress(
   businessId: string,
-  chain: BlockchainType
+  chain: BlockchainType,
+  /**
+   * Explicit derivation index, overriding the hash of `businessId`.
+   *
+   * F-1.3-14: the hash alone is not safe to derive money-holding addresses
+   * from — see `hashStringToNumber`. Callers that can check the resulting
+   * address for uniqueness pass an index and retry on collision.
+   */
+  indexOverride?: number
 ): Promise<PaymentAddress> {
   // Both secrets are fail-closed: an ephemeral mnemonic loses the keys to any
   // funds received at the derived address, and a fallback encryption key means
@@ -179,7 +188,7 @@ export async function generatePaymentAddress(
   const masterMnemonic = requireMasterMnemonic();
 
   // Use business ID hash as index for deterministic address generation
-  const index = hashStringToNumber(businessId);
+  const index = indexOverride ?? hashStringToNumber(businessId);
 
   const wallet = await generateWalletFromMnemonic(masterMnemonic, chain, index);
 
@@ -193,16 +202,27 @@ export async function generatePaymentAddress(
 }
 
 /**
- * Hash a string to a number for deterministic index generation
+ * Hash a string to a derivation index.
+ *
+ * F-1.3-14: this is a 32-bit string fold reduced modulo 10^6, and the addresses
+ * it derives hold customer money. A million slots means two different inputs
+ * share an index — and therefore an address and a private key — with about even
+ * odds by the 1,180th one. When that happens, one collection payment's funds
+ * land at another's address: the balance check confirms the wrong payment, and
+ * the sweep sends the money to the wrong destination. It is not an attack, just
+ * arithmetic.
+ *
+ * The range is widened to the full non-hardened BIP32 space using a real hash,
+ * which pushes the even-odds point from ~1,180 to ~54,000. That is a mitigation
+ * rather than a fix, and it is deliberately not the whole answer: callers that
+ * can check for uniqueness pass `indexOverride` and retry, which is what makes
+ * a collision impossible rather than merely unlikely.
  */
-function hashStringToNumber(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32-bit integer
-  }
-  return Math.abs(hash) % 1000000; // Limit to reasonable range
+export function hashStringToNumber(str: string): number {
+  // 2^31 - 1: the largest non-hardened BIP32 index.
+  const MAX_INDEX = 0x7fffffff;
+  const digest = createHash('sha256').update(str).digest();
+  return digest.readUInt32BE(0) % MAX_INDEX;
 }
 
 /**

--- a/src/lib/db/keyset.test.ts
+++ b/src/lib/db/keyset.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchAllKeyset } from './keyset';
+
+/**
+ * Regression tests for the `.limit(N)` with no `.order()` family
+ * (B-03, F-1.3-09, F-1.3-12, H-R-05).
+ *
+ * Every one of those sweeps read a bounded page of a set that does not drain —
+ * `status = 'sent'`, `status = 'funded'`, terminal escrow statuses — so past N
+ * rows the same N were processed on every run and the remainder never at all.
+ * Nothing errored and nothing was logged: the job reported success having
+ * silently ignored most of its work.
+ */
+
+/** A fake table that answers keyset pages the way PostgREST would. */
+function fakeTable(ids: string[], pageSize: number) {
+  const rows = ids.map((id) => ({ id }));
+  return vi.fn(async (cursor: string | null, size: number) => {
+    const start = cursor ? rows.findIndex((r) => r.id === cursor) + 1 : 0;
+    return { data: rows.slice(start, start + Math.min(size, pageSize)), error: null };
+  });
+}
+
+describe('fetchAllKeyset', () => {
+  it('walks past the first page instead of re-reading it', async () => {
+    // The finding in one assertion: 250 rows, 100 to a page. The old code saw
+    // the first 100 and nothing else, forever.
+    const ids = Array.from({ length: 250 }, (_, i) => `id-${String(i).padStart(4, '0')}`);
+    const page = fakeTable(ids, 100);
+
+    const result = await fetchAllKeyset<{ id: string }>(page, { pageSize: 100 });
+
+    expect(result.rows).toHaveLength(250);
+    expect(result.truncated).toBe(false);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('advances the cursor to the last id of the previous page', async () => {
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    const page = fakeTable(ids, 2);
+
+    await fetchAllKeyset<{ id: string }>(page, { pageSize: 2 });
+
+    // First call has no cursor; each later one resumes after the previous page.
+    expect(page.mock.calls.map((c) => c[0])).toEqual([null, 'b', 'd']);
+  });
+
+  it('stops on a short page without an extra round trip', async () => {
+    const page = fakeTable(['a', 'b', 'c'], 100);
+    await fetchAllKeyset<{ id: string }>(page, { pageSize: 100 });
+    expect(page).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles an empty set', async () => {
+    const page = fakeTable([], 100);
+    const result = await fetchAllKeyset<{ id: string }>(page, { pageSize: 100 });
+    expect(result.rows).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('flags truncation when the ceiling is reached', async () => {
+    // The ceiling is a runaway guard, not a working set — but a caller that
+    // silently stops early is the very bug this replaces, so it must be
+    // reported rather than inferred from a row count.
+    const ids = Array.from({ length: 100 }, (_, i) => `id-${String(i).padStart(4, '0')}`);
+    const page = fakeTable(ids, 10);
+
+    const result = await fetchAllKeyset<{ id: string }>(page, { pageSize: 10, maxRows: 30 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.rows).toHaveLength(30);
+  });
+
+  it('returns the rows read before a failing page, and the error', async () => {
+    // A sweep that processed 20 of 50 rows has still done 20 rows of real work;
+    // throwing that away would turn a partial outage into a total one.
+    let call = 0;
+    const page = vi.fn(async (cursor: string | null) => {
+      call++;
+      if (call === 1) {
+        return { data: [{ id: 'a' }, { id: 'b' }], error: null };
+      }
+      return { data: null, error: { message: 'connection reset' } };
+    });
+
+    const result = await fetchAllKeyset<{ id: string }>(page, { pageSize: 2 });
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.error).toBe('connection reset');
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/src/lib/db/keyset.ts
+++ b/src/lib/db/keyset.ts
@@ -1,0 +1,74 @@
+/**
+ * Keyset pagination for background sweeps.
+ *
+ * The same defect appears across the cron workers: a `.limit(N)` with no
+ * `.order()`. Postgres may return rows in any order it likes and in practice
+ * returns a stable physical one, so once a table holds more than N matching
+ * rows the sweep processes the same N on every run, forever, and the remainder
+ * are never processed at all. Nothing errors and nothing is logged — the job
+ * reports success having quietly ignored most of its work (B-03, F-1.3-09,
+ * F-1.3-12, H-R-05).
+ *
+ * Ordering alone does not fix it. These sweeps select rows that stay selectable
+ * until something moves them on — `status = 'sent'`, `status = 'funded'` — so
+ * an ordered query returns the same first page every time just as reliably. The
+ * page has to advance.
+ *
+ * Hence keyset rather than offset: `.range()` re-scans and skips, and rows
+ * shifting underneath a long sweep make it drop or duplicate entries. A cursor
+ * on a monotonic unique column is stable while the set changes.
+ */
+
+export interface KeysetPage<T> {
+  data: T[] | null;
+  error: { message: string } | null;
+}
+
+export interface KeysetResult<T> {
+  rows: T[];
+  /** True when `maxRows` was hit and the tail of the table was not visited. */
+  truncated: boolean;
+  /** Set when a page failed; `rows` then holds whatever was read before it. */
+  error?: string;
+}
+
+/**
+ * Walk every row matching a query, one page at a time.
+ *
+ * @param fetchPage - runs one page. Receives the last id of the previous page
+ *   (`null` for the first) and the page size; must apply `.order('id')`,
+ *   `.gt('id', cursor)` when a cursor is given, and `.limit(pageSize)`.
+ * @param opts.pageSize - rows per round trip.
+ * @param opts.maxRows - hard ceiling, a runaway guard rather than a working
+ *   set. Reaching it sets `truncated`, which callers should log: a sweep that
+ *   silently stops early is the bug this exists to prevent.
+ */
+export async function fetchAllKeyset<T extends { id: string }>(
+  fetchPage: (cursor: string | null, pageSize: number) => Promise<KeysetPage<T>>,
+  opts: { pageSize?: number; maxRows?: number } = {}
+): Promise<KeysetResult<T>> {
+  const pageSize = opts.pageSize ?? 100;
+  const maxRows = opts.maxRows ?? 5_000;
+
+  const rows: T[] = [];
+  let cursor: string | null = null;
+
+  while (rows.length < maxRows) {
+    const { data, error } = await fetchPage(cursor, pageSize);
+
+    if (error) {
+      // Return what was read rather than throwing it away: a sweep that
+      // processed 300 of 400 rows has still done 300 rows of real work.
+      return { rows, truncated: false, error: error.message };
+    }
+    if (!data || data.length === 0) break;
+
+    rows.push(...data);
+    cursor = data[data.length - 1].id;
+
+    // A short page is the last page.
+    if (data.length < pageSize) break;
+  }
+
+  return { rows, truncated: rows.length >= maxRows };
+}

--- a/src/lib/escrow/model-selection.ts
+++ b/src/lib/escrow/model-selection.ts
@@ -64,6 +64,19 @@ export type SelectEscrowModelResult =
  * Returns `ok: false` only when an explicit `multisig_2of3` request cannot be
  * honoured. An unspecified model always resolves to something creatable.
  */
+/**
+ * ESC-NEW-05: this function has no callers, and did not have any when the audit
+ * was written — the model decision is made by the two creation endpoints
+ * instead (`/api/escrow` is custodial-only; `/api/escrow/multisig` needs the
+ * three pubkeys, which a single resolver cannot conjure).
+ *
+ * It is kept, with its tests, because it is the clearest statement of the
+ * intended rules and is the right shape if the endpoints are ever merged. This
+ * note exists so nobody reads it as the thing that governs custody today: it
+ * does not. `MULTISIG_DEFAULT` is honoured by the browser's create page, and
+ * `/api/escrow` now tells an API caller when it has defaulted them to custodial
+ * on a deployment that advertises otherwise.
+ */
 export function selectEscrowModel(input: SelectEscrowModelInput): SelectEscrowModelResult {
   const { requested, chain, recurring = false, multisigEnabled, multisigDefault } = input;
 

--- a/src/lib/escrow/service.test.ts
+++ b/src/lib/escrow/service.test.ts
@@ -372,12 +372,16 @@ describe('Escrow Service', () => {
   });
 
   describe('refundEscrow', () => {
+    const PAST = new Date(Date.now() - 60_000).toISOString();
+    const FUTURE = new Date(Date.now() + 60 * 60_000).toISOString();
+
     it('should reject refund on non-funded escrow', async () => {
       const escrow = {
         id: 'esc-1',
         status: 'released',
         release_token: 'esc_tok',
         beneficiary_token: 'esc_ben',
+        expires_at: PAST,
       };
 
       const supabase = createMockSupabase({ singleData: escrow }) as any;
@@ -385,6 +389,94 @@ describe('Escrow Service', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Cannot refund');
+    });
+
+    it('refuses a depositor refund while the escrow is still live (CP-025)', async () => {
+      // The depositor's token used to refund on the spot, at any moment the
+      // escrow was funded — the buyer pulling their money back whenever they
+      // liked. The escrow protected the buyer from the seller and the seller
+      // from nobody, which is the one thing an escrow exists to do.
+      const escrow = {
+        id: 'esc-1',
+        status: 'funded',
+        release_token: 'esc_tok',
+        beneficiary_token: 'esc_ben',
+        expires_at: FUTURE,
+      };
+
+      const supabase = createMockSupabase({ singleData: escrow }) as any;
+      const result = await refundEscrow(supabase, 'esc-1', 'esc_tok');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('before the escrow expires');
+    });
+
+    it('allows the beneficiary to refund at any time (CP-025)', async () => {
+      // The beneficiary is relinquishing their own claim, so their token alone
+      // is enough — this is the cooperative path and must stay open.
+      const escrow = {
+        id: 'esc-1',
+        status: 'funded',
+        release_token: 'esc_tok',
+        beneficiary_token: 'esc_ben',
+        expires_at: FUTURE,
+      };
+
+      const supabase = createMockSupabase({ singleData: escrow }) as any;
+      const result = await refundEscrow(supabase, 'esc-1', 'esc_ben');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('allows the depositor to refund once the deadline has passed (CP-025)', async () => {
+      // The depositor must not be locked in forever; expiry is the safety valve.
+      const escrow = {
+        id: 'esc-1',
+        status: 'funded',
+        release_token: 'esc_tok',
+        beneficiary_token: 'esc_ben',
+        expires_at: PAST,
+      };
+
+      const supabase = createMockSupabase({ singleData: escrow }) as any;
+      const result = await refundEscrow(supabase, 'esc-1', 'esc_tok');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('treats an unreadable expiry as not-yet-expired (CP-025)', async () => {
+      // `new Date(undefined)` is an Invalid Date and every comparison against
+      // one is false, so a naive `expires_at > now` check would grant exactly
+      // the refund the gate exists to withhold.
+      const escrow = {
+        id: 'esc-1',
+        status: 'funded',
+        release_token: 'esc_tok',
+        beneficiary_token: 'esc_ben',
+        expires_at: undefined,
+      };
+
+      const supabase = createMockSupabase({ singleData: escrow }) as any;
+      const result = await refundEscrow(supabase, 'esc-1', 'esc_tok');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('before the escrow expires');
+    });
+
+    it('rejects a token that is neither party (CP-025)', async () => {
+      const escrow = {
+        id: 'esc-1',
+        status: 'funded',
+        release_token: 'esc_tok',
+        beneficiary_token: 'esc_ben',
+        expires_at: PAST,
+      };
+
+      const supabase = createMockSupabase({ singleData: escrow }) as any;
+      const result = await refundEscrow(supabase, 'esc-1', 'esc_not_a_party');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unauthorized');
     });
   });
 

--- a/src/lib/escrow/service.test.ts
+++ b/src/lib/escrow/service.test.ts
@@ -39,6 +39,9 @@ vi.mock('../wallets/system-wallet', () => ({
   getCommissionRate: vi.fn().mockReturnValue(0.01),
   generatePaymentAddress: vi.fn(),
   getFeePercentage: vi.fn().mockReturnValue(0.01),
+  // IA-016: escrow legs are now checked against the reserved platform wallets,
+  // the way /api/payments/create has always checked its payout leg.
+  isPlatformFeeWallet: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock('../crypto/encryption', () => ({
@@ -169,11 +172,56 @@ describe('Escrow Service', () => {
       expect(result.error?.toLowerCase()).toContain('depositor_address must be at least 10 characters');
     });
 
+    it('rejects an escrow leg that is malformed for its chain (IA-016)', async () => {
+      // Escrow addresses were validated by `.min(10)` and nothing else, while
+      // /api/payments/create validates the same kind of payout leg properly.
+      // A malformed address means a release broadcasts somewhere unspendable
+      // and the funds are gone with no recourse.
+      const supabase = { from: vi.fn() } as any;
+
+      const result = await createEscrow(supabase, {
+        chain: 'ETH',
+        amount: 1.0,
+        depositor_address: '0x1111111111111111111111111111111111111111',
+        beneficiary_address: 'not-an-ethereum-address-but-long-enough',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('beneficiary_address');
+      // Rejected before any database work.
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('rejects an escrow leg pointed at a platform fee wallet (IA-016)', async () => {
+      // Naming a platform wallet makes the escrow leg indistinguishable from a
+      // fee payment and corrupts reconciliation on both — which is exactly why
+      // payments/create rejects it there.
+      const { isPlatformFeeWallet } = await import('../wallets/system-wallet');
+      vi.mocked(isPlatformFeeWallet).mockImplementation(
+        (address: string) => address === '0x3333333333333333333333333333333333333333'
+      );
+
+      const supabase = { from: vi.fn() } as any;
+
+      const result = await createEscrow(supabase, {
+        chain: 'ETH',
+        amount: 1.0,
+        depositor_address: '0x1111111111111111111111111111111111111111',
+        beneficiary_address: '0x3333333333333333333333333333333333333333',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('may not be a platform wallet');
+      expect(supabase.from).not.toHaveBeenCalled();
+
+      vi.mocked(isPlatformFeeWallet).mockReturnValue(false);
+    });
+
     it('should create escrow with valid input', async () => {
       const insertedEscrow = {
         id: 'new-escrow-id',
-        depositor_address: '0xDepositor123456',
-        beneficiary_address: '0xBeneficiary789012',
+        depositor_address: '0x1111111111111111111111111111111111111111',
+        beneficiary_address: '0x2222222222222222222222222222222222222222',
         escrow_address: '0xEscrowAddress1234567890abcdef',
         chain: 'ETH',
         amount: 1.0,
@@ -230,8 +278,8 @@ describe('Escrow Service', () => {
       const result = await createEscrow(supabase, {
         chain: 'ETH',
         amount: 1.0,
-        depositor_address: '0xDepositor123456',
-        beneficiary_address: '0xBeneficiary789012',
+        depositor_address: '0x1111111111111111111111111111111111111111',
+        beneficiary_address: '0x2222222222222222222222222222222222222222',
         metadata: { job: 'code review' },
       });
 

--- a/src/lib/escrow/service.ts
+++ b/src/lib/escrow/service.ts
@@ -24,7 +24,12 @@ import { tryRequireEncryptionKey } from '@/lib/crypto/require-key';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { randomBytes } from 'crypto';
 import { z } from 'zod';
-import { generatePaymentAddress, type SystemBlockchain } from '../wallets/system-wallet';
+import {
+  generatePaymentAddress,
+  isPlatformFeeWallet,
+  type SystemBlockchain,
+} from '../wallets/system-wallet';
+import { isValidPayoutAddress } from '../blockchain/address-format';
 import { getFeePercentage } from '../payments/fees';
 import { getExchangeRate } from '../rates/tatum';
 import { sendEscrowWebhook } from '../webhooks/service';
@@ -128,6 +133,38 @@ export async function createEscrow(
   // Depositor and beneficiary can't be the same
   if (data.depositor_address === data.beneficiary_address) {
     return { success: false, error: 'Depositor and beneficiary must be different addresses' };
+  }
+
+  // IA-016: escrow addresses were checked by `.min(10)` and nothing else — no
+  // chain-format validation and no reserved-address check — while
+  // /api/payments/create validates both for exactly the same kind of payout
+  // leg. Sibling asymmetry again (§2.3).
+  //
+  // Two separate problems. A malformed address means a release broadcasts to
+  // somewhere unspendable and the funds are gone with no recourse, which
+  // `.min(10)` does nothing about. And naming a platform fee wallet as the
+  // depositor or beneficiary makes the escrow leg indistinguishable from a fee
+  // payment, corrupting reconciliation on both — the reason payments/create
+  // rejects it there.
+  const addressLegs: [string, string | undefined][] = [
+    ['depositor_address', data.depositor_address],
+    ['beneficiary_address', data.beneficiary_address],
+    ['arbiter_address', data.arbiter_address],
+  ];
+
+  for (const [field, address] of addressLegs) {
+    if (!address) continue;
+
+    // `false` = malformed for this chain → reject. `null` = a chain we have no
+    // validator for → do not block a legitimate escrow on a check we cannot
+    // make. Same three-state contract as payments/create.
+    if (isValidPayoutAddress(address, data.chain as SystemBlockchain) === false) {
+      return { success: false, error: `Invalid ${data.chain} ${field}` };
+    }
+
+    if (isPlatformFeeWallet(address)) {
+      return { success: false, error: `${field} may not be a platform wallet` };
+    }
   }
 
   // Auto-detect emails from wallet addresses if not provided.

--- a/src/lib/escrow/service.ts
+++ b/src/lib/escrow/service.ts
@@ -690,9 +690,45 @@ export async function refundEscrow(
 
   const escrow = data as Escrow;
 
+  // CP-025: a refund is no longer something the depositor can simply take.
+  //
+  // This accepted the depositor's token and refunded on the spot, at any moment
+  // while the escrow was funded. That is the buyer pulling their money back
+  // whenever they like — so the escrow protected the buyer from the seller and
+  // the seller from nobody. A seller who delivered had no more assurance than
+  // if they had been paid directly, which is the entire thing an escrow is for.
+  //
+  // Two refunds are legitimate, and both are still allowed:
+  //
+  //   - The beneficiary gives the money back. They are relinquishing their own
+  //     claim, so their token is sufficient, at any time.
+  //   - The deadline passes without release. The depositor should not be locked
+  //     in forever, so once `expires_at` is behind us their token works. (The
+  //     monitor usually gets there first and auto-refunds; this is the manual
+  //     equivalent, and the path that still works if the cron is behind.)
+  //
+  // What is gone is the depositor refunding *during* the window the seller is
+  // performing in.
   const role = authenticateEscrowAction(escrow, releaseToken);
-  if (role !== 'depositor') {
-    return { success: false, error: 'Unauthorized: invalid release token' };
+  if (role !== 'depositor' && role !== 'beneficiary') {
+    return { success: false, error: 'Unauthorized: invalid token' };
+  }
+
+  if (role === 'depositor') {
+    // An unreadable expiry is treated as "not yet expired". `new Date(undefined)`
+    // is an Invalid Date and every comparison against one is false, so a naive
+    // `expires_at > now` check would silently grant the very refund this gate
+    // exists to withhold.
+    const expiresAt = new Date(escrow.expires_at).getTime();
+    const hasExpired = Number.isFinite(expiresAt) && expiresAt <= Date.now();
+
+    if (!hasExpired) {
+      return {
+        success: false,
+        error:
+          'Cannot refund before the escrow expires. Ask the beneficiary to refund, or wait for expiry.',
+      };
+    }
   }
 
   // Only funded escrows can be refunded (not yet released)

--- a/src/lib/http/fetch-timeout.ts
+++ b/src/lib/http/fetch-timeout.ts
@@ -1,0 +1,33 @@
+/**
+ * `fetch` with a deadline.
+ *
+ * IA-008: the balance oracles issue dozens of calls to third-party explorers
+ * and RPC nodes, and not one of them set a timeout. Node's fetch has no default
+ * one, so a peer that accepts a connection and then never answers holds the
+ * request open indefinitely — and because the monitor awaits these calls in
+ * sequence, one unresponsive upstream stalls the entire cycle. Payments stop
+ * being confirmed platform-wide, and nothing errors: the cron is simply still
+ * running, forever.
+ *
+ * A slow upstream should cost one skipped check on one address, not the run.
+ */
+
+/** Long enough for a slow explorer, short enough that a hang is not a stall. */
+export const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+export async function fetchWithTimeout(
+  url: string,
+  init?: RequestInit,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    // Always cleared, including on the success path — an uncleared timer keeps
+    // the event loop alive and would stop a short-lived cron process exiting.
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/invoices/numbering.test.ts
+++ b/src/lib/invoices/numbering.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { nextInvoiceNumber, insertWithInvoiceNumber } from './numbering';
+
+/**
+ * Regression tests for the invoice-numbering family
+ * (`F-1.3-10`, `NEW-F1A-P-01`, `R4-DIN-07`).
+ *
+ * Four call sites generated `INV-NNN`; three of them ordered by `created_at`
+ * and took the newest row, which is not the row with the highest number, and
+ * none of the three retried the unique violation a concurrent create causes.
+ */
+
+function supabaseReturning(rows: { invoice_number: unknown }[]) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    not: vi.fn(() => chain),
+    then: (resolve: any) => resolve({ data: rows, error: null }),
+  };
+  return { from: vi.fn(() => chain) } as any;
+}
+
+describe('nextInvoiceNumber', () => {
+  it('starts at INV-001 for a business with no invoices', async () => {
+    expect(await nextInvoiceNumber(supabaseReturning([]), 'biz')).toBe('INV-001');
+  });
+
+  it('takes the highest parsed number, not the newest row', async () => {
+    // The bug in one assertion. Ordering by `created_at` and reading the first
+    // row returns whichever invoice happens to sort first by time — so a
+    // backdated or imported invoice makes the "maximum" too low and the next
+    // number collides with one that already exists.
+    const rows = [
+      { invoice_number: 'INV-002' },
+      { invoice_number: 'INV-017' },
+      { invoice_number: 'INV-009' },
+    ];
+    expect(await nextInvoiceNumber(supabaseReturning(rows), 'biz')).toBe('INV-018');
+  });
+
+  it('ignores rows whose number does not parse', async () => {
+    const rows = [
+      { invoice_number: 'INV-004' },
+      { invoice_number: 'LEGACY-XYZ' },
+      { invoice_number: null },
+    ];
+    expect(await nextInvoiceNumber(supabaseReturning(rows), 'biz')).toBe('INV-005');
+  });
+
+  it('keeps padding to three digits and grows past it', async () => {
+    expect(await nextInvoiceNumber(supabaseReturning([{ invoice_number: 'INV-008' }]), 'b')).toBe('INV-009');
+    expect(await nextInvoiceNumber(supabaseReturning([{ invoice_number: 'INV-999' }]), 'b')).toBe('INV-1000');
+  });
+});
+
+describe('insertWithInvoiceNumber', () => {
+  it('retries on a unique violation and advances the number', async () => {
+    // Two concurrent creates read the same maximum and compute the same next
+    // number; without this retry the loser's insert simply fails — which in
+    // convertToInvoice meant a proposal that would not convert, and in the
+    // recurring scheduler halted the subscription.
+    const supabase = supabaseReturning([{ invoice_number: 'INV-003' }]);
+    const attempted: string[] = [];
+
+    const attemptInsert = vi.fn(async (invoiceNumber: string) => {
+      attempted.push(invoiceNumber);
+      if (attempted.length === 1) {
+        return { data: null, error: { code: '23505', message: 'duplicate key' } };
+      }
+      return { data: { id: 'inv-1' }, error: null };
+    });
+
+    const result = await insertWithInvoiceNumber(supabase, 'biz', attemptInsert);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ id: 'inv-1' });
+    expect(attempted).toHaveLength(2);
+  });
+
+  it('does not retry an error that is not a unique violation', async () => {
+    // A permissions failure or a bad column is not a numbering collision, and
+    // retrying it four more times only delays the real error.
+    const supabase = supabaseReturning([]);
+    const attemptInsert = vi.fn(async () => ({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    }));
+
+    const result = await insertWithInvoiceNumber(supabase, 'biz', attemptInsert);
+
+    expect(result.error?.code).toBe('42501');
+    expect(attemptInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the attempt cap rather than looping forever', async () => {
+    const supabase = supabaseReturning([]);
+    const attemptInsert = vi.fn(async () => ({
+      data: null,
+      error: { code: '23505', message: 'duplicate key' },
+    }));
+
+    const result = await insertWithInvoiceNumber(supabase, 'biz', attemptInsert, 3);
+
+    expect(attemptInsert).toHaveBeenCalledTimes(3);
+    expect(result.error?.code).toBe('23505');
+  });
+
+  it('succeeds first time when there is no contention', async () => {
+    const supabase = supabaseReturning([{ invoice_number: 'INV-041' }]);
+    const attemptInsert = vi.fn(async (invoiceNumber: string) => ({
+      data: { invoice_number: invoiceNumber },
+      error: null,
+    }));
+
+    const result = await insertWithInvoiceNumber(supabase, 'biz', attemptInsert);
+
+    expect(attemptInsert).toHaveBeenCalledTimes(1);
+    expect(result.data).toEqual({ invoice_number: 'INV-042' });
+  });
+});

--- a/src/lib/invoices/numbering.ts
+++ b/src/lib/invoices/numbering.ts
@@ -1,0 +1,91 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Per-business invoice numbering.
+ *
+ * Four call sites generated `INV-NNN` and only one of them did it correctly.
+ * The other three (`F-1.3-10`, `NEW-F1A-P-01`, `R4-DIN-07`) shared two defects:
+ *
+ *  1. **Ordering by `created_at` and taking the first row.** The highest
+ *     *number* is not the newest *row*. Backdate an invoice, import a
+ *     historical one, or delete the most recent, and the "maximum" is whatever
+ *     happens to sort first by time — so the next number collides with one that
+ *     already exists.
+ *
+ *  2. **No retry on the unique violation.** `(business_id, invoice_number)` is
+ *     unique, so two concurrent creates both read the same maximum, both
+ *     compute the same next number, and the loser's insert fails with 23505.
+ *     In `convertToInvoice` that surfaces as a proposal that will not convert;
+ *     in the recurring scheduler it halts the subscription, because the cycle
+ *     throws and the schedule is never advanced.
+ *
+ * Both are fixed here, once, so the four sites cannot drift apart again — which
+ * is how three of them ended up wrong while the fourth was right.
+ */
+
+/**
+ * The next free number for a business, by parsed value rather than row order.
+ *
+ * Reads every numbered invoice for the business. That is a full scan per call,
+ * but invoice counts per business are small (tens to hundreds) and correctness
+ * here is worth more than the round trip — the alternative is a sequence, which
+ * is a schema change and would still need the retry below for imports.
+ */
+export async function nextInvoiceNumber(
+  supabase: SupabaseClient,
+  businessId: string
+): Promise<string> {
+  const { data: rows } = await supabase
+    .from('invoices')
+    .select('invoice_number')
+    .eq('business_id', businessId)
+    .not('invoice_number', 'is', null);
+
+  let highest = 0;
+  for (const row of rows || []) {
+    const match = String((row as { invoice_number: unknown }).invoice_number).match(/INV-(\d+)/);
+    if (match) {
+      const n = parseInt(match[1], 10);
+      if (Number.isFinite(n) && n > highest) highest = n;
+    }
+  }
+
+  return `INV-${String(highest + 1).padStart(3, '0')}`;
+}
+
+export interface InsertAttemptResult<T> {
+  data: T | null;
+  error: { message: string; code?: string } | null;
+}
+
+/**
+ * Insert an invoice, retrying on the unique-violation a concurrent create causes.
+ *
+ * Each retry re-reads the maximum, so two racing requests end up with
+ * consecutive numbers rather than one failing outright. Only 23505 is retried;
+ * anything else is a real failure and is returned immediately.
+ *
+ * @param attemptInsert - performs the insert with the supplied number. Kept as
+ *   a callback because the four call sites select different columns back and
+ *   write different rows; the only thing they need to share is the numbering.
+ */
+export async function insertWithInvoiceNumber<T>(
+  supabase: SupabaseClient,
+  businessId: string,
+  attemptInsert: (invoiceNumber: string) => PromiseLike<InsertAttemptResult<T>>,
+  maxAttempts = 5
+): Promise<InsertAttemptResult<T>> {
+  let invoiceNumber = await nextInvoiceNumber(supabase, businessId);
+  let result: InsertAttemptResult<T> = { data: null, error: null };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    result = await attemptInsert(invoiceNumber);
+
+    // 23505 = unique_violation. Anything else is a real failure.
+    if (!result.error || result.error.code !== '23505') return result;
+
+    invoiceNumber = await nextInvoiceNumber(supabase, businessId);
+  }
+
+  return result;
+}

--- a/src/lib/multisig/engine.test.ts
+++ b/src/lib/multisig/engine.test.ts
@@ -11,12 +11,30 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+
   createMultisigEscrow,
   proposeTransaction,
   broadcastTransaction,
   disputeMultisigEscrow,
   getMultisigEscrow,
 } from './engine';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { proposalChallenge, disputeChallenge } from './proof';
+
+// Proof-of-possession helpers (F-1.1-02).
+//
+// proposeTransaction and disputeMultisigEscrow now verify a secp256k1 signature
+// over the action's own terms before the pubkey is allowed to mean anything.
+// These tests therefore need a REAL keypair: a made-up pubkey can no longer act
+// as a participant, which is the entire point of the fix.
+const TEST_PRIV = secp256k1.utils.randomSecretKey();
+const TEST_PUB = Buffer.from(secp256k1.getPublicKey(TEST_PRIV, true)).toString('hex');
+
+function signChallenge(challenge: string): string {
+  const messageBytes = new TextEncoder().encode(challenge);
+  return Buffer.from(secp256k1.sign(messageBytes, TEST_PRIV)).toString('hex');
+}
+
 
 // ── Mock Setup ──────────────────────────────────────────────
 
@@ -378,12 +396,20 @@ describe('MultisigEscrowEngine', () => {
         return origFrom(table);
       });
 
+      const toAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      // Register the real key as the depositor on the stored escrow, so the
+      // verified signature resolves to a participant.
+      for (const [, e] of supabase._escrowStore) {
+        e.depositor_pubkey = TEST_PUB;
+      }
+
       const result = await proposeTransaction(
         supabase,
         escrowId,
         'release',
-        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-        '0x1234567890123456789012345678901234567890', // depositor
+        toAddress,
+        TEST_PUB,
+        signChallenge(proposalChallenge({ escrowId, proposalType: 'release', toAddress })),
       );
 
       expect(result.success).toBe(true);
@@ -610,11 +636,18 @@ describe('MultisigEscrowEngine', () => {
       }
 
       const escrowId = Array.from(supabase._escrowStore.keys())[0];
+      // The arbiter holds the real key here, so this still tests the ROLE
+      // rejection rather than stopping at the signature check.
+      for (const [, e] of supabase._escrowStore) {
+        e.arbiter_pubkey = TEST_PUB;
+      }
+      const disputeReason = 'Dispute reason for testing purposes';
       const result = await disputeMultisigEscrow(
         supabase,
         escrowId,
-        '0x9876543210987654321098765432109876543210', // arbiter
-        'Dispute reason for testing purposes',
+        TEST_PUB, // arbiter
+        disputeReason,
+        signChallenge(disputeChallenge({ escrowId, reason: disputeReason })),
       );
 
       expect(result.success).toBe(false);

--- a/src/lib/multisig/engine.ts
+++ b/src/lib/multisig/engine.ts
@@ -13,6 +13,7 @@
  * Core Rule: CoinPay can never move funds alone.
  */
 
+import { verifyActionProof, proposalChallenge, disputeChallenge } from './proof';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ChainAdapter } from './adapters/interface';
 import { getAdapterType } from './adapters/interface';
@@ -210,6 +211,7 @@ export async function proposeTransaction(
   proposalType: ProposalType,
   toAddress: string,
   signerPubkey: string,
+  signature?: string,
 ): Promise<ProposeResult> {
   // Fetch escrow
   const { data: escrow, error: fetchError } = await supabase
@@ -221,6 +223,16 @@ export async function proposeTransaction(
 
   if (fetchError || !escrow) {
     return { success: false, error: 'Multisig escrow not found' };
+  }
+
+  // Prove possession of the key BEFORE the pubkey is allowed to mean anything
+  // (F-1.1-02). Matching a public value proves only that you can read it.
+  if (!verifyActionProof(
+    proposalChallenge({ escrowId, proposalType, toAddress }),
+    signature,
+    signerPubkey,
+  )) {
+    return { success: false, error: 'Invalid or missing signature for this proposal' };
   }
 
   // Verify signer is a participant
@@ -583,6 +595,7 @@ export async function disputeMultisigEscrow(
   escrowId: string,
   signerPubkey: string,
   reason: string,
+  signature?: string,
 ): Promise<DisputeResult> {
   // Fetch escrow
   const { data: escrow, error: fetchError } = await supabase
@@ -594,6 +607,12 @@ export async function disputeMultisigEscrow(
 
   if (fetchError || !escrow) {
     return { success: false, error: 'Multisig escrow not found' };
+  }
+
+  // Proof of possession first (F-1.1-02): opening a dispute freezes an escrow,
+  // so being able to name a party's public key must not be enough to do it.
+  if (!verifyActionProof(disputeChallenge({ escrowId, reason }), signature, signerPubkey)) {
+    return { success: false, error: 'Invalid or missing signature for this dispute' };
   }
 
   // Verify signer is depositor or beneficiary

--- a/src/lib/multisig/proof.test.ts
+++ b/src/lib/multisig/proof.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { proposalChallenge, disputeChallenge, verifyActionProof } from './proof';
+
+/**
+ * Regression tests for F-1.1-02 (2026-08-19 audit).
+ *
+ * `resolveSignerRole` decided which party you are by comparing the pubkey you
+ * sent against the three stored on the escrow. A public key is public — and
+ * until this branch the escrow GET was unauthenticated too (F-1.1-03), so
+ * anyone could read all three and then act as any party by echoing one back.
+ */
+
+const priv = secp256k1.utils.randomSecretKey();
+const pub = Buffer.from(secp256k1.getPublicKey(priv, true)).toString('hex');
+
+const otherPriv = secp256k1.utils.randomSecretKey();
+const otherPub = Buffer.from(secp256k1.getPublicKey(otherPriv, true)).toString('hex');
+
+function sign(challenge: string, key: Uint8Array = priv): string {
+  return Buffer.from(secp256k1.sign(new TextEncoder().encode(challenge), key)).toString('hex');
+}
+
+const PROPOSAL = { escrowId: 'esc-1', proposalType: 'release', toAddress: '0xAbC' };
+
+describe('verifyActionProof', () => {
+  it('accepts a signature from the key behind the pubkey', () => {
+    const c = proposalChallenge(PROPOSAL);
+    expect(verifyActionProof(c, sign(c), pub)).toBe(true);
+  });
+
+  it('rejects a pubkey presented without any signature', () => {
+    // The finding itself: knowing a participant's public key was enough.
+    const c = proposalChallenge(PROPOSAL);
+    expect(verifyActionProof(c, undefined, pub)).toBe(false);
+    expect(verifyActionProof(c, '', pub)).toBe(false);
+  });
+
+  it('rejects a signature made by a different key', () => {
+    const c = proposalChallenge(PROPOSAL);
+    expect(verifyActionProof(c, sign(c, otherPriv), pub)).toBe(false);
+  });
+
+  it('rejects a signature over a different action', () => {
+    // Binding the challenge to the action is what stops a captured signature
+    // authorising a payout to somewhere else.
+    const signed = proposalChallenge(PROPOSAL);
+    const attempted = proposalChallenge({ ...PROPOSAL, toAddress: '0xAttacker' });
+    expect(verifyActionProof(attempted, sign(signed), pub)).toBe(false);
+  });
+
+  it('rejects a release signature replayed as a refund', () => {
+    const signed = proposalChallenge({ ...PROPOSAL, proposalType: 'release' });
+    const attempted = proposalChallenge({ ...PROPOSAL, proposalType: 'refund' });
+    expect(verifyActionProof(attempted, sign(signed), pub)).toBe(false);
+  });
+
+  it('rejects a signature for one escrow replayed against another', () => {
+    const signed = proposalChallenge(PROPOSAL);
+    const attempted = proposalChallenge({ ...PROPOSAL, escrowId: 'esc-2' });
+    expect(verifyActionProof(attempted, sign(signed), pub)).toBe(false);
+  });
+
+  it('rejects malformed input rather than throwing', () => {
+    const c = proposalChallenge(PROPOSAL);
+    expect(verifyActionProof(c, 'not-hex', pub)).toBe(false);
+    expect(verifyActionProof(c, sign(c), 'not-hex')).toBe(false);
+    expect(verifyActionProof(c, sign(c), undefined)).toBe(false);
+  });
+
+  it('binds a dispute to its stated reason', () => {
+    const signed = disputeChallenge({ escrowId: 'esc-1', reason: 'not delivered' });
+    const attempted = disputeChallenge({ escrowId: 'esc-1', reason: 'something else' });
+    expect(verifyActionProof(signed, sign(signed), pub)).toBe(true);
+    expect(verifyActionProof(attempted, sign(signed), pub)).toBe(false);
+  });
+
+  it('treats the recipient case-insensitively, as addresses are', () => {
+    const lower = proposalChallenge({ ...PROPOSAL, toAddress: '0xabc' });
+    const upper = proposalChallenge({ ...PROPOSAL, toAddress: '0xABC' });
+    expect(lower).toBe(upper);
+  });
+
+  it('a different key is genuinely different', () => {
+    // Guards the fixtures themselves: if these collided the tests above would
+    // pass for the wrong reason.
+    expect(pub).not.toBe(otherPub);
+  });
+});

--- a/src/lib/multisig/proof.ts
+++ b/src/lib/multisig/proof.ts
@@ -1,0 +1,77 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+/**
+ * Proof of possession for multisig escrow actions.
+ *
+ * F-1.1-02: `resolveSignerRole` decided which party you are by comparing the
+ * pubkey you sent against the three stored on the escrow. A public key is
+ * public — that is the entire point of it — and until this branch the escrow
+ * GET was unauthenticated too (F-1.1-03), so anyone could read all three
+ * pubkeys and then act as any party by echoing one back. No signature was
+ * required anywhere in propose or dispute.
+ *
+ * The fix is to require a signature over a challenge that *binds the specific
+ * action*, and to verify it against the claimed key before the role is
+ * resolved. Binding the action matters: a signature over a bare nonce could be
+ * captured and replayed against a different proposal, whereas one over
+ * "release escrow X to address Y" authorises only that.
+ *
+ * Multisig escrows use secp256k1 keys on every supported chain, so one verifier
+ * covers them.
+ */
+
+/**
+ * Canonical challenge for a proposal.
+ *
+ * Field order and separator are fixed because both sides must derive the same
+ * bytes; changing either silently invalidates every existing client.
+ */
+export function proposalChallenge(params: {
+  escrowId: string;
+  proposalType: string;
+  toAddress: string;
+}): string {
+  return [
+    'coinpay-multisig-propose',
+    params.escrowId,
+    params.proposalType,
+    params.toAddress.toLowerCase(),
+  ].join('|');
+}
+
+/** Canonical challenge for raising a dispute. */
+export function disputeChallenge(params: { escrowId: string; reason: string }): string {
+  return ['coinpay-multisig-dispute', params.escrowId, params.reason].join('|');
+}
+
+/**
+ * Verify a compact secp256k1 signature over `challenge` for `pubkeyHex`.
+ *
+ * Returns false on any malformed input rather than throwing: a caller deciding
+ * whether someone is authorised must get a boolean, not an exception that a
+ * surrounding try/catch might convert into a pass.
+ */
+export function verifyActionProof(
+  challenge: string,
+  signatureHex: string | undefined | null,
+  pubkeyHex: string | undefined | null,
+): boolean {
+  if (!signatureHex || !pubkeyHex) return false;
+
+  try {
+    const clean = (h: string) => (h.startsWith('0x') ? h.slice(2) : h);
+    // Verified over the raw challenge bytes, matching how wallet auth signs and
+    // verifies elsewhere in this codebase (see web-wallet/auth.ts). The two must
+    // agree on whether the message is pre-hashed, so following the existing
+    // convention is what keeps a client able to sign for both.
+    const messageBytes = new TextEncoder().encode(challenge);
+    const sigBytes = Uint8Array.from(Buffer.from(clean(signatureHex), 'hex'));
+    const pubKeyBytes = Uint8Array.from(Buffer.from(clean(pubkeyHex), 'hex'));
+
+    if (sigBytes.length === 0 || pubKeyBytes.length === 0) return false;
+
+    return secp256k1.verify(sigBytes, messageBytes, pubKeyBytes);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/multisig/validation.test.ts
+++ b/src/lib/multisig/validation.test.ts
@@ -133,6 +133,10 @@ describe('prepareTransactionSchema', () => {
       proposal_type: 'release',
       to_address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
     });
     expect(result.success).toBe(true);
   });
@@ -142,6 +146,10 @@ describe('prepareTransactionSchema', () => {
       proposal_type: 'refund',
       to_address: '0x1234567890123456789012345678901234567890',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
     });
     expect(result.success).toBe(true);
   });
@@ -151,6 +159,10 @@ describe('prepareTransactionSchema', () => {
       proposal_type: 'cancel',
       to_address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
     });
     expect(result.success).toBe(false);
   });
@@ -169,6 +181,10 @@ describe('signProposalSchema', () => {
     const result = signProposalSchema.safeParse({
       proposal_id: '00000000-0000-0000-0000-000000000001',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
       signature: '0xabcdef1234567890abcdef1234567890',
     });
     expect(result.success).toBe(true);
@@ -178,6 +194,10 @@ describe('signProposalSchema', () => {
     const result = signProposalSchema.safeParse({
       proposal_id: 'not-a-uuid',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
       signature: '0xabcdef1234567890',
     });
     expect(result.success).toBe(false);
@@ -202,6 +222,10 @@ describe('disputeSchema', () => {
   it('should accept valid dispute', () => {
     const result = disputeSchema.safeParse({
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
       reason: 'The goods were not delivered as described in the agreement',
     });
     expect(result.success).toBe(true);
@@ -210,6 +234,10 @@ describe('disputeSchema', () => {
   it('should require reason of at least 10 characters', () => {
     const result = disputeSchema.safeParse({
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
       reason: 'Too short',
     });
     expect(result.success).toBe(false);
@@ -218,6 +246,10 @@ describe('disputeSchema', () => {
   it('should enforce reason max of 2000 characters', () => {
     const result = disputeSchema.safeParse({
       signer_pubkey: '0x1234567890123456789012345678901234567890',
+      // F-1.1-02: propose and dispute now carry a signature proving the caller
+      // holds the key behind that pubkey. Schema-level here; the engine tests
+      // verify a real one.
+      signature: '0x' + 'ab'.repeat(32),
       reason: 'x'.repeat(2001),
     });
     expect(result.success).toBe(false);

--- a/src/lib/multisig/validation.test.ts
+++ b/src/lib/multisig/validation.test.ts
@@ -181,10 +181,6 @@ describe('signProposalSchema', () => {
     const result = signProposalSchema.safeParse({
       proposal_id: '00000000-0000-0000-0000-000000000001',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
-      // F-1.1-02: propose and dispute now carry a signature proving the caller
-      // holds the key behind that pubkey. Schema-level here; the engine tests
-      // verify a real one.
-      signature: '0x' + 'ab'.repeat(32),
       signature: '0xabcdef1234567890abcdef1234567890',
     });
     expect(result.success).toBe(true);
@@ -194,10 +190,6 @@ describe('signProposalSchema', () => {
     const result = signProposalSchema.safeParse({
       proposal_id: 'not-a-uuid',
       signer_pubkey: '0x1234567890123456789012345678901234567890',
-      // F-1.1-02: propose and dispute now carry a signature proving the caller
-      // holds the key behind that pubkey. Schema-level here; the engine tests
-      // verify a real one.
-      signature: '0x' + 'ab'.repeat(32),
       signature: '0xabcdef1234567890',
     });
     expect(result.success).toBe(false);

--- a/src/lib/multisig/validation.ts
+++ b/src/lib/multisig/validation.ts
@@ -60,6 +60,11 @@ export const prepareTransactionSchema = z.object({
   signer_pubkey: z.string({
     required_error: 'signer_pubkey is required',
   }).min(20, 'signer_pubkey must be at least 20 characters'),
+  // F-1.1-02: the pubkey alone identified the caller, and a pubkey is public.
+  // A signature over the proposal's own terms is what makes it proof.
+  signature: z.string({
+    required_error: 'signature is required',
+  }).min(10, 'signature must be at least 10 characters'),
 });
 
 // ── Sign Proposal ───────────────────────────────────────────
@@ -90,6 +95,11 @@ export const disputeSchema = z.object({
   signer_pubkey: z.string({
     required_error: 'signer_pubkey is required',
   }).min(20, 'signer_pubkey must be at least 20 characters'),
+  // F-1.1-02: opening a dispute freezes an escrow, so naming a party's public
+  // key must not be enough to do it.
+  signature: z.string({
+    required_error: 'signature is required',
+  }).min(10, 'signature must be at least 10 characters'),
   reason: z.string({
     required_error: 'reason is required',
   }).min(10, 'Dispute reason must be at least 10 characters')

--- a/src/lib/payments/business-collection.ts
+++ b/src/lib/payments/business-collection.ts
@@ -344,6 +344,30 @@ export async function forwardBusinessCollectionPaymentSecurely(
       };
     }
 
+    // Claim it atomically before doing anything irreversible.
+    //
+    // L-04 / R4-DIN-08: the check above is a READ, and the status write further
+    // down was unconditional. Two overlapping cron runs both read `confirmed`,
+    // both passed this check, and both went on to broadcast — sending 100% of
+    // the payment twice out of an address that holds it once. Overlapping runs
+    // are not hypothetical here: the retry queue re-enters this same function.
+    //
+    // The conditional UPDATE is the lock. Exactly one caller can move the row
+    // out of `confirmed`, and the loser is told so instead of proceeding.
+    const { data: claimed } = await supabase
+      .from('business_collection_payments')
+      .update({ status: 'forwarding' })
+      .eq('id', paymentId)
+      .eq('status', 'confirmed')
+      .select('id');
+
+    if (!claimed || claimed.length === 0) {
+      return {
+        success: false,
+        error: 'Payment is already being forwarded by another process',
+      };
+    }
+
     // Get and decrypt the private key securely
     if (!payment.private_key_encrypted) {
       return {
@@ -378,11 +402,8 @@ export async function forwardBusinessCollectionPaymentSecurely(
     let txHash: string | undefined;
 
     try {
-      // Update status to forwarding
-      await supabase
-        .from('business_collection_payments')
-        .update({ status: 'forwarding' })
-        .eq('id', paymentId);
+      // Status is already `forwarding` — set by the compare-and-swap claim
+      // above, which is what makes this section single-entry.
 
       // Forward 100% of the amount to destination wallet
       if (provider.sendTransaction) {

--- a/src/lib/payments/business-collection.ts
+++ b/src/lib/payments/business-collection.ts
@@ -12,7 +12,7 @@
 import { tryRequireEncryptionKey } from '@/lib/crypto/require-key';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getProvider, getRpcUrl, type BlockchainType } from '../blockchain/providers';
-import { generatePaymentAddress } from '../blockchain/wallets';
+import { generatePaymentAddress, hashStringToNumber } from '../blockchain/wallets';
 import { deliverWebhook, logWebhookAttempt, retryFailedWebhook } from '../webhooks/service';
 import { decrypt } from '../crypto/encryption';
 import { resolveWebhookSecret } from '../webhooks/secret';
@@ -268,12 +268,59 @@ export async function createBusinessCollectionPayment(
       };
     }
 
-    // Generate payment address using wallet service
-    const paymentAddressResult = await generatePaymentAddress(
-      `collection_${payment.id}`,
-      input.blockchain
-    );
-    
+    // Generate payment address, and prove it is not already in use.
+    //
+    // F-1.3-14: the index came from a hash with a 10^6 range, so two collection
+    // payments shared an address — and a private key — with about even odds by
+    // the 1,180th one. The funds for one then land at the other's address: the
+    // balance check confirms the wrong payment and the sweep sends the money to
+    // the wrong destination. Widening the hash makes that unlikely; checking
+    // makes it impossible.
+    //
+    // The derived address is deterministic in the index, so a collision is
+    // resolved by walking to the next index rather than by regenerating and
+    // hoping.
+    const COLLECTION_ADDRESS_ATTEMPTS = 20;
+    const baseIndex = hashStringToNumber(`collection_${payment.id}`);
+
+    let paymentAddressResult: Awaited<ReturnType<typeof generatePaymentAddress>> | null = null;
+
+    for (let attempt = 0; attempt < COLLECTION_ADDRESS_ATTEMPTS; attempt++) {
+      const candidate = await generatePaymentAddress(
+        `collection_${payment.id}`,
+        input.blockchain,
+        (baseIndex + attempt) % 0x7fffffff
+      );
+
+      const { data: clash, error: clashError } = await supabase
+        .from('business_collection_payments')
+        .select('id')
+        .eq('payment_address', candidate.address)
+        .neq('id', payment.id)
+        .limit(1)
+        .maybeSingle();
+
+      if (clashError) {
+        // Cannot prove the address is free. Deriving anyway is what the finding
+        // is about, so stop rather than risk two payments sharing a key.
+        console.error('[Collection] Could not check address uniqueness:', clashError);
+        return { success: false, error: 'Could not allocate a payment address; please retry.' };
+      }
+
+      if (!clash) {
+        paymentAddressResult = candidate;
+        break;
+      }
+
+      console.warn(
+        `[Collection] Derivation index ${baseIndex + attempt} for ${input.blockchain} is already in use; trying the next.`
+      );
+    }
+
+    if (!paymentAddressResult) {
+      return { success: false, error: 'Could not allocate a unique payment address; please retry.' };
+    }
+
     const paymentAddress = paymentAddressResult.address;
     
     // Update payment with generated address and encrypted private key

--- a/src/lib/payments/business-collection.ts
+++ b/src/lib/payments/business-collection.ts
@@ -405,8 +405,37 @@ export async function forwardBusinessCollectionPaymentSecurely(
       // Status is already `forwarding` — set by the compare-and-swap claim
       // above, which is what makes this section single-entry.
 
-      // Forward 100% of the amount to destination wallet
-      if (provider.sendTransaction) {
+      // F-1.3-15: the network fee has to come out of what is at the address.
+      //
+      // A collection address holds exactly `crypto_amount` — the quote adds no
+      // network fee on top — and this asked the provider to send all of it.
+      // On UTXO chains `BitcoinProvider.sendTransaction` refuses outright when
+      // `amount + fee > balance`, which is always true here, so **every BTC
+      // collection sweep threw** and the payment sat in `forwarding_failed`
+      // with the funds stranded. On EVM the same shortfall was silently
+      // absorbed by reducing the amount (see IA-010), so it "worked" while
+      // under-sending.
+      //
+      // `sendSplitTransaction` with a single recipient is the sweep primitive:
+      // it takes the fee out of the outputs rather than demanding it on top,
+      // which is the only thing that can happen when fee and funds are the same
+      // asset. Preferred where the provider offers it; `sendTransaction`
+      // remains the path for account-model chains that deduct gas separately.
+      const canSplit = typeof (provider as { sendSplitTransaction?: unknown }).sendSplitTransaction === 'function';
+
+      if (canSplit) {
+        txHash = await (provider as unknown as {
+          sendSplitTransaction: (
+            from: string,
+            recipients: Array<{ address: string; amount: string }>,
+            privateKey: string,
+          ) => Promise<string>;
+        }).sendSplitTransaction(
+          payment.payment_address,
+          [{ address: payment.destination_wallet, amount: payment.crypto_amount.toString() }],
+          privateKey
+        );
+      } else if (provider.sendTransaction) {
         txHash = await provider.sendTransaction(
           payment.payment_address,
           payment.destination_wallet,

--- a/src/lib/payments/monitor-balance.ts
+++ b/src/lib/payments/monitor-balance.ts
@@ -5,6 +5,7 @@
  */
 
 import { isSufficientPayment } from './tolerance';
+import { fetchWithTimeout } from '@/lib/http/fetch-timeout';
 
 // RPC endpoints for different blockchains
 const RPC_ENDPOINTS: Record<string, string> = {
@@ -77,7 +78,7 @@ export interface BalanceResult {
  */
 async function checkBitcoinBalance(address: string): Promise<BalanceResult> {
   try {
-    const response = await fetch(`https://blockstream.info/api/address/${address}`);
+    const response = await fetchWithTimeout(`https://blockstream.info/api/address/${address}`);
     if (!response.ok) {
       await drainResponse(response);
       return { balance: 0, error: 'checkBitcoinBalance: lookup failed' };
@@ -91,7 +92,7 @@ async function checkBitcoinBalance(address: string): Promise<BalanceResult> {
     let txHash: string | undefined;
     if (balance > 0) {
       try {
-        const txResponse = await fetch(`https://blockstream.info/api/address/${address}/txs`);
+        const txResponse = await fetchWithTimeout(`https://blockstream.info/api/address/${address}/txs`);
         if (txResponse.ok) {
           const txs = await txResponse.json();
           if (txs && txs.length > 0) {
@@ -122,7 +123,7 @@ async function checkBCHBalance(address: string): Promise<BalanceResult> {
     }
     const url = `https://rest.cryptoapis.io/blockchain-data/bitcoin-cash/mainnet/addresses/${address}`;
     
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -144,7 +145,7 @@ async function checkBCHBalance(address: string): Promise<BalanceResult> {
     if (balance > 0) {
       try {
         const txUrl = `https://rest.cryptoapis.io/blockchain-data/bitcoin-cash/mainnet/addresses/${address}/transactions`;
-        const txResponse = await fetch(txUrl, {
+        const txResponse = await fetchWithTimeout(txUrl, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
@@ -176,7 +177,7 @@ async function checkBCHBalance(address: string): Promise<BalanceResult> {
 async function checkEVMBalance(address: string, rpcUrl: string, chain: string): Promise<BalanceResult> {
   try {
     console.log(`[Monitor] Checking ${chain} balance for ${address}`);
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -227,7 +228,7 @@ async function checkEVMTokenBalance(
 ): Promise<BalanceResult> {
   try {
     const paddedAddress = address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -301,7 +302,7 @@ export async function primeSolanaBalances(
   for (let i = 0; i < unique.length; i += SOL_ACCOUNTS_PER_CALL) {
     const chunk = unique.slice(i, i + SOL_ACCOUNTS_PER_CALL);
     try {
-      const response = await fetch(rpcUrl, {
+      const response = await fetchWithTimeout(rpcUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -360,7 +361,7 @@ async function checkSolanaBalance(address: string, rpcUrl: string): Promise<Bala
       return solanaBalanceResult(address, primed, rpcUrl);
     }
 
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -407,7 +408,7 @@ async function solanaBalanceResult(
   // the pending set — the rest are still waiting for money to arrive.
   let txHash: string | undefined;
   try {
-    const sigResponse = await fetch(rpcUrl, {
+    const sigResponse = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -441,7 +442,7 @@ async function checkSolanaTokenBalance(
   decimals: number
 ): Promise<BalanceResult> {
   try {
-    const response = await fetch(rpcUrl, {
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -491,14 +492,14 @@ async function checkSolanaTokenBalance(
 async function checkDOGEBalance(address: string): Promise<BalanceResult> {
   try {
     // Try Blockcypher first
-    const response = await fetch(`https://api.blockcypher.com/v1/doge/main/addrs/${address}/balance`);
+    const response = await fetchWithTimeout(`https://api.blockcypher.com/v1/doge/main/addrs/${address}/balance`);
     if (response.ok) {
       const data = await response.json();
       const balance = (data.balance || 0) / 1e8;
       return { balance };
     }
     // Fallback to dogechain
-    const fallbackResponse = await fetch(`https://dogechain.info/api/v1/address/balance/${address}`);
+    const fallbackResponse = await fetchWithTimeout(`https://dogechain.info/api/v1/address/balance/${address}`);
     if (fallbackResponse.ok) {
       const data = await fallbackResponse.json();
       if (data.success === 1) {
@@ -518,7 +519,7 @@ async function checkDOGEBalance(address: string): Promise<BalanceResult> {
  */
 async function checkBNBBalance(address: string): Promise<BalanceResult> {
   try {
-    const response = await fetch(RPC_ENDPOINTS.BNB, {
+    const response = await fetchWithTimeout(RPC_ENDPOINTS.BNB, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -546,7 +547,7 @@ async function checkBNBBalance(address: string): Promise<BalanceResult> {
  */
 async function checkXRPBalance(address: string): Promise<BalanceResult> {
   try {
-    const response = await fetch(RPC_ENDPOINTS.XRP, {
+    const response = await fetchWithTimeout(RPC_ENDPOINTS.XRP, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -581,7 +582,7 @@ async function checkADABalance(address: string): Promise<BalanceResult> {
       console.error('[Monitor] BLOCKFROST_API_KEY not configured for ADA');
       return { balance: 0, error: 'checkADABalance: lookup failed' };
     }
-    const response = await fetch(`https://cardano-mainnet.blockfrost.io/api/v0/addresses/${address}`, {
+    const response = await fetchWithTimeout(`https://cardano-mainnet.blockfrost.io/api/v0/addresses/${address}`, {
       headers: { 'project_id': blockfrostKey },
     });
     if (response.status === 404) {
@@ -705,7 +706,7 @@ export async function processPayment(supabase: any, payment: Payment): Promise<{
     if (internalApiKey) {
       try {
         console.log(`[Monitor] Triggering forwarding for payment ${payment.id}`);
-        const forwardResponse = await fetch(`${appUrl}/api/payments/${payment.id}/forward`, {
+        const forwardResponse = await fetchWithTimeout(`${appUrl}/api/payments/${payment.id}/forward`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/lib/payments/monitor-escrow.ts
+++ b/src/lib/payments/monitor-escrow.ts
@@ -5,6 +5,7 @@
 import { checkBalance, processPayment, type Payment } from './monitor-balance';
 import { isSufficientPayment } from './tolerance';
 import { fetchAllKeyset } from '../db/keyset';
+import { createEscrow } from '../escrow/service';
 
 // ── Retry tracking (in-memory) ──
 // Prevents infinite retry loops that leak memory and cause OOM crashes.
@@ -485,35 +486,37 @@ export async function runRecurringEscrowCycle(supabase: any, now: Date): Promise
         let childCreated = false;
 
         if (series.payment_method === 'crypto') {
-          const res = await fetch(`${appUrl}/api/escrow`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${internalApiKey}`,
-            },
-            body: JSON.stringify({
-              business_id: series.merchant_id,
-              chain: series.coin,
-              amount: series.amount,
-              currency: series.currency,
-              depositor_address: series.depositor_address,
-              beneficiary_address: series.beneficiary_address,
-              description: series.description,
-              series_id: series.id,
-            }),
+          // ESC-NEW-06: call the service directly rather than POSTing to our own
+          // API with `Bearer INTERNAL_API_KEY`.
+          //
+          // `/api/escrow` authenticates via `authenticateRequest`, which has no
+          // notion of an internal key — it resolves merchant JWTs and business
+          // API keys. Every request this path made was therefore rejected 401
+          // and no series escrow was ever created here. It went unnoticed
+          // because the primary cron (`series-monitor.ts`) creates them by
+          // calling `createEscrow` directly and succeeds, so this fallback only
+          // mattered when the primary was down — which is exactly when it was
+          // needed.
+          //
+          // Server-side code calling server-side code has no reason to make an
+          // HTTP round trip and re-authenticate to itself; doing so is what
+          // created an auth mode that had to exist and did not.
+          const escrowResult = await createEscrow(supabase, {
+            business_id: series.merchant_id,
+            chain: series.coin,
+            amount: Number(series.amount),
+            depositor_address: series.depositor_address,
+            beneficiary_address: series.beneficiary_address,
+            series_id: series.id,
+            metadata: series.description ? { description: series.description } : undefined,
           });
 
-          if (res.ok) {
-            const escrow = await res.json();
-            await supabase
-              .from('escrows')
-              .update({ series_id: series.id })
-              .eq('id', escrow.id);
+          if (escrowResult.success && escrowResult.escrow) {
             childCreated = true;
             recordSuccess(retryKey);
-            console.log(`[Monitor] Created crypto escrow ${escrow.id} for series ${series.id}`);
+            console.log(`[Monitor] Created crypto escrow ${escrowResult.escrow.id} for series ${series.id}`);
           } else {
-            const errText = await res.text();
+            const errText = escrowResult.error || 'Unknown error';
             console.error(`[Monitor] Failed to create crypto escrow for series ${series.id}: ${errText}`);
             recordFailure(retryKey, errText.slice(0, 200));
             stats.errors++;

--- a/src/lib/payments/monitor-escrow.ts
+++ b/src/lib/payments/monitor-escrow.ts
@@ -4,6 +4,7 @@
 
 import { checkBalance, processPayment, type Payment } from './monitor-balance';
 import { isSufficientPayment } from './tolerance';
+import { fetchAllKeyset } from '../db/keyset';
 
 // ── Retry tracking (in-memory) ──
 // Prevents infinite retry loops that leak memory and cause OOM crashes.
@@ -272,11 +273,34 @@ export async function runEscrowCycle(supabase: any, now: Date): Promise<EscrowSt
     }
 
     // ── 2. Process released escrows (trigger settlement/forwarding) ──
-    const { data: releasedEscrows } = await supabase
-      .from('escrows')
-      .select('id, escrow_address, escrow_address_id, chain, amount, deposited_amount, fee_amount, beneficiary_address, business_id')
-      .eq('status', 'released')
-      .limit(20);
+    //
+    // F-1.3-12: this was `.limit(20)` with no `.order()`. An escrow stays
+    // `released` until it settles, so an escrow that can never settle — a dead
+    // RPC, a chain with no gas, a bad address — holds its slot in that window
+    // permanently. Twenty of them and the window is full: no newly-released
+    // escrow is ever settled again, and the job reports success every run.
+    //
+    // The retry gate inside `processEscrowSettlement` already declines to
+    // re-attempt an exhausted escrow, but a skipped escrow still occupied one
+    // of the twenty slots, so the gate made the stall cheaper rather than
+    // fixing it. Walking the set means a fresh escrow is always reached.
+    const { rows: releasedEscrows, truncated: releasedTruncated } = await fetchAllKeyset<any>(
+      (cursor, pageSize) => {
+        let q = supabase
+          .from('escrows')
+          .select('id, escrow_address, escrow_address_id, chain, amount, deposited_amount, fee_amount, beneficiary_address, business_id')
+          .eq('status', 'released')
+          .order('id', { ascending: true })
+          .limit(pageSize);
+        if (cursor) q = q.gt('id', cursor);
+        return q as unknown as Promise<{ data: any[] | null; error: { message: string } | null }>;
+      },
+      { pageSize: 20, maxRows: 500 }
+    );
+
+    if (releasedTruncated) {
+      console.warn('[Monitor] Released-escrow settlement hit its row ceiling; the tail was not processed this run');
+    }
 
     if (releasedEscrows && releasedEscrows.length > 0) {
       console.log(`[Monitor] Processing ${releasedEscrows.length} released escrows for settlement`);
@@ -286,12 +310,27 @@ export async function runEscrowCycle(supabase: any, now: Date): Promise<EscrowSt
     }
 
     // ── 3. Process refunded escrows (return funds to depositor) ──
-    const { data: refundedEscrows } = await supabase
-      .from('escrows')
-      .select('id, escrow_address, escrow_address_id, chain, deposited_amount, depositor_address')
-      .eq('status', 'refunded')
-      .is('settlement_tx_hash', null)
-      .limit(20);
+    //
+    // Same window, same defect as section 2 above — a refund that cannot be
+    // sent holds its slot and starves every later one.
+    const { rows: refundedEscrows, truncated: refundedTruncated } = await fetchAllKeyset<any>(
+      (cursor, pageSize) => {
+        let q = supabase
+          .from('escrows')
+          .select('id, escrow_address, escrow_address_id, chain, deposited_amount, depositor_address')
+          .eq('status', 'refunded')
+          .is('settlement_tx_hash', null)
+          .order('id', { ascending: true })
+          .limit(pageSize);
+        if (cursor) q = q.gt('id', cursor);
+        return q as unknown as Promise<{ data: any[] | null; error: { message: string } | null }>;
+      },
+      { pageSize: 20, maxRows: 500 }
+    );
+
+    if (refundedTruncated) {
+      console.warn('[Monitor] Refunded-escrow settlement hit its row ceiling; the tail was not processed this run');
+    }
 
     if (refundedEscrows && refundedEscrows.length > 0) {
       console.log(`[Monitor] Processing ${refundedEscrows.length} refunded escrows`);

--- a/src/lib/payments/monitor-escrow.ts
+++ b/src/lib/payments/monitor-escrow.ts
@@ -94,7 +94,60 @@ export async function runEscrowCycle(supabase: any, now: Date): Promise<EscrowSt
       for (const escrow of pendingEscrows) {
         stats.checked++;
         try {
+          // BL-02: check the balance BEFORE expiring, not instead of.
+          //
+          // This used to mark a pending escrow `expired` on the clock alone. If
+          // the deposit had landed but no cycle had yet observed it — it arrived
+          // between two runs, or in the last minutes before expiry — the escrow
+          // went to `expired` holding real money, and every exit closed at once:
+          // release wants `funded` or `disputed`, refund wants `funded`, dispute
+          // wants `funded`, and the auto-release/auto-refund sweep below selects
+          // only `funded`. Neither party could do anything and nothing would
+          // ever settle it. The funds were simply gone.
+          //
+          // Reading the chain first means a deposit that arrived in time is
+          // recognised as `funded`; the sweep below then auto-releases or
+          // auto-refunds it on the next cycle, according to the escrow's own
+          // setting. Only a genuinely empty escrow expires.
+          const balanceResult = await checkBalance(escrow.escrow_address, escrow.chain);
+          const balance = balanceResult.balance;
+
           if (new Date(escrow.expires_at) < now) {
+            // An unreadable balance is not an empty one. Expiring on a failed
+            // read is exactly the irreversible mistake this fix exists to stop,
+            // so leave it pending and try again next cycle.
+            if (balanceResult.error) {
+              console.warn(
+                `[Monitor] Escrow ${escrow.id} is past expiry but its balance could not be read (${balanceResult.error}); leaving pending`
+              );
+              stats.errors++;
+              continue;
+            }
+
+            if (isSufficientPayment(balance, escrow.amount)) {
+              await supabase
+                .from('escrows')
+                .update({
+                  status: 'funded',
+                  funded_at: now.toISOString(),
+                  deposited_amount: balance,
+                })
+                .eq('id', escrow.id)
+                .eq('status', 'pending');
+              await supabase.from('escrow_events').insert({
+                escrow_id: escrow.id,
+                event_type: 'funded',
+                actor: 'system',
+                details: {
+                  reason: 'Deposit found at expiry — funded rather than expired so it can still settle',
+                  deposited_amount: balance,
+                },
+              });
+              stats.funded++;
+              console.log(`[Monitor] Escrow ${escrow.id} was funded at expiry — marked funded, not expired`);
+              continue;
+            }
+
             await supabase
               .from('escrows')
               .update({ status: 'expired' })
@@ -104,15 +157,12 @@ export async function runEscrowCycle(supabase: any, now: Date): Promise<EscrowSt
               escrow_id: escrow.id,
               event_type: 'expired',
               actor: 'system',
-              details: {},
+              details: { confirmed_empty: true, balance },
             });
             stats.expired++;
-            console.log(`[Monitor] Escrow ${escrow.id} expired`);
+            console.log(`[Monitor] Escrow ${escrow.id} expired (confirmed empty)`);
             continue;
           }
-
-          const balanceResult = await checkBalance(escrow.escrow_address, escrow.chain);
-          const balance = balanceResult.balance;
 
           if (isSufficientPayment(balance, escrow.amount)) {
             await supabase
@@ -141,17 +191,42 @@ export async function runEscrowCycle(supabase: any, now: Date): Promise<EscrowSt
     }
 
     // ── 1b. Check funded escrows for expiration (auto-refund) ──
+    // F-1.1-01: multisig escrows are excluded here.
+    //
+    // This sweep flips an expired funded escrow to `released` or `refunded` and
+    // hands it to `processEscrowSettlement`, which moves funds using the key the
+    // platform holds. A 2-of-3 multisig escrow has no such key: its funds can
+    // only move through `proposeTransaction` or `disputeMultisigEscrow`, and
+    // both require status `funded`. Marking one `refunded` therefore closed the
+    // only two ways its money could ever move, while the settlement path it was
+    // handed to cannot sign for it either — so the flag would sit on a
+    // permanently unspendable escrow.
+    //
+    // Leaving them `funded` past expiry is correct: for a multisig the deadline
+    // is the point at which the participants should act, not a licence for the
+    // platform to act for them.
     const { data: fundedEscrows } = await supabase
       .from('escrows')
-      .select('id, escrow_address, escrow_address_id, chain, deposited_amount, depositor_address, beneficiary_address, amount, expires_at, allow_auto_release')
+      .select('id, escrow_address, escrow_address_id, chain, deposited_amount, depositor_address, beneficiary_address, amount, expires_at, allow_auto_release, escrow_model')
       .eq('status', 'funded')
       .lt('expires_at', now.toISOString())
+      .or('escrow_model.is.null,escrow_model.neq.multisig_2of3')
       .limit(50);
 
     if (fundedEscrows && fundedEscrows.length > 0) {
       console.log(`[Monitor] Processing ${fundedEscrows.length} expired funded escrows (auto-release/auto-refund)`);
       for (const escrow of fundedEscrows) {
         try {
+          // Belt and braces on the query filter above: a multisig escrow that
+          // reached this loop must not be transitioned, because doing so is
+          // irreversible for funds the platform cannot sign for.
+          if (escrow.escrow_model === 'multisig_2of3') {
+            console.warn(
+              `[Monitor] Skipping expired multisig escrow ${escrow.id} — its funds move only via propose/dispute, which require status 'funded'`
+            );
+            continue;
+          }
+
           if (escrow.allow_auto_release) {
             await supabase
               .from('escrows')

--- a/src/lib/payments/monitor-invoices.scheduler.test.ts
+++ b/src/lib/payments/monitor-invoices.scheduler.test.ts
@@ -41,6 +41,9 @@ function makeSupabase(schedules: any[]) {
       insert: (payload: any) => { ctx.op = 'insert'; ctx.payload = payload; return builder; },
       update: (payload: any) => { ctx.op = 'update'; ctx.payload = payload; return builder; },
       eq: (col: string, val: any) => { ctx.filters[col] = val; return builder; },
+      // Invoice numbering scans every numbered invoice for the business
+      // (F-1.3-10 / R4-DIN-07), so the chain now includes `.not()`.
+      not: () => builder,
       lte: () => builder,
       order: () => builder,
       limit: () => builder,
@@ -58,7 +61,10 @@ function makeSupabase(schedules: any[]) {
             recorded.inserts.push(ctx.payload);
             result = { data: null, error: null };
           } else {
-            result = { data: { invoice_number: 'INV-011' }, error: null };
+            // The numbering helper reads ALL numbered invoices and takes the
+            // highest parsed value, rather than ordering by created_at and
+            // trusting the first row — so this answers with a list.
+            result = { data: [{ invoice_number: 'INV-011' }], error: null };
           }
         }
         return Promise.resolve(result).then(resolve, reject);

--- a/src/lib/payments/monitor-invoices.ts
+++ b/src/lib/payments/monitor-invoices.ts
@@ -8,6 +8,7 @@ import { checkBalance } from './monitor-balance';
 import { isSufficientPayment } from './tolerance';
 import { resolvePayee } from './payee';
 import { getPaymentReceivingWallet } from '../wallets/supported-coins';
+import { fetchAllKeyset } from '../db/keyset';
 
 // Invoice Payment Monitoring
 // ────────────────────────────────────────────────────────────
@@ -25,16 +26,42 @@ export async function runInvoiceMonitorCycle(supabase: any, now: Date): Promise<
 
   try {
     // 1. Check sent invoices for incoming payments
-    const { data: sentInvoices } = await supabase
-      .from('invoices')
-      .select(`
-        *,
-        clients (id, name, email, company_name),
-        businesses (id, name, merchant_id)
-      `)
-      .eq('status', 'sent')
-      .not('payment_address', 'is', null)
-      .limit(100);
+    //
+    // F-1.3-09: this was `.limit(100)` with no `.order()`. An invoice stays
+    // `sent` until it is paid, so the matching set does not drain — once more
+    // than 100 invoices are awaiting payment, the same 100 are checked on every
+    // run and the rest are never checked at all. Payments to them are simply
+    // never detected, and the whole invoice rail stalls platform-wide with no
+    // error anywhere. (18 invoices are `sent` in production today, so this is
+    // latent rather than active — but it triggers on growth, silently.)
+    //
+    // Ordering alone would not fix it: an ordered query returns the same first
+    // page just as reliably. The page has to advance, so this walks the set.
+    const { rows: sentInvoices, truncated, error: sweepError } = await fetchAllKeyset<any>(
+      (cursor, pageSize) => {
+        let q = supabase
+          .from('invoices')
+          .select(`
+            *,
+            clients (id, name, email, company_name),
+            businesses (id, name, merchant_id)
+          `)
+          .eq('status', 'sent')
+          .not('payment_address', 'is', null)
+          .order('id', { ascending: true })
+          .limit(pageSize);
+        if (cursor) q = q.gt('id', cursor);
+        return q as unknown as Promise<{ data: any[] | null; error: { message: string } | null }>;
+      }
+    );
+
+    if (sweepError) {
+      console.error('[Monitor] Invoice sweep page failed:', sweepError);
+      stats.errors++;
+    }
+    if (truncated) {
+      console.warn('[Monitor] Invoice sweep hit its row ceiling; the tail was not checked this run');
+    }
 
     if (sentInvoices) {
       for (const invoice of sentInvoices) {

--- a/src/lib/payments/monitor-invoices.ts
+++ b/src/lib/payments/monitor-invoices.ts
@@ -9,6 +9,7 @@ import { isSufficientPayment } from './tolerance';
 import { resolvePayee } from './payee';
 import { getPaymentReceivingWallet } from '../wallets/supported-coins';
 import { fetchAllKeyset } from '../db/keyset';
+import { insertWithInvoiceNumber } from '../invoices/numbering';
 
 // Invoice Payment Monitoring
 // ────────────────────────────────────────────────────────────
@@ -407,21 +408,14 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
           continue;
         }
 
-        // Generate next invoice number
-        const { data: maxInvoice } = await supabase
-          .from('invoices')
-          .select('invoice_number')
-          .eq('business_id', templateInvoice.business_id)
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .single();
-
-        let nextNum = 1;
-        if (maxInvoice?.invoice_number) {
-          const match = maxInvoice.invoice_number.match(/INV-(\d+)/);
-          if (match) nextNum = parseInt(match[1], 10) + 1;
-        }
-        const invoiceNumber = `INV-${String(nextNum).padStart(3, '0')}`;
+        // F-1.3-10 / R4-DIN-07: this reused the numbering its interactive
+        // sibling had already been fixed for — ordering by `created_at` and
+        // taking the newest row, which is not the highest number, with no retry
+        // on the unique violation two overlapping cycles produce. Here the
+        // consequence is worse than a failed request: the cycle throws, the
+        // schedule is never advanced, and the subscription silently stops
+        // invoicing. The number is now produced by the shared helper at the
+        // point of insert.
 
         const nextDueDate = calculateNextInvoiceDueDate(
           new Date(schedule.next_due_date),
@@ -471,7 +465,10 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
         // resolution landed somewhere else it no longer refers to anything.
         const payeeMoved = payee.address !== templateInvoice.merchant_wallet_address;
 
-        const { error: createError } = await supabase
+        const { data: createdInvoice, error: createError } = await insertWithInvoiceNumber<any>(
+          supabase,
+          templateInvoice.business_id,
+          (invoiceNumber) => supabase
           .from('invoices')
           .insert({
             user_id: templateInvoice.user_id,
@@ -494,7 +491,10 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
               payee_source: payee.source,
               ...(payeeUnverified ? { payee_unverified: true } : {}),
             },
-          });
+          })
+          .select('invoice_number')
+          .single()
+        );
 
         if (createError) {
           console.error(`[Monitor] Failed to create scheduled invoice:`, createError);
@@ -511,7 +511,7 @@ export async function runInvoiceSchedulerCycle(supabase: any, now: Date): Promis
           .eq('id', schedule.id);
 
         stats.created++;
-        console.log(`[Monitor] Created recurring invoice ${invoiceNumber} for schedule ${schedule.id}`);
+        console.log(`[Monitor] Created recurring invoice ${createdInvoice?.invoice_number} for schedule ${schedule.id}`);
       } catch (err) {
         console.error(`[Monitor] Error processing schedule ${schedule.id}:`, err);
         stats.errors++;

--- a/src/lib/payments/monitor.test.ts
+++ b/src/lib/payments/monitor.test.ts
@@ -762,10 +762,123 @@ describe('Payment Monitor', () => {
           return {};
         });
 
+        // BL-02: expiry now reads the chain before writing. An empty address
+        // still expires — but it has to be *known* empty, not assumed.
+        vi.mocked(global.fetch).mockResolvedValue({
+          ok: true,
+          json: async () => ({ chain_stats: { funded_txo_sum: 0, spent_txo_sum: 0 } }),
+        } as any);
+
         const { runOnce } = await import('./monitor');
         await runOnce();
 
         expect(mockUpdate).toHaveBeenCalledWith({ status: 'expired' });
+      });
+
+      it('does not expire an escrow that was funded before the deadline', async () => {
+        // BL-02: this used to mark the escrow `expired` on the clock alone. An
+        // escrow holding real money then had every exit closed at once —
+        // release wants funded or disputed, refund wants funded, dispute wants
+        // funded, and the auto-release sweep selects only funded. Nothing could
+        // move the money, ever.
+        const fundedAtExpiry = {
+          id: 'escrow-funded-at-expiry',
+          escrow_address: 'bc1qtest',
+          chain: 'BTC',
+          amount: 0.001,
+          status: 'created',
+          expires_at: new Date(Date.now() - 1000).toISOString(),
+        };
+
+        const mockUpdate = vi.fn(() => ({
+          eq: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+        }));
+
+        mockSupabase.from = vi.fn((table: string) => {
+          if (table === 'payments') {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve({ data: [], error: null })) })),
+              })),
+            };
+          }
+          if (table === 'escrows') {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  limit: vi.fn(() => Promise.resolve({ data: [fundedAtExpiry], error: null })),
+                })),
+              })),
+              update: mockUpdate,
+            };
+          }
+          if (table === 'escrow_events') {
+            return { insert: vi.fn(() => Promise.resolve({ error: null })) };
+          }
+          return {};
+        });
+
+        // 0.001 BTC = 100000 sats: the deposit landed.
+        vi.mocked(global.fetch).mockResolvedValue({
+          ok: true,
+          json: async () => ({ chain_stats: { funded_txo_sum: 100000, spent_txo_sum: 0 } }),
+        } as any);
+
+        const { runOnce } = await import('./monitor');
+        await runOnce();
+
+        expect(mockUpdate).not.toHaveBeenCalledWith({ status: 'expired' });
+        expect(mockUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'funded', deposited_amount: 0.001 })
+        );
+      });
+
+      it('leaves an escrow pending when the balance cannot be read at expiry', async () => {
+        // Expiring on a failed read is the same irreversible mistake: an
+        // unreadable balance is not a known-empty one.
+        const expiredEscrow = {
+          id: 'escrow-unreadable',
+          escrow_address: 'bc1qtest',
+          chain: 'BTC',
+          amount: 0.001,
+          status: 'created',
+          expires_at: new Date(Date.now() - 1000).toISOString(),
+        };
+
+        const mockUpdate = vi.fn(() => ({
+          eq: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+        }));
+
+        mockSupabase.from = vi.fn((table: string) => {
+          if (table === 'payments') {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve({ data: [], error: null })) })),
+              })),
+            };
+          }
+          if (table === 'escrows') {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  limit: vi.fn(() => Promise.resolve({ data: [expiredEscrow], error: null })),
+                })),
+              })),
+              update: mockUpdate,
+            };
+          }
+          if (table === 'escrow_events') {
+            return { insert: vi.fn(() => Promise.resolve({ error: null })) };
+          }
+          return {};
+        });
+
+        vi.mocked(global.fetch).mockResolvedValue({ ok: false, text: async () => '' } as any);
+
+        const { runOnce } = await import('./monitor');
+        await runOnce();
+
+        expect(mockUpdate).not.toHaveBeenCalledWith({ status: 'expired' });
       });
     });
 
@@ -790,12 +903,19 @@ describe('Payment Monitor', () => {
               select: vi.fn(() => ({
                 eq: vi.fn((_col: string, value: string) => {
                   if (value === 'created') return { limit: emptyLimit };
-                  if (value === 'funded') return { lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  // F-1.1-01: the expired-funded sweep now excludes multisig
+                  // escrows in the query, so the chain is .lt().or().limit().
+                  if (value === 'funded') {
+                    return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
+                  }
                   if (value === 'released') return {
                     limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
                   };
                   if (value === 'refunded') return { is: vi.fn(() => ({ limit: emptyLimit })) };
-                  return { limit: emptyLimit, lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  return {
+                    limit: emptyLimit,
+                    lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })),
+                  };
                 }),
               })),
             };
@@ -846,14 +966,21 @@ describe('Payment Monitor', () => {
               select: vi.fn(() => ({
                 eq: vi.fn((_col: string, value: string) => {
                   if (value === 'created') return { limit: emptyLimit };
-                  if (value === 'funded') return { lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  // F-1.1-01: the expired-funded sweep now excludes multisig
+                  // escrows in the query, so the chain is .lt().or().limit().
+                  if (value === 'funded') {
+                    return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
+                  }
                   if (value === 'released') return { limit: emptyLimit };
                   if (value === 'refunded') return {
                     is: vi.fn(() => ({
                       limit: vi.fn(() => Promise.resolve({ data: [refundedEscrow], error: null })),
                     })),
                   };
-                  return { limit: emptyLimit, lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  return {
+                    limit: emptyLimit,
+                    lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })),
+                  };
                 }),
               })),
             };
@@ -904,12 +1031,19 @@ describe('Payment Monitor', () => {
               select: vi.fn(() => ({
                 eq: vi.fn((_col: string, value: string) => {
                   if (value === 'created') return { limit: emptyLimit };
-                  if (value === 'funded') return { lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  // F-1.1-01: the expired-funded sweep now excludes multisig
+                  // escrows in the query, so the chain is .lt().or().limit().
+                  if (value === 'funded') {
+                    return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
+                  }
                   if (value === 'released') return {
                     limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
                   };
                   if (value === 'refunded') return { is: vi.fn(() => ({ limit: emptyLimit })) };
-                  return { limit: emptyLimit, lt: vi.fn(() => ({ limit: emptyLimit })) };
+                  return {
+                    limit: emptyLimit,
+                    lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })),
+                  };
                 }),
               })),
             };

--- a/src/lib/payments/monitor.test.ts
+++ b/src/lib/payments/monitor.test.ts
@@ -909,9 +909,11 @@ describe('Payment Monitor', () => {
                     return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
                   }
                   if (value === 'released') return {
-                    limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
+                    order: vi.fn(() => ({
+                      limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
+                    })),
                   };
-                  if (value === 'refunded') return { is: vi.fn(() => ({ limit: emptyLimit })) };
+                  if (value === 'refunded') return { is: vi.fn(() => ({ order: vi.fn(() => ({ limit: emptyLimit })) })) };
                   return {
                     limit: emptyLimit,
                     lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })),
@@ -971,10 +973,12 @@ describe('Payment Monitor', () => {
                   if (value === 'funded') {
                     return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
                   }
-                  if (value === 'released') return { limit: emptyLimit };
+                  if (value === 'released') return { order: vi.fn(() => ({ limit: emptyLimit })) };
                   if (value === 'refunded') return {
                     is: vi.fn(() => ({
-                      limit: vi.fn(() => Promise.resolve({ data: [refundedEscrow], error: null })),
+                      order: vi.fn(() => ({
+                        limit: vi.fn(() => Promise.resolve({ data: [refundedEscrow], error: null })),
+                      })),
                     })),
                   };
                   return {
@@ -1037,9 +1041,11 @@ describe('Payment Monitor', () => {
                     return { lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })) };
                   }
                   if (value === 'released') return {
-                    limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
+                    order: vi.fn(() => ({
+                      limit: vi.fn(() => Promise.resolve({ data: [releasedEscrow], error: null })),
+                    })),
                   };
-                  if (value === 'refunded') return { is: vi.fn(() => ({ limit: emptyLimit })) };
+                  if (value === 'refunded') return { is: vi.fn(() => ({ order: vi.fn(() => ({ limit: emptyLimit })) })) };
                   return {
                     limit: emptyLimit,
                     lt: vi.fn(() => ({ or: vi.fn(() => ({ limit: emptyLimit })) })),

--- a/src/lib/payments/monitor.test.ts
+++ b/src/lib/payments/monitor.test.ts
@@ -128,8 +128,12 @@ describe('Payment Monitor', () => {
       const { runOnce } = await import('./monitor');
       await runOnce();
 
+      // IA-008: balance lookups now carry an abort signal, so the call has a
+      // second argument. The deadline is the point — a peer that accepts a
+      // connection and never answers used to hold the whole cycle open.
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('blockstream.info')
+        expect.stringContaining('blockstream.info'),
+        expect.objectContaining({ signal: expect.anything() })
       );
     });
 

--- a/src/lib/payouts/resolve-indeterminate.test.ts
+++ b/src/lib/payouts/resolve-indeterminate.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveIndeterminatePayout } from './service';
+
+/**
+ * Regression tests for N-03 (2026-08-19 audit).
+ *
+ * `indeterminate` had no exit transition. A payout lands there when the
+ * broadcast outcome is unknown — a timeout after the node may already have
+ * accepted the transaction — and `retryPayout` refuses to touch one, correctly,
+ * because re-sending could pay the recipient twice. Its error message told the
+ * operator to mark the payout completed with its tx_hash, or failed and retry,
+ * and no route or function existed to do either. The state described a
+ * procedure nobody could carry out, so those payouts were stuck forever.
+ */
+
+function supabaseWith(payout: Record<string, unknown> | null, updated: unknown = { id: 'p1' }) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    update: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    single: vi.fn().mockResolvedValue({ data: payout, error: payout ? null : { message: 'not found' } }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: updated, error: null }),
+  };
+  return { from: vi.fn(() => chain), _chain: chain } as any;
+}
+
+const INDETERMINATE = { id: 'p1', business_id: 'b1', status: 'indeterminate', recipient_wallet: '0xabc' };
+
+describe('resolveIndeterminatePayout', () => {
+  it('marks a payout completed when given the transaction hash', async () => {
+    const supabase = supabaseWith(INDETERMINATE);
+    const result = await resolveIndeterminatePayout(supabase, 'b1', 'p1', 'completed', '0xdeadbeef');
+
+    expect(result.success).toBe(true);
+    expect(supabase._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed', tx_hash: '0xdeadbeef' })
+    );
+  });
+
+  it('refuses to mark completed without a transaction hash', async () => {
+    // The hash is the evidence the transfer landed. Accepting the claim without
+    // it would let an operator close a payout on nothing but assertion.
+    const supabase = supabaseWith(INDETERMINATE);
+    const result = await resolveIndeterminatePayout(supabase, 'b1', 'p1', 'completed');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('transaction hash is required');
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('marks a payout failed so it becomes retryable again', async () => {
+    const supabase = supabaseWith(INDETERMINATE);
+    const result = await resolveIndeterminatePayout(supabase, 'b1', 'p1', 'failed');
+
+    expect(result.success).toBe(true);
+    expect(supabase._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' })
+    );
+  });
+
+  it('refuses to resolve a payout that is not indeterminate', async () => {
+    // This transition exists only to break the deadlock. Pointing it at a
+    // completed payout would be a way to rewrite settled money records.
+    const supabase = supabaseWith({ ...INDETERMINATE, status: 'completed' });
+    const result = await resolveIndeterminatePayout(supabase, 'b1', 'p1', 'failed');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Only an indeterminate payout');
+  });
+
+  it('refuses when the payout belongs to another business', async () => {
+    const supabase = supabaseWith(null);
+    const result = await resolveIndeterminatePayout(supabase, 'other-business', 'p1', 'failed');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Payout not found');
+  });
+
+  it('loses gracefully when another operator resolved it first', async () => {
+    // The update is conditioned on the status still being indeterminate, so two
+    // operators cannot both apply an outcome to the same payout.
+    const supabase = supabaseWith(INDETERMINATE, null);
+    const result = await resolveIndeterminatePayout(supabase, 'b1', 'p1', 'failed');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('resolved by someone else');
+  });
+});

--- a/src/lib/payouts/service.ts
+++ b/src/lib/payouts/service.ts
@@ -365,6 +365,83 @@ function isAmbiguousBroadcastError(err: unknown): boolean {
 }
 
 /**
+ * Resolve a payout whose broadcast outcome was never determined.
+ *
+ * N-03: `indeterminate` had no exit. A payout entered it when the broadcast
+ * result was ambiguous — a timeout after the node may already have accepted the
+ * transaction — and `retryPayout` refuses to touch one, correctly, because
+ * re-sending could pay the recipient twice. Its error message told the operator
+ * to "mark the payout completed with its tx_hash" or "mark it failed and
+ * retry", and **no route or function existed to do either**. The state was a
+ * dead end that described a procedure nobody could carry out.
+ *
+ * This is the missing transition, and it is deliberately manual: only a human
+ * who has looked at the chain can say which way it went. Nothing here inspects
+ * the chain itself, because a wrong automatic answer either pays twice or
+ * strands a real payment.
+ *
+ * @param resolution - `completed` (the transfer landed; `txHash` is required so
+ *   the record points at it) or `failed` (it did not; the payout becomes
+ *   retryable again).
+ */
+export async function resolveIndeterminatePayout(
+  supabase: SupabaseClient,
+  businessId: string,
+  payoutId: string,
+  resolution: 'completed' | 'failed',
+  txHash?: string
+): Promise<PayoutResult> {
+  if (resolution === 'completed' && !txHash?.trim()) {
+    return {
+      success: false,
+      error: 'A transaction hash is required to mark a payout completed — it is the evidence the transfer landed.',
+    };
+  }
+
+  const { data: payout, error } = await supabase
+    .from('affiliate_payouts')
+    .select('*')
+    .eq('id', payoutId)
+    .eq('business_id', businessId)
+    .single();
+
+  if (error || !payout) {
+    return { success: false, error: 'Payout not found' };
+  }
+
+  if (payout.status !== 'indeterminate') {
+    return {
+      success: false,
+      error: `Only an indeterminate payout can be resolved this way; this one is '${payout.status}'.`,
+    };
+  }
+
+  // Conditioned on the status still being indeterminate, so two operators
+  // resolving the same payout cannot both apply an outcome.
+  const { data: updated } = await supabase
+    .from('affiliate_payouts')
+    .update({
+      status: resolution,
+      ...(resolution === 'completed' ? { tx_hash: txHash!.trim(), paid_at: new Date().toISOString() } : {}),
+      error_message:
+        resolution === 'completed'
+          ? null
+          : 'Broadcast confirmed not to have landed; resolved manually and available for retry.',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', payoutId)
+    .eq('status', 'indeterminate')
+    .select()
+    .maybeSingle();
+
+  if (!updated) {
+    return { success: false, error: 'Payout was resolved by someone else while this request was in flight.' };
+  }
+
+  return { success: true, payout: updated };
+}
+
+/**
  * Retry a failed payout.
  */
 export async function retryPayout(
@@ -389,8 +466,9 @@ export async function retryPayout(
       success: false,
       error:
         `Payout ${payoutId} has an unknown broadcast outcome and cannot be retried automatically. ` +
-        `Check ${payout.recipient_wallet} on-chain: if the transfer landed, mark the payout completed ` +
-        `with its tx_hash; if it did not, mark it failed and retry.`,
+        `Check ${payout.recipient_wallet} on-chain, then PATCH this payout with ` +
+        `{"resolution":"completed","tx_hash":"..."} if the transfer landed, or ` +
+        `{"resolution":"failed"} if it did not — which makes it retryable again.`,
     };
   }
 

--- a/src/lib/proposals/expiry.test.ts
+++ b/src/lib/proposals/expiry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertNotExpired } from './service';
+import type { Proposal } from './types';
+
+/**
+ * Regression tests for NEW-F1A-P-02 (2026-08-19 audit).
+ *
+ * `expires_at` was checked in exactly one place — `acceptProposal` — so an
+ * expired proposal could still be countered, rejected, withdrawn, re-sent and
+ * viewed by token. The deadline meant "you cannot accept this" rather than
+ * "this is over", which is not what either party takes it to mean.
+ *
+ * `'expired'` is also a permitted value of `proposals_status_check` that
+ * nothing ever wrote, so no proposal has ever appeared as expired anywhere —
+ * they sit as `sent` for ever.
+ */
+
+function supabase() {
+  const chain: any = {
+    update: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    in: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  return { from: vi.fn(() => chain), _chain: chain } as any;
+}
+
+const PAST = new Date(Date.now() - 60_000).toISOString();
+const FUTURE = new Date(Date.now() + 60 * 60_000).toISOString();
+
+function proposal(over: Partial<Proposal> = {}): Proposal {
+  return { id: 'p1', status: 'sent', expires_at: FUTURE, ...over } as Proposal;
+}
+
+describe('assertNotExpired', () => {
+  it('allows a proposal inside its deadline', async () => {
+    const db = supabase();
+    expect(await assertNotExpired(db, proposal())).toBeNull();
+    expect(db.from).not.toHaveBeenCalled();
+  });
+
+  it('allows a proposal with no deadline at all', async () => {
+    const db = supabase();
+    expect(await assertNotExpired(db, proposal({ expires_at: null }))).toBeNull();
+  });
+
+  it('refuses a proposal past its deadline', async () => {
+    const result = await assertNotExpired(supabase(), proposal({ expires_at: PAST }));
+    expect(result?.ok).toBe(false);
+    expect(result?.code).toBe('EXPIRED');
+    expect(result?.status).toBe(409);
+  });
+
+  it("gives the 'expired' status a producer", async () => {
+    // The state was reachable in the schema and in the type union, and
+    // unreachable in practice — nothing ever wrote it.
+    const db = supabase();
+    await assertNotExpired(db, proposal({ expires_at: PAST }));
+
+    expect(db.from).toHaveBeenCalledWith('proposals');
+    expect(db._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'expired' })
+    );
+    // Conditioned on the proposal still being negotiable, so a concurrent
+    // accept or reject is not overwritten by a lazy expiry.
+    expect(db._chain.in).toHaveBeenCalledWith('status', ['sent', 'countered']);
+  });
+
+  it('does not rewrite the status of an already-closed proposal', async () => {
+    // An accepted proposal that happens to be past its deadline is still
+    // accepted; expiry must not undo a decision.
+    const db = supabase();
+    const result = await assertNotExpired(db, proposal({ status: 'accepted', expires_at: PAST }));
+
+    expect(result?.ok).toBe(false);
+    expect(db.from).not.toHaveBeenCalled();
+  });
+
+  it('treats an unparseable deadline as no deadline', async () => {
+    // Refusing to act because of a bad timestamp would be a worse failure than
+    // letting it through — the deal is real, the date field is not.
+    const db = supabase();
+    expect(await assertNotExpired(db, proposal({ expires_at: 'not-a-date' }))).toBeNull();
+  });
+});

--- a/src/lib/proposals/service.ts
+++ b/src/lib/proposals/service.ts
@@ -174,6 +174,15 @@ export async function addRevision(
     return { ok: false, error: 'A positive amount is required', status: 400 };
   }
 
+  // NEW-F1A-P-02: countering an expired proposal used to work, which meant a
+  // deadline stopped the deal closing but not the negotiation continuing — the
+  // one thing a deadline is for. The opening offer is exempt: a draft being
+  // sent for the first time has no deadline to have passed yet.
+  if (isNegotiable(proposal.status)) {
+    const expired = await assertNotExpired(supabase, proposal);
+    if (expired) return expired;
+  }
+
   const { data: previous } = await supabase
     .from('proposal_revisions')
     .select(REVISION_SELECT)
@@ -256,6 +265,49 @@ export async function addRevision(
 }
 
 /** Guard: may `party` put a counter-offer on this proposal right now? */
+/**
+ * Refuse a proposal past its own deadline, and record that it is past it.
+ *
+ * NEW-F1A-P-02: `expires_at` was checked in exactly one place — `acceptProposal`
+ * — so a proposal could still be countered, rejected, withdrawn, re-sent and
+ * viewed by token long after it had expired. The deadline meant "you cannot
+ * accept this", not "this is over", which is not what either party reads it as
+ * when they set one.
+ *
+ * `'expired'` is also a permitted value of `proposals_status_check` that
+ * *nothing ever wrote*. The state existed in the schema and in the type union
+ * and was unreachable, so no proposal has ever shown as expired in any list or
+ * dashboard — they simply sit as `sent` for ever.
+ *
+ * Both halves are fixed here. The status is flipped on the way past, which
+ * gives the state a producer without a new cron: expiry is only interesting
+ * when someone tries to act, and that is exactly when this runs. The write is
+ * conditioned on the status still being negotiable so it cannot overwrite a
+ * concurrent accept or reject.
+ */
+export async function assertNotExpired(
+  supabase: SupabaseClient,
+  proposal: Proposal,
+): Promise<ServiceResult<null> | null> {
+  if (!proposal.expires_at) return null;
+
+  const expiresAt = new Date(proposal.expires_at).getTime();
+  // An unparseable deadline is treated as no deadline rather than as an expired
+  // one — refusing to act on a proposal because of a bad timestamp would be a
+  // worse failure than letting it through.
+  if (!Number.isFinite(expiresAt) || expiresAt > Date.now()) return null;
+
+  if (isNegotiable(proposal.status)) {
+    await supabase
+      .from('proposals')
+      .update({ status: 'expired', updated_at: new Date().toISOString() })
+      .eq('id', proposal.id)
+      .in('status', ['sent', 'countered']);
+  }
+
+  return { ok: false, error: 'This proposal has expired', code: 'EXPIRED', status: 409 };
+}
+
 export function assertCounterable(
   status: ProposalStatus,
   party: Party,
@@ -310,9 +362,8 @@ export async function acceptProposal(
     return { ok: false, error: reason, code: 'NOT_ACCEPTABLE', status: 409 };
   }
 
-  if (proposal.expires_at && new Date(proposal.expires_at) < new Date()) {
-    return { ok: false, error: 'This proposal has expired', code: 'EXPIRED', status: 409 };
-  }
+  const expiredOnAccept = await assertNotExpired(supabase, proposal);
+  if (expiredOnAccept) return expiredOnAccept;
 
   // Payee gate.
   let payeeAddress = revision.merchant_wallet_address;
@@ -429,6 +480,12 @@ export async function rejectProposal(
       status: 409,
     };
   }
+
+  // NEW-F1A-P-02: the deadline applied only to accepting, so an expired
+  // proposal could still be rejected — and the rejection would look like a
+  // live decision rather than something that had already lapsed.
+  const expiredOnReject = await assertNotExpired(supabase, proposal);
+  if (expiredOnReject) return expiredOnReject;
 
   const now = new Date().toISOString();
 

--- a/src/lib/proposals/service.ts
+++ b/src/lib/proposals/service.ts
@@ -27,6 +27,7 @@ import {
   type ProposalStatus,
   type RevisionInput,
 } from './types';
+import { insertWithInvoiceNumber } from '../invoices/numbering';
 
 export interface ServiceError {
   ok: false;
@@ -503,25 +504,21 @@ export async function convertToInvoice(
     return { ok: false, error: payee.error, code: payee.code, status: payee.status };
   }
 
-  const { data: maxInvoice } = await supabase
-    .from('invoices')
-    .select('invoice_number')
-    .eq('business_id', proposal.business_id)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  let nextNum = 1;
-  const match = maxInvoice?.invoice_number?.match(/INV-(\d+)/);
-  if (match) nextNum = parseInt(match[1], 10) + 1;
-
-  const { data: invoice, error } = await supabase
+  // NEW-F1A-P-01: this ordered by `created_at` and took the newest row, which
+  // is not the highest number — backdate or delete an invoice and the next
+  // number collides with one that already exists. There was also no retry on
+  // the unique violation a concurrent create causes, so the loser simply could
+  // not convert their proposal. Both are handled by the shared helper now.
+  const { data: invoice, error } = await insertWithInvoiceNumber<any>(
+    supabase,
+    proposal.business_id,
+    (invoiceNumber) => supabase
     .from('invoices')
     .insert({
       user_id: proposal.user_id,
       business_id: proposal.business_id,
       client_id: proposal.client_id,
-      invoice_number: `INV-${String(nextNum).padStart(3, '0')}`,
+      invoice_number: invoiceNumber,
       status: 'draft',
       currency: revision.currency || 'USD',
       amount: revision.amount,
@@ -538,7 +535,8 @@ export async function convertToInvoice(
       },
     })
     .select('*')
-    .single();
+    .single()
+  );
 
   if (error || !invoice) {
     return { ok: false, error: error?.message || 'Failed to create invoice', status: 400 };

--- a/src/lib/realtime/useRealtimePayments.ts
+++ b/src/lib/realtime/useRealtimePayments.ts
@@ -103,13 +103,15 @@ export function useRealtimePayments({
         url += `?businessId=${businessId}`;
       }
 
-      // Get auth token
-      const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
-      if (token) {
-        url += `${businessId ? '&' : '?'}token=${token}`;
-      }
-
-      const eventSource = new EventSource(url);
+      // G-1.2-04: the session token is no longer appended to the URL.
+      //
+      // It is a 7-day credential, and a URL puts it into proxy and CDN access
+      // logs, browser history, and the `Referer` header of anything navigated
+      // to next. `EventSource` cannot set headers, which is why it was there —
+      // but it does send cookies on a same-origin request, and the session
+      // cookie is httpOnly, so `withCredentials` authenticates the stream
+      // without the credential ever appearing in a URL.
+      const eventSource = new EventSource(url, { withCredentials: true });
       eventSourceRef.current = eventSource;
 
       eventSource.onopen = () => {

--- a/src/lib/wallet-sdk/backup.test.ts
+++ b/src/lib/wallet-sdk/backup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { encryptSeedPhrase, decryptSeedPhrase } from './backup';
+import { encryptSeedPhrase, decryptSeedPhrase, assertBackupPasswordStrength } from './backup';
 
 describe('wallet-sdk/backup', () => {
   const testMnemonic =
@@ -70,7 +70,10 @@ describe('wallet-sdk/backup', () => {
     });
 
     it('should work with unicode characters in the password', async () => {
-      const unicodePassword = '密码🔐пароль';
+      // Lengthened when the backup password gained a minimum (L6B-05 / REC-01).
+      // The point of this test is that unicode round-trips through the crypto,
+      // not that a 9-character password is acceptable.
+      const unicodePassword = '密码🔐пароль-очень-длинный';
       const { data } = await encryptSeedPhrase(testMnemonic, unicodePassword, testWalletId);
       const decrypted = await decryptSeedPhrase(data, unicodePassword);
 
@@ -101,5 +104,45 @@ describe('wallet-sdk/backup', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+/**
+ * Regression tests for L6B-05 and REC-01 (2026-08-19 audit).
+ *
+ * `encryptSeedPhrase` accepted any password, including an empty one, while the
+ * wallet create and import flows require length plus a strength score. The
+ * exported file is the artefact that leaves the device, so it had the weakest
+ * gate protecting the strongest secret.
+ */
+describe('assertBackupPasswordStrength', () => {
+  it('rejects an empty or short password', () => {
+    expect(() => assertBackupPasswordStrength('')).toThrow(/at least 12/);
+    expect(() => assertBackupPasswordStrength('short')).toThrow(/at least 12/);
+    expect(() => assertBackupPasswordStrength('elevenchars')).toThrow(/at least 12/);
+  });
+
+  it('accepts a long passphrase without punctuation or digits', () => {
+    // Length is the rule, because demanding character classes penalises exactly
+    // the passwords people should be encouraged to use.
+    expect(() => assertBackupPasswordStrength('correct horse battery staple')).not.toThrow();
+  });
+
+  it('accepts a long non-Latin passphrase', () => {
+    expect(() => assertBackupPasswordStrength('密码密码密码密码密码密码密码密码')).not.toThrow();
+  });
+
+  it('accepts 12-15 characters when types are mixed', () => {
+    expect(() => assertBackupPasswordStrength('Tr0ubador!xyz')).not.toThrow();
+  });
+
+  it('rejects 12-15 characters of a single type', () => {
+    expect(() => assertBackupPasswordStrength('aaaaaaaaaaaaa')).toThrow(/16\+|mix/);
+  });
+
+  it('counts emoji as one character, not two', () => {
+    // 11 code points: must fail, and must fail on LENGTH rather than by
+    // accident of UTF-16 units making it look like 12+.
+    expect(() => assertBackupPasswordStrength('🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐')).toThrow(/at least 12/);
   });
 });

--- a/src/lib/wallet-sdk/backup.ts
+++ b/src/lib/wallet-sdk/backup.ts
@@ -26,11 +26,59 @@ export interface EncryptedBackup {
  * @param walletId - Wallet ID (used in filename and file header)
  * @returns Encrypted backup with raw bytes and suggested filename
  */
+/**
+ * Minimum strength for the passphrase protecting an exported seed phrase.
+ *
+ * L6B-05 / REC-01: this accepted any password, including an empty one, while
+ * the wallet create and import flows require length >= 8 plus a strength score.
+ * The exported file is the one artefact that leaves the device — the thing an
+ * attacker walks away with — so it should not have the weakest gate.
+ *
+ * The rule is LENGTH-primary, deliberately. Requiring particular character
+ * classes is a poor proxy for entropy and actively penalises the passwords
+ * people should be encouraged to use: a long passphrase, or a non-Latin one,
+ * can be far stronger than `Passw0rd!` while failing an upper/lower/digit
+ * check. Counted in code points, so an emoji or a CJK character counts once
+ * rather than twice.
+ *
+ * Enforced here rather than only in the UI: the UI check protects one button,
+ * this protects every caller of the SDK.
+ */
+export function assertBackupPasswordStrength(password: string): void {
+  const chars = [...(password ?? '')];
+
+  if (chars.length < 12) {
+    throw new Error(
+      'Backup password too weak — it is the only thing protecting your seed phrase. ' +
+      'It needs at least 12 characters.'
+    );
+  }
+
+  // Long enough that variety stops mattering much.
+  if (chars.length >= 16) return;
+
+  const classes = [
+    /\p{Ll}/u,
+    /\p{Lu}/u,
+    /\p{Nd}/u,
+    /[^\p{L}\p{Nd}]/u,
+  ].filter((re) => re.test(password)).length;
+
+  if (classes < 2) {
+    throw new Error(
+      'Backup password too weak — it is the only thing protecting your seed phrase. ' +
+      'Use 16+ characters, or mix character types.'
+    );
+  }
+}
+
 export async function encryptSeedPhrase(
   mnemonic: string,
   password: string,
   walletId: string
 ): Promise<EncryptedBackup> {
+  assertBackupPasswordStrength(password);
+
   // Lazy-load openpgp to avoid crashing in jsdom/SSR environments
   const openpgp = await import('openpgp');
 

--- a/src/lib/wallet-sdk/lightning.ts
+++ b/src/lib/wallet-sdk/lightning.ts
@@ -63,15 +63,21 @@ export function createLightningMethods(
 
     /**
      * Provision a Lightning node for this wallet.
+     *
+     * @param _mnemonic - **Deprecated and ignored.** Provisioning creates a
+     *   custodial LNbits wallet; there is no signer and nothing to derive, so
+     *   the seed was sent, validated and discarded (NEW-20). It is no longer
+     *   transmitted. The parameter is retained only so existing call sites keep
+     *   compiling — pass `undefined`, or drop it once callers are updated.
+     * @param businessId - Optional business to attach the node to.
      */
-    async enableLightning(mnemonic: string, businessId?: string): Promise<LightningNode> {
+    async enableLightning(_mnemonic?: string, businessId?: string): Promise<LightningNode> {
       const data = await client.request<any>({
         method: 'POST',
         path: '/api/lightning/nodes',
         body: {
           wallet_id: walletId,
           business_id: businessId,
-          mnemonic,
         },
         authenticated: true,
       });

--- a/src/lib/wallet-sdk/verify-prepared.test.ts
+++ b/src/lib/wallet-sdk/verify-prepared.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { preparedTxPaysRecipient } from './verify-prepared';
+import type { UnsignedTransactionData } from '../web-wallet/prepare-tx';
+
+/**
+ * Regression tests for REC-04 (2026-08-19 audit).
+ *
+ * `WalletSDK.send()` asked the server to prepare a transaction and then signed
+ * whatever came back. Holding the key locally only protects the user if the
+ * thing being signed is inspected — otherwise a hostile server returns an
+ * unsigned_tx paying its own address, echoes the requested recipient in the
+ * JSON beside it, and the SDK signs it.
+ */
+
+const PAYEE_EVM = '0x1111111111111111111111111111111111111111';
+const ATTACKER_EVM = '0x2222222222222222222222222222222222222222';
+const TOKEN = '0x3333333333333333333333333333333333333333';
+
+function evmNative(to: string): UnsignedTransactionData {
+  return { type: 'evm', chainId: 1, nonce: 0, to, value: '0x1', gasLimit: 21000,
+    maxFeePerGas: '0x1', maxPriorityFeePerGas: '0x1' } as UnsignedTransactionData;
+}
+
+/** ERC-20 transfer(address,uint256): selector + padded recipient + padded amount. */
+function evmToken(recipient: string): UnsignedTransactionData {
+  const padded = recipient.replace(/^0x/, '').padStart(64, '0');
+  const amount = '1'.padStart(64, '0');
+  return {
+    type: 'evm', chainId: 1, nonce: 0, to: TOKEN, value: '0x0', gasLimit: 60000,
+    maxFeePerGas: '0x1', maxPriorityFeePerGas: '0x1',
+    data: `0xa9059cbb${padded}${amount}`, contractAddress: TOKEN,
+  } as UnsignedTransactionData;
+}
+
+describe('preparedTxPaysRecipient', () => {
+  it('accepts a native EVM transfer to the requested address', () => {
+    expect(preparedTxPaysRecipient(evmNative(PAYEE_EVM), PAYEE_EVM)).toBe(true);
+  });
+
+  it('rejects a native EVM transfer redirected elsewhere', () => {
+    // The attack in one line.
+    expect(preparedTxPaysRecipient(evmNative(ATTACKER_EVM), PAYEE_EVM)).toBe(false);
+  });
+
+  it('reads the recipient out of ERC-20 calldata, not the contract address', () => {
+    // A token transfer's `to` is the token contract, so comparing that field
+    // would pass for any recipient at all.
+    expect(preparedTxPaysRecipient(evmToken(PAYEE_EVM), PAYEE_EVM)).toBe(true);
+    expect(preparedTxPaysRecipient(evmToken(ATTACKER_EVM), PAYEE_EVM)).toBe(false);
+  });
+
+  it('is case-insensitive for EVM addresses', () => {
+    expect(preparedTxPaysRecipient(evmNative(PAYEE_EVM.toUpperCase()), PAYEE_EVM)).toBe(true);
+  });
+
+  it('accepts a Bitcoin tx that pays the payee alongside change', () => {
+    const tx = {
+      type: 'btc', feeRate: 1, inputs: [],
+      outputs: [
+        { address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', value: 100000 },
+        { address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', value: 50000 },
+      ],
+    } as unknown as UnsignedTransactionData;
+    expect(preparedTxPaysRecipient(tx, '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2')).toBe(true);
+  });
+
+  it('rejects a Bitcoin tx that pays the payee nothing', () => {
+    const tx = {
+      type: 'btc', feeRate: 1, inputs: [],
+      outputs: [{ address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', value: 150000 }],
+    } as unknown as UnsignedTransactionData;
+    expect(preparedTxPaysRecipient(tx, '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2')).toBe(false);
+  });
+
+  it('finds a Solana recipient in instruction fields or account keys', () => {
+    const payee = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const byField = {
+      type: 'sol', recentBlockhash: 'x', feePayer: 'y',
+      instructions: [{ destination: payee }],
+    } as unknown as UnsignedTransactionData;
+    const byKeys = {
+      type: 'sol', recentBlockhash: 'x', feePayer: 'y',
+      instructions: [{ keys: [{ pubkey: payee }] }],
+    } as unknown as UnsignedTransactionData;
+
+    expect(preparedTxPaysRecipient(byField, payee)).toBe(true);
+    expect(preparedTxPaysRecipient(byKeys, payee)).toBe(true);
+    expect(preparedTxPaysRecipient(byField, 'SomeOtherAddress1111111111111111111111111')).toBe(false);
+  });
+
+  it('refuses an unrecognised shape rather than passing it', () => {
+    // "Cannot check" must not read as "checked and fine".
+    const weird = { type: 'quantum' } as unknown as UnsignedTransactionData;
+    expect(preparedTxPaysRecipient(weird, PAYEE_EVM)).toBe(false);
+  });
+
+  it('refuses an empty expected recipient', () => {
+    expect(preparedTxPaysRecipient(evmNative(PAYEE_EVM), '')).toBe(false);
+  });
+});

--- a/src/lib/wallet-sdk/verify-prepared.ts
+++ b/src/lib/wallet-sdk/verify-prepared.ts
@@ -1,0 +1,78 @@
+import type { UnsignedTransactionData } from '../web-wallet/prepare-tx';
+
+/**
+ * Check that a server-prepared transaction pays who the caller asked it to.
+ *
+ * REC-04: `WalletSDK.send()` asked the server to prepare a transaction and then
+ * signed whatever came back. The wallet holds the key, so the server never
+ * needs to see it — but that only helps if the thing being signed is checked.
+ * A compromised or hostile server could return an `unsigned_tx` paying its own
+ * address while echoing the requested recipient back in the JSON alongside it,
+ * and the SDK would sign it without looking.
+ *
+ * The unsigned transaction is a structured object rather than an opaque blob,
+ * so this needs no chain-specific decoding: the recipient is right there in
+ * every variant.
+ *
+ * Recipient only, deliberately. It is the field that turns a payment into a
+ * theft, and it can be compared exactly on all three chain families. Amounts
+ * live in different units per variant (hex wei, satoshis, lamports) and the
+ * conversion from the caller's human-readable figure is where a bug would
+ * silently weaken the check; the broadcast endpoint verifies the amount
+ * server-side against the prepared row instead.
+ */
+export function preparedTxPaysRecipient(
+  unsignedTx: UnsignedTransactionData,
+  expectedTo: string,
+): boolean {
+  if (!expectedTo) return false;
+  const want = expectedTo.trim().toLowerCase();
+
+  switch (unsignedTx.type) {
+    case 'evm': {
+      // For an ERC-20 transfer the tx `to` is the token contract and the real
+      // recipient sits in the calldata, left-padded to 32 bytes after the
+      // 4-byte selector.
+      if (unsignedTx.data && unsignedTx.data !== '0x' && unsignedTx.data.length >= 138) {
+        const recipient = `0x${unsignedTx.data.slice(34, 74)}`.toLowerCase();
+        return recipient === want;
+      }
+      return (unsignedTx.to ?? '').toLowerCase() === want;
+    }
+
+    case 'btc':
+    case 'bch': {
+      // A real spend has a change output back to the sender, so this asks
+      // whether the payee is paid at all — not whether they are the only one.
+      // Bitcoin addresses are case-sensitive, so compare both ways.
+      return (unsignedTx.outputs ?? []).some(
+        (o) => o.address === expectedTo.trim() || o.address?.toLowerCase() === want,
+      );
+    }
+
+    case 'sol': {
+      const instructions = unsignedTx.instructions ?? [];
+      return instructions.some((ix) => {
+        const raw = ix as unknown as Record<string, unknown>;
+        const candidates = [raw.destination, raw.to, raw.recipient]
+          .filter((v): v is string => typeof v === 'string');
+        if (candidates.some((c) => c === expectedTo.trim() || c.toLowerCase() === want)) {
+          return true;
+        }
+        const keys = raw.keys;
+        if (Array.isArray(keys)) {
+          return keys.some((k) => {
+            const pk = (k as { pubkey?: unknown })?.pubkey;
+            return typeof pk === 'string' && (pk === expectedTo.trim() || pk.toLowerCase() === want);
+          });
+        }
+        return false;
+      });
+    }
+
+    default:
+      // An unrecognised shape cannot be checked, and "cannot check" must not
+      // read as "checked and fine".
+      return false;
+  }
+}

--- a/src/lib/wallet-sdk/wallet.ts
+++ b/src/lib/wallet-sdk/wallet.ts
@@ -90,6 +90,27 @@ export class Wallet {
     const mnemonic = generateMnemonic(options.words || 12);
     const bundle = await deriveWalletBundle(mnemonic, chains);
 
+    if (!bundle.privateKeySecp256k1) {
+      throw new WalletSDKError(
+        'NO_SECP256K1_KEY',
+        'Cannot derive proof-of-ownership key',
+        400
+      );
+    }
+
+    // V-04: /create used to accept a public key and a list of on-chain
+    // addresses from anyone, unauthenticated and unproved, while its sibling
+    // /import required a signature for exactly the same write. Signed the same
+    // way as import, with the master account key that matches the
+    // public_key_secp256k1 being registered.
+    const proofMessage = `coinpayportal:create:${Date.now()}`;
+    const proofSignature = uint8ArrayToHex(
+      secp256k1.sign(
+        new TextEncoder().encode(proofMessage),
+        hexToUint8Array(bundle.privateKeySecp256k1)
+      )
+    );
+
     const result = await client.request<{
       wallet_id: string;
       created_at: string;
@@ -105,6 +126,10 @@ export class Wallet {
           address: a.address,
           derivation_path: a.derivationPath,
         })),
+        proof_of_ownership: {
+          message: proofMessage,
+          signature: proofSignature,
+        },
       },
     });
 
@@ -849,7 +874,8 @@ export class Wallet {
   }
 
   getLightningNode() { return this.ln.getLightningNode(); }
-  enableLightning(mnemonic: string, businessId?: string) { return this.ln.enableLightning(mnemonic, businessId); }
+  /** @param _mnemonic - Deprecated and ignored; the seed is no longer sent (NEW-20). */
+  enableLightning(_mnemonic?: string, businessId?: string) { return this.ln.enableLightning(undefined, businessId); }
   getLightningAddress() { return this.ln.getLightningAddress(); }
   setLightningAddress(username: string) { return this.ln.setLightningAddress(username); }
   createLightningInvoice(amount: number, memo?: string) { return this.ln.createLightningInvoice(amount, memo); }

--- a/src/lib/wallet-sdk/wallet.ts
+++ b/src/lib/wallet-sdk/wallet.ts
@@ -5,6 +5,7 @@
  * Uses fetch() exclusively — NO Supabase imports.
  */
 
+import { preparedTxPaysRecipient } from './verify-prepared';
 import { WalletAPIClient, hexToUint8Array, uint8ArrayToHex } from './client';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { WalletEventEmitter } from './events';
@@ -614,6 +615,21 @@ export class Wallet {
       priority: options.priority,
     });
     console.log('[WalletSDK.send] Prepared tx:', { txId: prepared.txId, fee: prepared.fee });
+
+    // Check what the server handed back actually pays the intended recipient
+    // before signing it (REC-04).
+    //
+    // Holding the key locally is only a protection if the thing being signed is
+    // inspected. A hostile or compromised server could return an unsigned_tx
+    // paying its own address while echoing the requested recipient in the JSON
+    // beside it, and this signed whatever arrived.
+    if (!preparedTxPaysRecipient(prepared.unsignedTx, options.toAddress)) {
+      throw new WalletSDKError(
+        'PREPARED_TX_MISMATCH',
+        `The prepared transaction does not pay ${options.toAddress} — refusing to sign it.`,
+        400
+      );
+    }
 
     console.log('[WalletSDK.send] Signing transaction...');
     const signed = await signTransaction({

--- a/src/lib/wallets/derivation-family.test.ts
+++ b/src/lib/wallets/derivation-family.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  PLATFORM_ARBITER_DERIVATION_INDEX,
   acquireFamilyIndex,
   bumpFamilyIndex,
   getDerivationFamily,
@@ -200,13 +201,27 @@ describe('getMaxFamilyIndex', () => {
 });
 
 describe('acquireFamilyIndex', () => {
-  it('initializes the family counter from -1 when no row exists', async () => {
+  it('starts a fresh family at 1, because 0 belongs to the platform arbiter', async () => {
+    // ESC-NEW-14: `getMaxFamilyIndex` returns -1 for a family with no
+    // addresses, so this used to start at `seed + 1` = 0 — the same index
+    // GET /api/escrow/platform-arbiter derives the arbiter key at, from the
+    // same system mnemonic. The first payment or escrow address ever created on
+    // a chain therefore derived the very key the platform signs disputes with.
     const supabase = makeMockSupabase();
     const idx = await acquireFamilyIndex(supabase, 'USDC_POL');
-    expect(idx).toBe(0);
-    // Counter should now sit at 1 so the next caller gets 1.
+    expect(idx).toBe(1);
     const next = await acquireFamilyIndex(supabase, 'USDC_POL');
-    expect(next).toBe(1);
+    expect(next).toBe(2);
+  });
+
+  it('never issues the platform arbiter index, even from a legacy counter', async () => {
+    // A counter created before the reservation can still be sitting on 0.
+    const supabase = makeMockSupabase();
+    supabase.indexes.set('EVM', PLATFORM_ARBITER_DERIVATION_INDEX);
+
+    const idx = await acquireFamilyIndex(supabase, 'USDC_POL');
+    expect(idx).not.toBe(PLATFORM_ARBITER_DERIVATION_INDEX);
+    expect(idx).toBe(1);
   });
 
   it('seeds a fresh USDC_POL counter past existing ETH addresses (regression for d0rz)', async () => {
@@ -229,7 +244,8 @@ describe('acquireFamilyIndex', () => {
     for (let i = 0; i < 5; i++) {
       got.push(await acquireFamilyIndex(supabase, 'USDC_POL'));
     }
-    expect(got).toEqual([0, 1, 2, 3, 4]);
+    // Offset by one: index 0 is reserved for the platform arbiter (ESC-NEW-14).
+    expect(got).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('returns 10 distinct indexes under concurrent acquisition (Promise.all)', async () => {
@@ -238,8 +254,9 @@ describe('acquireFamilyIndex', () => {
       Array.from({ length: 10 }, () => acquireFamilyIndex(supabase, 'USDC_POL'))
     );
     expect(new Set(results).size).toBe(10);
-    // Final counter should be 10
-    expect(supabase.indexes.get('EVM')).toBe(10);
+    // 1..10 rather than 0..9 — index 0 is reserved (ESC-NEW-14).
+    expect(results).not.toContain(PLATFORM_ARBITER_DERIVATION_INDEX);
+    expect(supabase.indexes.get('EVM')).toBe(11);
   });
 
   it('shares the EVM counter across mixed-coin requests so no two callers get the same index', async () => {
@@ -249,19 +266,21 @@ describe('acquireFamilyIndex', () => {
     // 9 EVM + 1 SOL → EVM should produce 9 distinct indexes 0..8, SOL should produce 0
     const evmResults = results.slice(0, 9);
     expect(new Set(evmResults).size).toBe(9);
-    expect(results[9]).toBe(0); // USDC_SOL has its own counter
+    expect(evmResults).not.toContain(PLATFORM_ARBITER_DERIVATION_INDEX);
+    // USDC_SOL has its own counter — which reserves index 0 just the same.
+    expect(results[9]).toBe(1);
   });
 });
 
 describe('bumpFamilyIndex', () => {
   it('moves the family counter forward but never backward', async () => {
     const supabase = makeMockSupabase();
-    await acquireFamilyIndex(supabase, 'USDC_POL'); // counter → 1
-    await acquireFamilyIndex(supabase, 'USDC_POL'); // counter → 2
+    await acquireFamilyIndex(supabase, 'USDC_POL'); // issues 1, counter → 2
+    await acquireFamilyIndex(supabase, 'USDC_POL'); // issues 2, counter → 3
 
-    // Try to regress (newIndex=0 → would set counter to 1, but current=2)
+    // Try to regress (newIndex=0 → would set counter to 1, but current=3)
     await bumpFamilyIndex(supabase, 'USDC_POL', 0);
-    expect(supabase.indexes.get('EVM')).toBe(2);
+    expect(supabase.indexes.get('EVM')).toBe(3);
 
     // Move forward
     await bumpFamilyIndex(supabase, 'USDC_POL', 9);

--- a/src/lib/wallets/derivation-family.ts
+++ b/src/lib/wallets/derivation-family.ts
@@ -28,6 +28,25 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+/**
+ * Derivation index reserved for the platform arbiter, never issued as a
+ * payment or escrow address.
+ *
+ * ESC-NEW-14: `GET /api/escrow/platform-arbiter` derives the arbiter key at
+ * index 0 of the *same* system mnemonic these payment addresses come from — and
+ * `getMaxFamilyIndex` returns -1 for a family with no addresses yet, so the
+ * counter started at `seed + 1` = 0. The first payment or escrow address ever
+ * created on a chain therefore derived the very key the platform arbiter signs
+ * disputes with: one key, two roles, and customer funds sitting on the
+ * arbiter's address.
+ *
+ * The codebase already reserves BIP44 account 1 for the gas relayer for exactly
+ * this reason (see GAS_RELAYER_DERIVATION_PATH). This is the same idea one
+ * level down: a slot the counter can never enter.
+ */
+export const PLATFORM_ARBITER_DERIVATION_INDEX = 0;
+
+
 export type SystemBlockchain =
   | 'BTC' | 'BCH' | 'ETH' | 'POL' | 'SOL'
   | 'DOGE' | 'XRP' | 'ADA' | 'BNB'
@@ -103,6 +122,7 @@ export async function acquireFamilyIndex(
   cryptocurrency: SystemBlockchain
 ): Promise<number> {
   const familyKey = getDerivationFamily(cryptocurrency);
+  // ESC-NEW-14: never hand out the platform arbiter's index. See the constant.
 
   for (let attempt = 0; attempt < 10; attempt++) {
     const { data: indexData, error: indexError } = await supabase
@@ -114,7 +134,10 @@ export async function acquireFamilyIndex(
     if (indexError || !indexData) {
       // Initialize the row, seeded past any pre-existing addresses in
       // the family so we don't immediately collide with them.
-      const seed = await getMaxFamilyIndex(supabase, cryptocurrency);
+      const seed = Math.max(
+        await getMaxFamilyIndex(supabase, cryptocurrency),
+        PLATFORM_ARBITER_DERIVATION_INDEX
+      );
       const { error: insertErr } = await supabase
         .from('system_wallet_indexes')
         .insert({ cryptocurrency: familyKey, next_index: seed + 2 });
@@ -125,12 +148,18 @@ export async function acquireFamilyIndex(
       continue;
     }
 
-    const candidate = indexData.next_index;
+    // A counter created before this reservation existed can still be sitting on
+    // the arbiter's index; step over it rather than deriving a duplicate key.
+    const candidate =
+      indexData.next_index === PLATFORM_ARBITER_DERIVATION_INDEX
+        ? indexData.next_index + 1
+        : indexData.next_index;
+
     const { data: swapped, error: casError } = await supabase
       .from('system_wallet_indexes')
       .update({ next_index: candidate + 1 })
       .eq('cryptocurrency', familyKey)
-      .eq('next_index', candidate)
+      .eq('next_index', indexData.next_index)
       .select('next_index')
       .single();
 

--- a/src/lib/wallets/merchant-service.test.ts
+++ b/src/lib/wallets/merchant-service.test.ts
@@ -113,7 +113,7 @@ describe('Merchant Wallet Service', () => {
     it('should create wallet without label', async () => {
       const walletData = {
         cryptocurrency: 'ETH' as const,
-        wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1234',
+        wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1',
       };
 
       const expectedWallet = {
@@ -203,7 +203,7 @@ describe('Merchant Wallet Service', () => {
           id: 'wallet-2',
           merchant_id: merchantId,
           cryptocurrency: 'ETH',
-          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1234',
+          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1',
           label: null,
           is_active: true,
           created_at: '2024-01-01T00:00:00Z',
@@ -462,7 +462,7 @@ describe('Merchant Wallet Service', () => {
           id: 'mw-2',
           merchant_id: merchantId,
           cryptocurrency: 'ETH',
-          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1234',
+          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1',
           is_active: true,
         },
       ];
@@ -545,7 +545,7 @@ describe('Merchant Wallet Service', () => {
           id: 'mw-2',
           merchant_id: merchantId,
           cryptocurrency: 'ETH',
-          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1234',
+          wallet_address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1',
           is_active: true,
         },
       ];

--- a/src/lib/wallets/merchant-service.ts
+++ b/src/lib/wallets/merchant-service.ts
@@ -1,12 +1,12 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { SUPPORTED_CRYPTOCURRENCIES, type Cryptocurrency } from './service';
+import { validateWalletAddress } from './validate-address';
 
 /**
  * Validation schemas
  */
 const cryptocurrencySchema = z.enum(SUPPORTED_CRYPTOCURRENCIES);
-const walletAddressSchema = z.string().min(26, 'Invalid wallet address').max(100);
 const labelSchema = z.string().max(100).optional();
 
 /**
@@ -73,12 +73,18 @@ export async function createMerchantWallet(
       };
     }
 
-    // Validate wallet address
-    const addressResult = walletAddressSchema.safeParse(input.wallet_address);
-    if (!addressResult.success) {
+    // Validate wallet address.
+    //
+    // H-R-09: this checked length only (26-100 chars), so anything of roughly
+    // the right size was accepted as a payout destination — an address for the
+    // wrong chain, a transposed character, a sentence. Now format-checked
+    // against the chain it is being saved for, via the shared validator both
+    // wallet tables use.
+    const addressResult = validateWalletAddress(input.wallet_address, input.cryptocurrency);
+    if (!addressResult.ok) {
       return {
         success: false,
-        error: addressResult.error.errors[0].message,
+        error: addressResult.error,
       };
     }
 
@@ -261,13 +267,13 @@ export async function updateMerchantWallet(
       };
     }
 
-    // Validate wallet address if provided
+    // Validate wallet address if provided (H-R-09 — see the create path).
     if (input.wallet_address) {
-      const addressResult = walletAddressSchema.safeParse(input.wallet_address);
-      if (!addressResult.success) {
+      const addressResult = validateWalletAddress(input.wallet_address, cryptocurrency);
+      if (!addressResult.ok) {
         return {
           success: false,
-          error: addressResult.error.errors[0].message,
+          error: addressResult.error,
         };
       }
     }

--- a/src/lib/wallets/secure-forwarding.ts
+++ b/src/lib/wallets/secure-forwarding.ts
@@ -14,6 +14,7 @@
  * - All key operations are logged (without exposing key material)
  */
 
+import { settlementThreshold, toFiniteNumber } from '@/lib/payments/tolerance';
 import { tryRequireEncryptionKey } from '@/lib/crypto/require-key';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { ethers } from 'ethers';
@@ -616,6 +617,52 @@ export async function forwardPaymentSecurely(
             error: 'Address holds no balance to forward',
           };
         }
+
+        // The floor check the comment above promises (BL-04).
+        //
+        // Only `<= 0` was actually tested, so the "floor sanity check" existed
+        // in prose and nowhere else. A balance that had dropped below the
+        // expected amount but stayed above zero — funds partially moved, or a
+        // stale read mid-sweep — forwarded anyway, splitting a pot that no
+        // longer matched what the payment recorded.
+        //
+        // `settlementThreshold` is the same relative epsilon confirmation uses,
+        // so a float round-trip does not trip this while a real shortfall does.
+        const expected = toFiniteNumber(payment.crypto_amount);
+        if (expected !== null && expected > 0 && actualBalance < settlementThreshold(expected)) {
+          console.error(
+            `[SECURE] Payment ${paymentId}: address holds ${actualBalance} but ${expected} was confirmed — ` +
+            'funds appear to have already moved. Refusing to forward on a stale view.'
+          );
+          await supabase
+            .from('payments')
+            .update({ status: 'confirmed', updated_at: new Date().toISOString() })
+            .eq('id', paymentId)
+            .eq('status', 'forwarding');
+          return {
+            success: false,
+            error: 'Address balance is below the confirmed amount — refusing to forward',
+          };
+        }
+
+        // F-1.1-13: a balance inside (0, gasReserve] leaves nothing to split
+        // once gas is held back, and the tiered split then misbehaves rather
+        // than reporting the real problem.
+        if (gasReserve > 0 && actualBalance <= gasReserve) {
+          console.error(
+            `[SECURE] Payment ${paymentId}: balance ${actualBalance} does not exceed the ${gasReserve} gas reserve`
+          );
+          await supabase
+            .from('payments')
+            .update({ status: 'confirmed', updated_at: new Date().toISOString() })
+            .eq('id', paymentId)
+            .eq('status', 'forwarding');
+          return {
+            success: false,
+            error: 'Address balance does not cover the gas reserve',
+          };
+        }
+
         potToSplit = actualBalance;
       } else {
         console.warn(

--- a/src/lib/wallets/service.ts
+++ b/src/lib/wallets/service.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
+import { validateWalletAddress } from './validate-address';
 
 /**
  * Supported cryptocurrencies
@@ -30,7 +31,6 @@ export type Cryptocurrency = (typeof SUPPORTED_CRYPTOCURRENCIES)[number];
  * Validation schemas
  */
 const cryptocurrencySchema = z.enum(SUPPORTED_CRYPTOCURRENCIES);
-const walletAddressSchema = z.string().min(26, 'Invalid wallet address').max(100);
 
 /**
  * Types
@@ -92,12 +92,18 @@ export async function createWallet(
       };
     }
 
-    // Validate wallet address
-    const addressResult = walletAddressSchema.safeParse(input.wallet_address);
-    if (!addressResult.success) {
+    // Validate wallet address.
+    //
+    // H-R-09: this checked length only (26-100 chars), so anything of roughly
+    // the right size was accepted as a payout destination — an address for the
+    // wrong chain, a transposed character, a sentence. Now format-checked
+    // against the chain it is being saved for, via the shared validator both
+    // wallet tables use.
+    const addressResult = validateWalletAddress(input.wallet_address, input.cryptocurrency);
+    if (!addressResult.ok) {
       return {
         success: false,
-        error: addressResult.error.errors[0].message,
+        error: addressResult.error,
       };
     }
 
@@ -318,13 +324,13 @@ export async function updateWallet(
       };
     }
 
-    // Validate wallet address if provided
+    // Validate wallet address if provided (H-R-09 — see the create path).
     if (input.wallet_address) {
-      const addressResult = walletAddressSchema.safeParse(input.wallet_address);
-      if (!addressResult.success) {
+      const addressResult = validateWalletAddress(input.wallet_address, cryptocurrency);
+      if (!addressResult.ok) {
         return {
           success: false,
-          error: addressResult.error.errors[0].message,
+          error: addressResult.error,
         };
       }
     }

--- a/src/lib/wallets/system-wallet.test.ts
+++ b/src/lib/wallets/system-wallet.test.ts
@@ -285,12 +285,38 @@ describe('System Wallet', () => {
     });
 
     describe('ADA derivation', () => {
-      it('should derive ADA address (simplified)', async () => {
+      it('derives a real, spendable Cardano address', async () => {
+        // L5-02: this used to produce `addr1_${pubkeyHex.slice(0,40)}...` — a
+        // placeholder, trailing ellipsis included, that is not a Cardano
+        // address in any sense. Production issued five of them between
+        // February and July 2026 and none was ever paid, because no wallet
+        // will accept a malformed address. This is the *custodial* wallet: the
+        // address a customer is told to send money to.
+        //
+        // The old assertion matched that exact broken shape, so the bug had a
+        // test defending it.
         const result = await deriveSystemPaymentAddress('ADA', 0);
-        // Simplified ADA address format
-        expect(result.address).toMatch(/^addr1_[a-f0-9]+\.\.\.$/);
+
         expect(result.cryptocurrency).toBe('ADA');
         expect(result.derivationPath).toBe("m/44'/1815'/0'/0'");
+
+        // No underscore, no ellipsis: bech32 has neither.
+        expect(result.address).not.toContain('_');
+        expect(result.address).not.toContain('.');
+        expect(result.address).toMatch(/^addr1[0-9a-z]+$/);
+
+        // The real check. The forwarding path calls Address.from_bech32 on this
+        // string, so if the library will not parse it the funds cannot be moved
+        // even after they arrive.
+        const CardanoWasm = await import('@emurgo/cardano-serialization-lib-nodejs');
+        const lib = (CardanoWasm as unknown as { default?: unknown }).default ?? CardanoWasm;
+        const parsed = (lib as any).Address.from_bech32(result.address);
+        expect(parsed.to_bech32()).toBe(result.address);
+
+        // And the fallback the spend path uses to recover the payment key hash
+        // (`to_bytes().slice(1, 29)`) must land on 28 bytes of key hash.
+        const keyHashSlice = Buffer.from(parsed.to_bytes()).subarray(1, 29);
+        expect(keyHashSlice.length).toBe(28);
       });
 
       it('should derive different addresses for different indexes', async () => {
@@ -318,9 +344,15 @@ describe('System Wallet', () => {
       });
 
       it('should throw error for unsupported cryptocurrency', async () => {
+        // The mnemonic lookup happens before the chain switch, so an unknown
+        // chain is refused with "no mnemonic configured for INVALID" rather
+        // than reaching the `Unsupported cryptocurrency` throw further down.
+        // Either way it is refused and nothing is derived, which is what
+        // matters; this assertion had simply drifted from the code while the
+        // file sat excluded from the test run.
         await expect(
           deriveSystemPaymentAddress('INVALID' as SystemBlockchain, 0)
-        ).rejects.toThrow(/Unsupported cryptocurrency/);
+        ).rejects.toThrow(/INVALID/);
       });
     });
   });

--- a/src/lib/wallets/system-wallet.ts
+++ b/src/lib/wallets/system-wallet.ts
@@ -19,6 +19,7 @@
  */
 
 import { tryRequireEncryptionKey } from '@/lib/crypto/require-key';
+import { getCardanoSerializationLib } from '@/lib/server/optional-deps';
 import { HDKey } from '@scure/bip32';
 import { generateMnemonic as bip39GenerateMnemonic, mnemonicToSeedSync, validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
@@ -654,12 +655,34 @@ async function deriveCardanoWallet(
   const path = `m/44'/1815'/${index}'/0'`;
   const { key } = deriveEd25519Key(seed, path);
 
-  const publicKey = await getEd25519PublicKey(key);
-  
-  // Simplified: return hex-encoded public key as placeholder
-  // Full Cardano addresses require bech32 encoding with specific prefixes
-  // For production, use a proper Cardano library
-  const address = `addr1_${publicKey.toString('hex').substring(0, 40)}...`;
+  // L5-02: this used to return `addr1_${pubkeyHex.slice(0,40)}...` — a
+  // placeholder, ellipsis and all, that is not a Cardano address in any sense.
+  // Production has been handing these out since February 2026; five were issued
+  // and none was ever paid, because no wallet will accept a malformed address.
+  //
+  // It was never a "simplified" address, it was an unusable one, and this is
+  // the *custodial* wallet — the address a customer is told to pay.
+  //
+  // The forwarding side was fine all along: `CardanoProvider.sendTransaction`
+  // builds and submits real transactions with cardano-serialization-lib, which
+  // is already a dependency. Only generation was a stub, so the rail was broken
+  // at exactly one end.
+  //
+  // An enterprise address (payment credential, no staking part) is the right
+  // shape for a receive-and-forward address: it needs no stake registration and
+  // the spend path derives the key hash from `to_bytes().slice(1, 29)`, which is
+  // precisely the payment key hash an enterprise address carries.
+  const CardanoWasm = await getCardanoSerializationLib();
+
+  const privateKeyObj = CardanoWasm.PrivateKey.from_normal_bytes(key);
+  const publicKeyObj = privateKeyObj.to_public();
+
+  const address = CardanoWasm.EnterpriseAddress.new(
+    CardanoWasm.NetworkInfo.mainnet().network_id(),
+    CardanoWasm.Credential.from_keyhash(publicKeyObj.hash())
+  )
+    .to_address()
+    .to_bech32();
 
   return {
     address,

--- a/src/lib/wallets/validate-address.test.ts
+++ b/src/lib/wallets/validate-address.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { validateWalletAddress } from './validate-address';
+
+/**
+ * Regression tests for H-R-09 (2026-08-19 audit).
+ *
+ * `walletAddressSchema` was `z.string().min(26).max(100)` — length and nothing
+ * else — and was declared separately in `wallets/service.ts` and
+ * `wallets/merchant-service.ts`, so the two payout tables could drift apart as
+ * well as both being wrong.
+ *
+ * These rows are payout destinations: whatever a merchant saves is where their
+ * money is sent. There is no confirmation step downstream and no way to recall
+ * a transfer, so this validator is the only thing between a typo and a
+ * permanent loss.
+ */
+describe('validateWalletAddress', () => {
+  it('accepts a well-formed address for its chain', () => {
+    const r = validateWalletAddress('0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1', 'ETH');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an EVM address of the wrong length', () => {
+    // Found in this repository's own test fixtures, where it had passed the
+    // length-only check for as long as it had existed: 44 hex characters where
+    // an Ethereum address has 40. Long enough to look right at a glance.
+    const r = validateWalletAddress('0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1234', 'ETH');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an address that belongs to a different chain', () => {
+    // The realistic mistake: a merchant pastes their Bitcoin address into the
+    // Ethereum row. Both are "a wallet address" and both pass on length.
+    const r = validateWalletAddress('1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', 'ETH');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects prose of a plausible length', () => {
+    const r = validateWalletAddress('please send my money here thanks', 'ETH');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects anything too short or too long to be an address', () => {
+    expect(validateWalletAddress('0xabc', 'ETH').ok).toBe(false);
+    expect(validateWalletAddress('0x' + 'a'.repeat(200), 'ETH').ok).toBe(false);
+  });
+
+  it('rejects a non-string', () => {
+    expect(validateWalletAddress(undefined, 'ETH').ok).toBe(false);
+    expect(validateWalletAddress(12345, 'ETH').ok).toBe(false);
+  });
+
+  it('trims surrounding whitespace rather than rejecting it', () => {
+    // Pasting an address commonly brings a trailing space or newline with it,
+    // and failing on that would be an annoyance rather than a protection.
+    const r = validateWalletAddress('  0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1  ', 'ETH');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.address).toBe('0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1');
+  });
+
+  it('allows a chain it has no validator for, rather than blocking the save', () => {
+    // `isValidPayoutAddress` is three-state on purpose: `null` means "no rule
+    // for this chain". Refusing then would break saving a perfectly good
+    // address, which is worse than the check being unavailable — and it is the
+    // same contract /api/payments/create uses for the same decision.
+    const r = validateWalletAddress('some-address-for-an-unknown-chain-value', 'NOT_A_CHAIN');
+    expect(r.ok).toBe(true);
+  });
+});

--- a/src/lib/wallets/validate-address.ts
+++ b/src/lib/wallets/validate-address.ts
@@ -1,0 +1,45 @@
+import { isValidPayoutAddress } from '../blockchain/address-format';
+
+/**
+ * Validate a merchant-supplied payout address.
+ *
+ * H-R-09: `walletAddressSchema` was `z.string().min(26).max(100)` — length and
+ * nothing else — and it was declared separately in `wallets/service.ts` and
+ * `wallets/merchant-service.ts`, so the two tables could drift apart as well as
+ * both being wrong. These rows are payout destinations: whatever a merchant
+ * saves here is where their money is sent. A transposed character, an address
+ * pasted for the wrong chain, or a line of prose 30 characters long all passed.
+ *
+ * Now shared, so the two wallet tables cannot disagree about what a valid
+ * address is, and format-checked against the chain it is being saved for.
+ *
+ * `isValidPayoutAddress` is deliberately three-state and that is preserved
+ * here: `false` means "malformed for this chain" and is rejected, while `null`
+ * means "no validator exists for this chain" and is allowed through. Blocking a
+ * chain we have no rule for would break saving a perfectly good address, which
+ * is a worse outcome than the check being unavailable — and it is the same
+ * contract /api/payments/create already uses for the same decision.
+ */
+export function validateWalletAddress(
+  address: unknown,
+  cryptocurrency: string
+): { ok: true; address: string } | { ok: false; error: string } {
+  if (typeof address !== 'string') {
+    return { ok: false, error: 'Invalid wallet address' };
+  }
+
+  const trimmed = address.trim();
+
+  // Kept as a cheap first pass. No supported chain has an address shorter than
+  // 26 characters or longer than 100, so this rejects obvious rubbish before
+  // any per-chain work.
+  if (trimmed.length < 26 || trimmed.length > 100) {
+    return { ok: false, error: 'Invalid wallet address' };
+  }
+
+  if (isValidPayoutAddress(trimmed, cryptocurrency) === false) {
+    return { ok: false, error: `Invalid ${cryptocurrency} wallet address` };
+  }
+
+  return { ok: true, address: trimmed };
+}

--- a/src/lib/web-bot-auth/directory.ts
+++ b/src/lib/web-bot-auth/directory.ts
@@ -18,6 +18,7 @@ import {
   // createPublicKey only accepts Node's.
   type JsonWebKey as NodeJsonWebKey,
 } from 'crypto';
+import { safeFetch } from '@/lib/security/ssrf';
 
 /** RFC 8037 Ed25519 public JWK. */
 export interface Ed25519Jwk {
@@ -146,34 +147,41 @@ export async function fetchDirectory(signatureAgent: string): Promise<Ed25519Jwk
   const cached = directoryCache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.keys;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  // NEW-23: the fetch used to be a bare `fetch()` guarded only by
+  // `assertSafeDirectoryUrl`, which matches private *literals* — 127.x, 10.x,
+  // fc00::/7 and so on. That does nothing about a hostname: `keys.attacker.test`
+  // with an A record pointing at 169.254.169.254 passes every one of those
+  // patterns, and the comment on that function admits as much. The URL comes
+  // from an attacker-controlled request header, so this is a request-forgery
+  // primitive into the deployment's own network.
+  //
+  // `safeFetch` is the codebase's real answer: it resolves the hostname and
+  // rejects on the *resolved address*, then re-validates every redirect hop
+  // against the same rules. The literal checks stay because they reject the
+  // obvious cases before any DNS lookup happens, and because they enforce the
+  // https-only rule the spec requires.
+  const fetched = await safeFetch(key, {
+    timeoutMs: FETCH_TIMEOUT_MS,
+    headers: { accept: `${DIRECTORY_CONTENT_TYPE}, application/json` },
+  });
 
-  let body: string;
-  try {
-    const response = await fetch(key, {
-      // A redirect could bounce the fetch to an internal address that the
-      // checks above already rejected for the original URL.
-      redirect: 'error',
-      signal: controller.signal,
-      headers: { accept: `${DIRECTORY_CONTENT_TYPE}, application/json` },
-    });
+  if (!fetched.ok) {
+    throw new Error(`Key directory could not be fetched: ${fetched.reason}`);
+  }
 
-    if (!response.ok) {
-      throw new Error(`Key directory returned HTTP ${response.status}`);
-    }
+  const response = fetched.response;
+  if (!response.ok) {
+    throw new Error(`Key directory returned HTTP ${response.status}`);
+  }
 
-    const length = Number(response.headers.get('content-length') ?? 0);
-    if (length > MAX_DIRECTORY_BYTES) {
-      throw new Error('Key directory is too large');
-    }
+  const length = Number(response.headers.get('content-length') ?? 0);
+  if (length > MAX_DIRECTORY_BYTES) {
+    throw new Error('Key directory is too large');
+  }
 
-    body = await response.text();
-    if (body.length > MAX_DIRECTORY_BYTES) {
-      throw new Error('Key directory is too large');
-    }
-  } finally {
-    clearTimeout(timer);
+  const body = await response.text();
+  if (body.length > MAX_DIRECTORY_BYTES) {
+    throw new Error('Key directory is too large');
   }
 
   let parsed: unknown;

--- a/src/lib/web-wallet/__tests__/send-transaction-flow.test.ts
+++ b/src/lib/web-wallet/__tests__/send-transaction-flow.test.ts
@@ -35,24 +35,48 @@ function createMockSupabase(overrides: {
     error: overrides.selectError ?? null,
   });
 
+  // WW-01: broadcast re-checks the wallet's whitelist and daily spend limit,
+  // because prepare moves no money and broadcast does. `wallet_settings` is
+  // read as select→eq→single, one `eq` shorter than the transaction lookup, so
+  // the mock answers per table. Wide-open settings keep these tests about the
+  // broadcast path they were written for.
+  const settingsChain: any = {
+    select: vi.fn(() => settingsChain),
+    eq: vi.fn(() => settingsChain),
+    insert: vi.fn(() => settingsChain),
+    upsert: vi.fn(() => settingsChain),
+    single: vi.fn().mockResolvedValue({
+      data: {
+        wallet_id: 'w1',
+        daily_spend_limit: null,
+        whitelist_addresses: [],
+        whitelist_enabled: false,
+      },
+      error: null,
+    }),
+  };
+
   return {
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            single: singleMock,
-          }),
-        }),
-      }),
-      update: updateMock,
-      insert: vi.fn().mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === 'wallet_settings') return settingsChain;
+      return {
         select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { id: 'tx-prepared-001', status: 'pending' },
-            error: null,
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: singleMock,
+            }),
           }),
         }),
-      }),
+        update: updateMock,
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'tx-prepared-001', status: 'pending' },
+              error: null,
+            }),
+          }),
+        }),
+      };
     }),
     _updateMock: updateMock,
   } as any;

--- a/src/lib/web-wallet/auth.ts
+++ b/src/lib/web-wallet/auth.ts
@@ -8,7 +8,9 @@
  */
 
 import { secp256k1 } from '@noble/curves/secp256k1';
+import { ed25519 } from '@noble/curves/ed25519.js';
 import { createHash, randomBytes } from 'crypto';
+import { base58Decode } from './identity';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { generateToken, verifyToken } from '../auth/jwt';
 import { checkAndRecordSignatureAsync } from './rate-limit';
@@ -223,6 +225,49 @@ export function verifyChallengeSignature(
   try {
     const messageBytes = new TextEncoder().encode(challenge);
     return verifySecp256k1Signature(signatureHex, messageBytes, publicKeyHex);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify an ed25519 signature over a challenge message.
+ *
+ * NEW-09: `importWallet` verified proof of ownership only inside
+ * `if (public_key_secp256k1)`. The import schema requires *at least one* of the
+ * two keys, so submitting only `public_key_ed25519` skipped the check
+ * entirely — the `proof_of_ownership` object was still mandatory, but its
+ * contents were never read and any string passed. That let an unauthenticated
+ * caller register a wallet under an ed25519 public key they do not hold.
+ *
+ * The public key is base58 (the Solana convention used for ed25519 throughout
+ * this codebase) and the signature is hex, matching the secp256k1 path. Signed
+ * over the raw message bytes, as `verifyChallengeSignature` does, so a client
+ * constructs both proofs the same way.
+ *
+ * Returns false rather than throwing on malformed input: a caller deciding
+ * whether to trust someone needs a boolean, not an exception that a
+ * surrounding try/catch might turn into a pass.
+ */
+export function verifyEd25519ChallengeSignature(
+  challenge: string,
+  signatureHex: string,
+  publicKeyBase58: string
+): boolean {
+  try {
+    if (!challenge || !signatureHex || !publicKeyBase58) return false;
+
+    const clean = signatureHex.startsWith('0x') ? signatureHex.slice(2) : signatureHex;
+    const signature = Uint8Array.from(Buffer.from(clean, 'hex'));
+    // Ed25519 signatures are exactly 64 bytes. Buffer.from silently stops at
+    // the first invalid hex pair, so check the decoded length rather than
+    // trusting that the input was hex at all.
+    if (signature.length !== 64) return false;
+
+    const publicKey = base58Decode(publicKeyBase58);
+    if (publicKey.length !== 32) return false;
+
+    return ed25519.verify(signature, new TextEncoder().encode(challenge), publicKey);
   } catch {
     return false;
   }

--- a/src/lib/web-wallet/broadcast.test.ts
+++ b/src/lib/web-wallet/broadcast.test.ts
@@ -16,6 +16,8 @@ function createMockSupabase(overrides: {
   txRecord?: any;
   txError?: any;
   updateError?: any;
+  settings?: any;
+  spendRows?: { amount: string }[];
 } = {}) {
   const defaultTx = {
     id: 'tx-123',
@@ -39,14 +41,48 @@ function createMockSupabase(overrides: {
     data: overrides.txRecord ?? defaultTx,
     error: overrides.txError ?? null,
   });
-  const eqWallet = vi.fn().mockReturnValue({ single: singleFn });
+  // The daily-spend query is `.eq().eq().eq()[.neq()].in().gte()` awaited
+  // directly, rather than `.single()`. Thenable so `await` resolves it.
+  const spendRows = overrides.spendRows ?? [];
+  const spendChain: any = {
+    eq: vi.fn(() => spendChain),
+    neq: vi.fn(() => spendChain),
+    in: vi.fn(() => spendChain),
+    gte: vi.fn(() => spendChain),
+    then: (resolve: any) => resolve({ data: spendRows, error: null }),
+  };
+
+  const eqWallet = vi.fn().mockReturnValue({ single: singleFn, eq: spendChain.eq });
   const eqId = vi.fn().mockReturnValue({ eq: eqWallet });
   const selectFn = vi.fn().mockReturnValue({ eq: eqId });
 
+  // WW-01: broadcast now re-checks the wallet's whitelist and daily spend
+  // limit, because prepare moves no money and broadcast does. That reads
+  // `wallet_settings`, whose query shape is select→eq→single rather than the
+  // transaction's select→eq→eq→single, so the mock has to answer per table.
+  // Settings are returned wide open, so these tests still exercise the binding
+  // logic they were written for rather than the limit.
+  const settingsSingle = vi.fn().mockResolvedValue({
+    data: overrides.settings ?? {
+      wallet_id: 'w1',
+      daily_spend_limit: null,
+      whitelist_addresses: [],
+      whitelist_enabled: false,
+    },
+    error: null,
+  });
+  const settingsChain: any = {
+    select: vi.fn(() => settingsChain),
+    eq: vi.fn(() => settingsChain),
+    single: settingsSingle,
+    insert: vi.fn(() => settingsChain),
+    upsert: vi.fn(() => settingsChain),
+  };
+
   return {
-    from: vi.fn().mockReturnValue({
-      select: selectFn,
-      update: updateFn,
+    from: vi.fn((table: string) => {
+      if (table === 'wallet_settings') return settingsChain;
+      return { select: selectFn, update: updateFn };
     }),
   } as any;
 }
@@ -574,6 +610,80 @@ describe('broadcastTransaction — signed/prepared binding (WW-01)', () => {
 
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  it('refuses at broadcast when the daily spend limit is already exhausted', async () => {
+    // WW-01's second half: the whitelist and daily spend limit were enforced at
+    // prepare and never again. Prepare moves no money — broadcast does — and
+    // the check ran BEFORE the transaction row was inserted, so two prepares
+    // racing each other both read the same pre-insert total and both passed.
+    // By broadcast time every pending row exists, so the sum is the real one.
+    const signed = await signNative(TO, '1');
+    const supabase = createMockSupabase({
+      txRecord: {
+        id: 'tx-123',
+        wallet_id: 'w1',
+        chain: 'ETH',
+        status: 'pending',
+        from_address: '0xSENDER',
+        to_address: TO,
+        amount: '1',
+        metadata: {
+          unsigned_tx: { type: 'evm' },
+          expires_at: new Date(Date.now() + 300_000).toISOString(),
+        },
+      },
+      settings: {
+        wallet_id: 'w1',
+        daily_spend_limit: 0.5,
+        whitelist_addresses: [],
+        whitelist_enabled: false,
+      },
+    });
+
+    const result = await broadcastTransaction(supabase, 'w1', {
+      tx_id: 'tx-123',
+      signed_tx: signed,
+      chain: 'ETH',
+    });
+
+    expect(result.success).toBe(false);
+    // Nothing may reach the network once the limit says no.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses at broadcast when the recipient is not whitelisted', async () => {
+    const signed = await signNative(TO, '1');
+    const supabase = createMockSupabase({
+      txRecord: {
+        id: 'tx-123',
+        wallet_id: 'w1',
+        chain: 'ETH',
+        status: 'pending',
+        from_address: '0xSENDER',
+        to_address: TO,
+        amount: '1',
+        metadata: {
+          unsigned_tx: { type: 'evm' },
+          expires_at: new Date(Date.now() + 300_000).toISOString(),
+        },
+      },
+      settings: {
+        wallet_id: 'w1',
+        daily_spend_limit: null,
+        whitelist_addresses: ['0x0000000000000000000000000000000000000009'],
+        whitelist_enabled: true,
+      },
+    });
+
+    const result = await broadcastTransaction(supabase, 'w1', {
+      tx_id: 'tx-123',
+      signed_tx: signed,
+      chain: 'ETH',
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('refuses a signed transaction whose amount differs from the prepared one', async () => {

--- a/src/lib/web-wallet/broadcast.ts
+++ b/src/lib/web-wallet/broadcast.ts
@@ -8,6 +8,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { WalletChain } from './identity';
 import { isValidChain } from './identity';
+import { checkTransactionAllowed } from './settings';
 
 /** Truncate an address for safe logging */
 function truncAddr(addr: string): string {
@@ -575,6 +576,62 @@ export async function broadcastTransaction(
       error: 'Signed transaction does not match the prepared transaction',
       code: 'TX_BINDING_MISMATCH',
     };
+  }
+
+  if (!binding.verified && !binding.mismatch) {
+    // Not a disagreement — an inability to tell. BCH has no decoder here
+    // (bitcoinjs-lib does not handle its SIGHASH_FORKID variant) and Solana's
+    // transfer amount sits in instruction data whose layout is program-specific,
+    // so on those chains the amount is not bound to what was prepared.
+    //
+    // Refusing outright would take those chains offline, so the broadcast
+    // proceeds. The outcome is already recorded on the row below as
+    // `binding_verified`; this makes the same fact visible in the logs at the
+    // moment it happens, rather than only to whoever later reads the metadata.
+    //
+    // The residual gap is real and is tracked: on BCH and Solana the *amount*
+    // in the signed bytes is still not compared to the prepared amount.
+    console.warn(
+      `[Broadcast] Tx ${input.tx_id} on ${chain} could not be bound to the prepared transaction: ${binding.reason}`
+    );
+  }
+
+  // Re-check the wallet's own spending controls, now, against the record the
+  // signed bytes were just bound to.
+  //
+  // WW-01: the whitelist and daily spend limit were enforced at prepare and
+  // never again. Prepare moves no money — broadcast does — and the check ran
+  // *before* the transaction row was inserted, so two prepares racing each
+  // other both read the same pre-insert total and both passed. By the time we
+  // are here every pending row exists, so the sum is the real one.
+  //
+  // `to_address` and `amount` come from the prepared record rather than the
+  // request, and the binding check above has already refused any signed
+  // transaction that disagrees with them on the chains it can decode.
+  if (txRecord.to_address && txRecord.amount !== null && txRecord.amount !== undefined) {
+    const securityCheck = await checkTransactionAllowed(
+      supabase,
+      walletId,
+      txRecord.to_address,
+      Number(txRecord.amount),
+      chain,
+      // This transaction's own row is already `pending` and counted; excluding
+      // it stops the amount being charged against the limit twice.
+      txRecord.id
+    );
+
+    if (!securityCheck.allowed) {
+      await supabase
+        .from('wallet_transactions')
+        .update({
+          status: 'failed',
+          metadata: { ...txRecord.metadata, failure_reason: securityCheck.reason },
+        })
+        .eq('id', input.tx_id);
+
+      console.error(`[Broadcast] Refused tx ${input.tx_id}: ${securityCheck.reason}`);
+      return { success: false, error: securityCheck.reason, code: 'SECURITY_CHECK_FAILED' };
+    }
   }
 
   // Broadcast to the network

--- a/src/lib/web-wallet/identity.ts
+++ b/src/lib/web-wallet/identity.ts
@@ -207,7 +207,7 @@ export function buildDerivationPath(chain: WalletChain, index: number): string {
 
 const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
-function base58Decode(str: string): Uint8Array {
+export function base58Decode(str: string): Uint8Array {
   // Count leading '1' characters (each represents a zero byte)
   let leadingZeros = 0;
   for (const char of str) {

--- a/src/lib/web-wallet/rate-limit.ts
+++ b/src/lib/web-wallet/rate-limit.ts
@@ -102,6 +102,9 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   // 120 calls — so this leaves generous headroom for several terminals behind
   // one NAT while still bounding the endpoint.
   'cli_auth_poll': { limit: 600, windowSeconds: 600 },       // 600/10min per IP
+  // SUB-02: each checkout derives an HD address and stores an encrypted key,
+  // so an unbounded loop accumulates key material as well as rows.
+  'subscription_checkout': { limit: 10, windowSeconds: 300 }, // 10/5min per merchant
   // WebAuthn. `login-options` answers differently for a registered and an
   // unregistered account, so without a limit it is a free user-enumeration
   // oracle; the verify endpoints back an authentication decision.

--- a/src/lib/web-wallet/rate-limit.ts
+++ b/src/lib/web-wallet/rate-limit.ts
@@ -96,6 +96,12 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'invoice_email_resend': { limit: 10, windowSeconds: 300 },  // 10/5min per business
   'p2p_request': { limit: 30, windowSeconds: 60 },           // 30/min per issuing platform
   'cli_auth_start': { limit: 10, windowSeconds: 300 },       // 10/5min per IP
+  // NEW-11: `poll` was unauthenticated and unlimited, and its answers are
+  // distinguishable (invalid / pending / denied / expired), so it was a free
+  // status oracle. A legitimate CLI polls every 5s for at most 10 minutes —
+  // 120 calls — so this leaves generous headroom for several terminals behind
+  // one NAT while still bounding the endpoint.
+  'cli_auth_poll': { limit: 600, windowSeconds: 600 },       // 600/10min per IP
   // WebAuthn. `login-options` answers differently for a registered and an
   // unregistered account, so without a limit it is a free user-enumeration
   // oracle; the verify endpoints back an authentication decision.

--- a/src/lib/web-wallet/rate-limit.ts
+++ b/src/lib/web-wallet/rate-limit.ts
@@ -120,6 +120,12 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   // Releases Boltz refund/claim key material to the owning wallet. Authorized,
   // but key material leaving the system deserves its own tight budget.
   'swap_recovery': { limit: 10, windowSeconds: 300 },        // 10/5min per wallet
+  // Password reset. Two keys, deliberately: the per-EMAIL bucket is a victim's
+  // bucket, so an attacker who can exhaust it cheaply denies that account its
+  // reset flow. The per-IP bucket is the attacker's own and is the one that
+  // actually costs them something.
+  'password_reset_email': { limit: 3, windowSeconds: 900 },  // 3/15min per email
+  'password_reset_ip': { limit: 10, windowSeconds: 900 },    // 10/15min per IP
 };
 
 /** In-memory fallback store */

--- a/src/lib/web-wallet/service.test.ts
+++ b/src/lib/web-wallet/service.test.ts
@@ -31,6 +31,19 @@ function signMessage(message: string, privateKey: Uint8Array): string {
   return Buffer.from(signatureBytes).toString('hex');
 }
 
+/**
+ * A valid proof of ownership for a keypair.
+ *
+ * V-04: createWallet used to take a public key and a list of on-chain
+ * addresses from an unauthenticated caller and write both without asking for
+ * any proof they were the caller's, while its sibling importWallet had always
+ * required a signature. Both now go through the same check, so every create
+ * test has to hold the private key it claims.
+ */
+function proofFor(privateKey: Uint8Array, message = 'coinpayportal:create:test') {
+  return { message, signature: signMessage(message, privateKey) };
+}
+
 /** Create a mock Supabase client with chainable query builder */
 function createMockSupabase() {
   const mockChain = () => {
@@ -139,7 +152,11 @@ describe('Web Wallet Service', () => {
   describe('createWallet', () => {
     it('should reject missing public keys', async () => {
       const supabase = createMockSupabase();
-      const result = await createWallet(supabase, {});
+      // A proof is present but no key is claimed, so the "at least one public
+      // key" rule is still what rejects this — not the new proof requirement.
+      const result = await createWallet(supabase, {
+        proof_of_ownership: { message: 'coinpayportal:create:test', signature: 'aa' },
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain('At least one public key');
     });
@@ -148,8 +165,11 @@ describe('Web Wallet Service', () => {
       const supabase = createMockSupabase();
       const result = await createWallet(supabase, {
         public_key_secp256k1: 'not-a-valid-key',
+        proof_of_ownership: { message: 'coinpayportal:create:test', signature: 'aa' },
       });
       expect(result.success).toBe(false);
+      // Key format is checked before the signature, so a malformed key still
+      // gets the specific error rather than a generic proof failure.
       expect(result.error).toContain('Invalid secp256k1');
     });
 
@@ -169,6 +189,7 @@ describe('Web Wallet Service', () => {
 
       const result = await createWallet(supabase, {
         public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: proofFor(keypair.privateKey),
       });
 
       expect(result.success).toBe(true);
@@ -186,6 +207,7 @@ describe('Web Wallet Service', () => {
 
       const result = await createWallet(supabase, {
         public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: proofFor(keypair.privateKey),
       });
 
       expect(result.success).toBe(false);
@@ -202,6 +224,7 @@ describe('Web Wallet Service', () => {
 
       const result = await createWallet(supabase, {
         public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: proofFor(keypair.privateKey),
         initial_addresses: [
           { chain: 'ETH', address: 'invalid-address', derivation_path: "m/44'/60'/0'/0/0" },
         ],
@@ -228,6 +251,7 @@ describe('Web Wallet Service', () => {
 
       const result = await createWallet(supabase, {
         public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: proofFor(keypair.privateKey),
         initial_addresses: [
           {
             chain: 'ETH',
@@ -265,6 +289,7 @@ describe('Web Wallet Service', () => {
 
       const result = await createWallet(supabase, {
         public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: proofFor(keypair.privateKey),
         initial_addresses: [
           {
             chain: 'LN',
@@ -277,6 +302,119 @@ describe('Web Wallet Service', () => {
       expect(result.success).toBe(true);
       expect(result.data?.addresses).toHaveLength(1);
       expect(result.data?.addresses?.[0]?.chain).toBe('LN');
+    });
+  });
+
+  describe('proof of ownership', () => {
+    it('refuses to create a wallet for a key the caller cannot sign for', async () => {
+      // V-04: creation took a self-declared public key and a list of on-chain
+      // addresses from an unauthenticated caller and wrote both, asking for no
+      // proof that any of it was theirs. `wallet_addresses` is globally unique
+      // on (address, chain), so an unproved registration permanently denies
+      // that address to whoever actually owns it.
+      const victim = generateTestKeypair();
+      const attacker = generateTestKeypair();
+      const supabase = createSequentialMockSupabase();
+
+      const message = 'coinpayportal:create:test';
+      const result = await createWallet(supabase, {
+        public_key_secp256k1: victim.publicKeyHex,
+        // A perfectly valid signature — over the right message, by the wrong key.
+        proof_of_ownership: { message, signature: signMessage(message, attacker.privateKey) },
+        initial_addresses: [
+          {
+            chain: 'ETH',
+            address: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
+            derivation_path: "m/44'/60'/0'/0/0",
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('INVALID_SIGNATURE');
+      // Nothing may be written on an unproved claim — the squat must not land.
+      expect(supabase.from).not.toHaveBeenCalledWith('wallet_addresses');
+    });
+
+    it('refuses to create a wallet with no signature at all', async () => {
+      const keypair = generateTestKeypair();
+      const supabase = createSequentialMockSupabase();
+
+      const result = await createWallet(supabase, {
+        public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: { message: 'coinpayportal:create:test' },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('INVALID_SIGNATURE');
+    });
+
+    it('refuses an ed25519-only import whose proof is not checkable', async () => {
+      // NEW-09: verification sat inside `if (public_key_secp256k1)`, and the
+      // schema requires only *one* of the two keys. Omitting the secp256k1 key
+      // therefore skipped the check entirely — `proof_of_ownership` was still
+      // mandatory, but nothing in it was ever read and any string passed.
+      const supabase = createSequentialMockSupabase();
+
+      const result = await importWallet(supabase, {
+        // A structurally valid base58 ed25519 key that is not the caller's.
+        public_key_ed25519: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        proof_of_ownership: {
+          message: 'CoinPayPortal wallet import: 1234567890',
+          signature: 'deadbeef',
+          signature_ed25519: 'deadbeef',
+        },
+        addresses: [
+          {
+            chain: 'SOL',
+            address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            derivation_path: "m/44'/501'/0'",
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('INVALID_SIGNATURE');
+      expect(supabase.from).not.toHaveBeenCalledWith('wallet_addresses');
+    });
+
+    it('refuses an ed25519-only import that omits the ed25519 signature', async () => {
+      // The exact shape of the bypass: send only the ed25519 key, and the
+      // secp256k1 branch that did the verifying is never entered.
+      const supabase = createSequentialMockSupabase();
+
+      const result = await importWallet(supabase, {
+        public_key_ed25519: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        proof_of_ownership: {
+          message: 'CoinPayPortal wallet import: 1234567890',
+          signature: 'anything at all',
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('INVALID_SIGNATURE');
+    });
+
+    it('caps how many addresses one registration may claim', async () => {
+      // V-04: `initial_addresses` was unbounded, so a single request could
+      // claim thousands of addresses it did not own — and each one is
+      // permanent, because the uniqueness is global.
+      const keypair = generateTestKeypair();
+      const supabase = createSequentialMockSupabase();
+
+      const message = 'coinpayportal:create:test';
+      const result = await createWallet(supabase, {
+        public_key_secp256k1: keypair.publicKeyHex,
+        proof_of_ownership: { message, signature: signMessage(message, keypair.privateKey) },
+        initial_addresses: Array.from({ length: 500 }, () => ({
+          chain: 'ETH',
+          address: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
+          derivation_path: "m/44'/60'/0'/0/0",
+        })),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('VALIDATION_ERROR');
     });
   });
 

--- a/src/lib/web-wallet/service.ts
+++ b/src/lib/web-wallet/service.ts
@@ -16,7 +16,7 @@ import {
   VALID_CHAINS,
   type WalletChain,
 } from './identity';
-import { generateChallenge, verifyChallengeSignature, generateWalletToken } from './auth';
+import { generateChallenge, verifyChallengeSignature, verifyEd25519ChallengeSignature, generateWalletToken } from './auth';
 
 /** Truncate an address for safe logging: first 8 + last 4 chars */
 function truncAddr(addr: string): string {
@@ -34,10 +34,33 @@ const addressInputSchema = z.object({
   derivation_path: z.string().min(1, 'Derivation path is required'),
 });
 
+/**
+ * Ceiling on addresses accepted in one registration call.
+ *
+ * V-04: `initial_addresses` was unbounded. `wallet_addresses` is globally
+ * unique on `(address, chain)`, so every accepted row permanently denies that
+ * address to the wallet that actually owns it — one request could claim
+ * thousands. A real wallet registers one address per supported chain.
+ */
+const MAX_INITIAL_ADDRESSES = VALID_CHAINS.length * 4;
+
 const createWalletSchema = z.object({
   public_key_secp256k1: z.string().optional(),
   public_key_ed25519: z.string().optional(),
-  initial_addresses: z.array(addressInputSchema).optional().default([]),
+  initial_addresses: z
+    .array(addressInputSchema)
+    .max(MAX_INITIAL_ADDRESSES, `At most ${MAX_INITIAL_ADDRESSES} addresses may be registered at once`)
+    .optional()
+    .default([]),
+  // V-04: creation took a self-declared public key and a list of on-chain
+  // addresses from an unauthenticated caller and wrote both, asking for no
+  // proof that any of it was theirs. Its sibling /import has always required a
+  // signature. Required here now too.
+  proof_of_ownership: z.object({
+    message: z.string().min(1),
+    signature: z.string().min(1).optional(),
+    signature_ed25519: z.string().min(1).optional(),
+  }),
 }).refine(
   (data) => data.public_key_secp256k1 || data.public_key_ed25519,
   { message: 'At least one public key must be provided' }
@@ -46,10 +69,18 @@ const createWalletSchema = z.object({
 const importWalletSchema = z.object({
   public_key_secp256k1: z.string().optional(),
   public_key_ed25519: z.string().optional(),
-  addresses: z.array(addressInputSchema).optional().default([]),
+  addresses: z
+    .array(addressInputSchema)
+    .max(MAX_INITIAL_ADDRESSES, `At most ${MAX_INITIAL_ADDRESSES} addresses may be registered at once`)
+    .optional()
+    .default([]),
   proof_of_ownership: z.object({
     message: z.string().min(1),
-    signature: z.string().min(1),
+    // The secp256k1 signature. Optional at the schema level because an
+    // ed25519-only wallet has none to give; `verifyKeyOwnership` requires
+    // whichever signature matches the key actually presented (NEW-09).
+    signature: z.string().min(1).optional(),
+    signature_ed25519: z.string().min(1).optional(),
   }),
 }).refine(
   (data) => data.public_key_secp256k1 || data.public_key_ed25519,
@@ -74,6 +105,73 @@ interface ServiceResult<T = Record<string, unknown>> {
   code?: string;
 }
 
+/**
+ * Verify that the caller holds the private key behind every public key they
+ * present, and return an error result if not.
+ *
+ * Shared by create (V-04) and import (NEW-09) so the two cannot drift apart
+ * again — the whole class of bug here was one sibling checking what the other
+ * did not. Every key presented must be proved:
+ *
+ *   - secp256k1 key present → `signature` must verify against it.
+ *   - no secp256k1 key → the ed25519 key is the only identity claimed, and
+ *     `signature_ed25519` must verify against it.
+ *
+ * Real clients send both keys and a secp256k1 signature, which is why the
+ * ed25519 branch is a fallback rather than an additional requirement:
+ * demanding both signatures would break every client in the field to close a
+ * gap that only exists when secp256k1 is absent.
+ */
+function verifyKeyOwnership(input: {
+  public_key_secp256k1?: string;
+  public_key_ed25519?: string;
+  proof_of_ownership: {
+    message: string;
+    signature?: string;
+    signature_ed25519?: string;
+  };
+}): ServiceResult | null {
+  const { public_key_secp256k1, public_key_ed25519, proof_of_ownership } = input;
+
+  if (public_key_secp256k1) {
+    // `signature` is schema-optional only so an ed25519-only wallet can omit
+    // it. Absent here it is a missing proof, which is a rejection, not a skip.
+    const valid =
+      !!proof_of_ownership.signature &&
+      verifyChallengeSignature(
+        proof_of_ownership.message,
+        proof_of_ownership.signature,
+        public_key_secp256k1
+      );
+    if (!valid) {
+      console.error('[WebWallet] Rejected: invalid secp256k1 proof of ownership');
+      return {
+        success: false,
+        error: 'Invalid proof of ownership signature',
+        code: 'INVALID_SIGNATURE',
+      };
+    }
+    return null;
+  }
+
+  const valid =
+    !!public_key_ed25519 &&
+    verifyEd25519ChallengeSignature(
+      proof_of_ownership.message,
+      proof_of_ownership.signature_ed25519 ?? '',
+      public_key_ed25519
+    );
+  if (!valid) {
+    console.error('[WebWallet] Rejected: invalid ed25519 proof of ownership');
+    return {
+      success: false,
+      error: 'Invalid proof of ownership signature',
+      code: 'INVALID_SIGNATURE',
+    };
+  }
+  return null;
+}
+
 // ──────────────────────────────────────────────
 // Wallet CRUD
 // ──────────────────────────────────────────────
@@ -92,7 +190,8 @@ export async function createWallet(
     return { success: false, error: parsed.error.issues[0].message, code: 'VALIDATION_ERROR' };
   }
 
-  const { public_key_secp256k1, public_key_ed25519, initial_addresses } = parsed.data;
+  const { public_key_secp256k1, public_key_ed25519, initial_addresses, proof_of_ownership } =
+    parsed.data;
 
   console.log(`[WebWallet] Creating wallet with ${initial_addresses.length} initial addresses`);
 
@@ -123,6 +222,23 @@ export async function createWallet(
       };
     }
   }
+
+  // V-04: creation asked for no proof of anything. An unauthenticated caller
+  // could declare a public key that was not theirs and, more damagingly, a list
+  // of on-chain addresses that were not theirs — and `wallet_addresses` is
+  // globally unique on `(address, chain)`, so whoever registers an address
+  // first holds it and the rightful owner can never register it at all.
+  //
+  // The identical check has guarded /import since it was written; only this
+  // sibling was missing it (§2.3). Placed after the format checks so a
+  // malformed key still gets a useful error, and before the first write so
+  // nothing is persisted on an unproved claim.
+  const proofError = verifyKeyOwnership({
+    public_key_secp256k1,
+    public_key_ed25519,
+    proof_of_ownership,
+  });
+  if (proofError) return proofError;
 
   // Check for existing wallet with same public key
   if (public_key_secp256k1) {
@@ -219,18 +335,20 @@ export async function importWallet(
     return { success: false, error: 'Invalid ed25519 public key', code: 'INVALID_KEY' };
   }
 
-  // Verify proof of ownership (secp256k1 signature on the message)
-  if (public_key_secp256k1) {
-    const valid = verifyChallengeSignature(
-      proof_of_ownership.message,
-      proof_of_ownership.signature,
-      public_key_secp256k1
-    );
-    if (!valid) {
-      console.error('[WebWallet] Import failed: invalid proof of ownership signature');
-      return { success: false, error: 'Invalid proof of ownership signature', code: 'INVALID_SIGNATURE' };
-    }
-  }
+  // Verify proof of ownership.
+  //
+  // NEW-09: this was `if (public_key_secp256k1) { ...verify... }` and nothing
+  // else. The schema requires *at least one* of the two keys, so an import
+  // carrying only `public_key_ed25519` never reached a verification call — the
+  // `proof_of_ownership` object was still required, but no part of it was ever
+  // read, and any string at all was accepted. Registering a wallet under a key
+  // you do not hold was a matter of omitting one field.
+  const proofError = verifyKeyOwnership({
+    public_key_secp256k1,
+    public_key_ed25519,
+    proof_of_ownership,
+  });
+  if (proofError) return proofError;
 
   // Check if wallet already exists with this key
   if (public_key_secp256k1) {

--- a/src/lib/web-wallet/settings.ts
+++ b/src/lib/web-wallet/settings.ts
@@ -180,7 +180,19 @@ export async function checkTransactionAllowed(
   walletId: string,
   toAddress: string,
   amount: number,
-  chain: WalletChain
+  chain: WalletChain,
+  /**
+   * Transaction row to leave out of today's running total.
+   *
+   * WW-01: the check ran only at prepare, *before* the row was inserted. Two
+   * prepares racing each other therefore both saw the same pre-insert total and
+   * both passed, and nothing re-checked at broadcast — the moment money
+   * actually moves. Re-running it at broadcast fixes that, but by then this
+   * transaction's own row is already `pending` and counted, so without
+   * excluding it the amount would be charged against the limit twice and
+   * legitimate sends would be refused. Pass the id being broadcast.
+   */
+  excludeTxId?: string
 ): Promise<{ allowed: true } | { allowed: false; reason: string }> {
   const settingsResult = await getSettings(supabase, walletId);
   if (!settingsResult.success) {
@@ -223,7 +235,7 @@ export async function checkTransactionAllowed(
     // and lets a chain with small unit values run far past the intended cap.
     // Comparing like with like makes the limit per-chain, which is what the
     // units it is expressed in already imply.
-    const { data: todayTxs, error } = await supabase
+    let spendQuery = supabase
       .from('wallet_transactions')
       .select('amount')
       .eq('wallet_id', walletId)
@@ -231,6 +243,10 @@ export async function checkTransactionAllowed(
       .eq('chain', chain)
       .in('status', ['pending', 'confirming', 'confirmed'])
       .gte('created_at', todayStart.toISOString());
+
+    if (excludeTxId) spendQuery = spendQuery.neq('id', excludeTxId);
+
+    const { data: todayTxs, error } = await spendQuery;
 
     if (error || !todayTxs) {
       // Second fail-open path: an error here skipped the limit check entirely

--- a/supabase/migrations/20260819170000_proposal_and_escrow_idempotency.sql
+++ b/supabase/migrations/20260819170000_proposal_and_escrow_idempotency.sql
@@ -1,0 +1,37 @@
+-- CP-024 and IA-017 (2026-08-19 audit): uniqueness that exists only for
+-- `payments`.
+--
+-- CP-024 — proposal→invoice conversion is a read-then-write: it checks whether
+-- `proposals.invoice_id` is set, then sets it. Two concurrent conversions both
+-- see null and both create an invoice, so one proposal bills the client twice.
+-- Nothing in the schema stopped the second write.
+--
+-- IA-017 — escrow and swap creation accept no idempotency key, so a retried
+-- request (a client timeout, a proxy replay) creates a second escrow or swap.
+-- `payments` already solves this with a partial unique index over
+-- `metadata->>'idempotency_key'`; the same mechanism is simply absent here.
+--
+-- Verified against production before applying: zero duplicate `invoice_id`
+-- values, so the unique index validates without a data cleanup.
+--
+-- These indexes are the enforcement half. Callers that do not send an
+-- idempotency key are unaffected (the index is partial), exactly as on
+-- `payments` — but a caller that does send one now gets the guarantee rather
+-- than a suggestion.
+
+-- CP-024: one invoice per proposal.
+create unique index if not exists proposals_invoice_id_uidx
+  on public.proposals (invoice_id)
+  where invoice_id is not null;
+
+-- IA-017: escrow creation, keyed per business, mirroring
+-- payments_business_idempotency_key_uidx.
+create unique index if not exists escrows_business_idempotency_key_uidx
+  on public.escrows (business_id, ((metadata ->> 'idempotency_key')))
+  where (metadata ->> 'idempotency_key') is not null;
+
+-- IA-017: swap creation. `swaps` has no `metadata` column; `provider_data` is
+-- its jsonb bag, and swaps are scoped to a wallet rather than a business.
+create unique index if not exists swaps_wallet_idempotency_key_uidx
+  on public.swaps (wallet_id, ((provider_data ->> 'idempotency_key')))
+  where (provider_data ->> 'idempotency_key') is not null;

--- a/supabase/migrations/20260819180000_stripe_webhook_idempotency.sql
+++ b/supabase/migrations/20260819180000_stripe_webhook_idempotency.sql
@@ -1,0 +1,30 @@
+-- INV-01: Stripe webhook idempotency.
+--
+-- The webhook handler dispatched on `event.type` and never looked at
+-- `event.id`. Stripe redelivers an event whenever the endpoint times out or
+-- answers non-2xx, and may deliver duplicates regardless — so every handler was
+-- re-runnable by a retry the platform did not control. `charge.refunded` and
+-- `payment_intent.succeeded` both write money-shaped records.
+--
+-- The primary key is the claim: an INSERT that conflicts means the event has
+-- already been taken, and the second delivery returns 200 without re-running
+-- anything. A handler that throws deletes its own claim, so a genuine failure
+-- still gets Stripe's retry rather than being permanently swallowed.
+
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+    event_id    TEXT PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Retention sweep support: these rows are only useful for as long as Stripe
+-- might retry (it gives up after ~3 days), but they are cheap, so nothing
+-- deletes them automatically. The index makes a manual prune fast.
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_received_at
+    ON stripe_webhook_events (received_at);
+
+ALTER TABLE stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+
+-- No policies: this table is written only by the webhook handler, which uses
+-- the service role. Enabling RLS without a policy denies every anon/authenticated
+-- read, which is what is wanted — an event ledger is not merchant-facing data.

--- a/supabase/migrations/20260819190000_collection_blockchain_check_token_variants.sql
+++ b/supabase/migrations/20260819190000_collection_blockchain_check_token_variants.sql
@@ -1,0 +1,29 @@
+-- NEW-L5-1: bring `business_collection_payments_blockchain_check` up to date
+-- with the chains the application actually supports.
+--
+-- The constraint was written on 2025-11-30 and never revisited. It allows the
+-- eleven chains that existed then; `business-collection.ts` has since grown to
+-- eighteen, and the seven token variants added since — USDT_ETH, USDT_POL,
+-- USDT_SOL, USDC_ETH, USDC_POL, USDC_SOL, USDC_BASE — are all rejected at
+-- INSERT. A merchant collecting in any of them gets a constraint violation from
+-- a code path that believes the chain is supported, because `SUPPORTED_
+-- BLOCKCHAINS` and this list were never the same list.
+--
+-- Verified before applying: production holds only ETH and BTC rows, so no
+-- existing row can violate the new list and it can be validated immediately
+-- rather than left NOT VALID.
+--
+-- The values below are exactly `SUPPORTED_BLOCKCHAINS` in
+-- src/lib/payments/business-collection.ts. Keep them in step.
+
+ALTER TABLE business_collection_payments
+    DROP CONSTRAINT IF EXISTS business_collection_payments_blockchain_check;
+
+ALTER TABLE business_collection_payments
+    ADD CONSTRAINT business_collection_payments_blockchain_check
+    CHECK (blockchain = ANY (ARRAY[
+        'BTC', 'BCH', 'ETH', 'POL', 'SOL',
+        'DOGE', 'XRP', 'ADA', 'BNB',
+        'USDT', 'USDT_ETH', 'USDT_POL', 'USDT_SOL',
+        'USDC', 'USDC_ETH', 'USDC_POL', 'USDC_SOL', 'USDC_BASE'
+    ]::text[]));

--- a/supabase/migrations/20260819200000_reputation_receipts_policy_matches_intent.sql
+++ b/supabase/migrations/20260819200000_reputation_receipts_policy_matches_intent.sql
@@ -1,0 +1,33 @@
+-- IA-002 (verification follow-up): make the policy on `reputation_receipts`
+-- say what the grants already enforce.
+--
+-- The table carries `SELECT ... USING (true)` for `anon, authenticated`, which
+-- reads as "world-readable". It is not readable today only because neither role
+-- holds a SELECT grant on it — RLS is evaluated *after* the grant check, so a
+-- permissive policy on an ungranted table is inert.
+--
+-- That is a trap rather than a control. `GRANT SELECT ON ALL TABLES IN SCHEMA
+-- public TO anon` is a routine Supabase incantation, and running it once would
+-- publish every row of this table with no other change and no warning. As of
+-- this migration that is 14,346 receipts carrying `agent_did`, `buyer_did`,
+-- `escrow_tx`, and amounts totalling $1,050,924 — the platform's entire
+-- transaction history, by counterparty and value.
+--
+-- Nothing reads this table through PostgREST today (the application uses the
+-- service role, which bypasses RLS entirely), so narrowing the policy cannot
+-- break a working path. It removes the discrepancy between what the policy
+-- claims and what the deployment actually intends.
+--
+-- The sibling reputation tables are deliberately left alone: `mutual_attestations`,
+-- `reputation_credentials` and `reputation_revocations` ARE granted to `anon`
+-- and are the public, verifiable trust graph. That is the product working as
+-- designed.
+
+DROP POLICY IF EXISTS "Anyone can view reputation receipts" ON reputation_receipts;
+
+CREATE POLICY "Service role manages reputation receipts"
+    ON reputation_receipts
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);

--- a/supabase/migrations/20260819200000_reputation_receipts_policy_matches_intent.sql
+++ b/supabase/migrations/20260819200000_reputation_receipts_policy_matches_intent.sql
@@ -8,10 +8,13 @@
 --
 -- That is a trap rather than a control. `GRANT SELECT ON ALL TABLES IN SCHEMA
 -- public TO anon` is a routine Supabase incantation, and running it once would
--- publish every row of this table with no other change and no warning. As of
--- this migration that is 14,346 receipts carrying `agent_did`, `buyer_did`,
--- `escrow_tx`, and amounts totalling $1,050,924 — the platform's entire
--- transaction history, by counterparty and value.
+-- publish every row of this table with no other change and no warning.
+--
+-- Scale, for proportion: 14,346 rows, of which 14,333 are `did:web:ugig.net`
+-- reputation receipts totalling $921.03. These are ugig.net's agent trust graph,
+-- not CoinPay payment records — those live in `payments` and are not affected.
+-- The point of this migration is that the policy should say what the grants
+-- already enforce, not that anything valuable was at risk.
 --
 -- Nothing reads this table through PostgREST today (the application uses the
 -- service role, which bypasses RLS entirely), so narrowing the policy cannot

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,16 +19,21 @@ export default defineConfig({
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
-      // Skip blockchain tests due to ws CommonJS/ESM incompatibility (except providers.test.ts which is fully mocked)
+      // These were all excluded for a ws CommonJS/ESM incompatibility. The `ws`
+      // alias below fixes that, and the exclusions outlived it — four of the
+      // seven files now run clean and are back in the suite.
+      //
+      // Leaving them out had a cost. `system-wallet.test.ts` covers custodial
+      // address derivation, and while it sat unrun its ADA test asserted the
+      // shape of a *broken* address (`addr1_<hex>...`, ellipsis and all), so
+      // the L5-02 defect had a passing-looking test defending it. Production
+      // issued five unusable ADA addresses before anyone noticed.
+      //
+      // The three below no longer fail on module loading either — they fail on
+      // assertions that drifted while nobody was running them. That is a
+      // to-do, not a module problem; do not re-add the others without checking.
       'src/lib/blockchain/wallets.test.ts',
-      'src/lib/blockchain/monitor.test.ts',
-      // Skip system-wallet test due to ethers/ws CommonJS/ESM incompatibility
-      'src/lib/wallets/system-wallet.test.ts',
-      // Skip payment service tests that import system-wallet (ethers/ws issue)
       'src/lib/payments/service.test.ts',
-      'src/lib/payments/service.expiration.test.ts',
-      // Skip API route tests that pull system-wallet through payment flow (same ws issue)
-      'src/app/api/payments/route.test.ts',
       'src/app/api/cron/monitor-payments/route.test.ts',
     ],
   },


### PR DESCRIPTION
Continues #277 and #278. Master had 64 findings fixed; this branch adds **~55 more**, taking the audit from 64 to roughly **160 of 338**.

Every schema claim below was checked against the live production database, not inferred from migrations.

## Money can no longer be stranded or moved twice

**`BL-02`** — the monitor marked a pending escrow `expired` on the clock alone, without reading its balance. A deposit landing between two cron runs left the escrow holding real money in a status where *every* exit is closed at once: release wants `funded` or `disputed`, refund wants `funded`, dispute wants `funded`, and the auto-release sweep selects only `funded`. Nothing could move that money again, ever. The balance is now read before the write, and an unreadable balance leaves it pending rather than expiring on a failed read.

**`F-1.1-01`** — that same sweep flipped expired funded **multisig** escrows to `refunded` and handed them to a settlement path that signs with a key the platform holds. A 2-of-3 escrow has no such key; its funds move only via `proposeTransaction`/`disputeMultisigEscrow`, both of which require `funded`. Marking one refunded closed the only two exits while giving it to a path that cannot sign for it.

**`CP-025`** — `refundEscrow` accepted the depositor's token and refunded on the spot, any time the escrow was funded. That is the buyer pulling their money back whenever they like: the escrow protected the buyer from the seller and the seller from nobody. Both legitimate refunds still work — the beneficiary relinquishing their claim at any time, and the depositor once the deadline passes.

> The expiry check treats an unreadable date as *not* expired. `new Date(undefined)` is an Invalid Date and every comparison against one is false, so the obvious `expires_at > now` form would have granted exactly the refund the gate exists to withhold — and the existing fixture had no `expires_at`, so it would have sailed through.

**`F-1.3-04`** — `balance-checkers.ts`, the oracle *forwarding* reads, had `case 'DOGE': console.log('not yet implemented'); return 0`. DOGE payments are **confirmed** by a different oracle that has always had a real implementation, so the two disagreed by construction: a confirmed DOGE payment reached forwarding, was told the address held nothing, and was pushed back to `confirmed` on every run thereafter while the funds sat at the intermediary address. Production has never confirmed a DOGE payment (all four are `expired`), so nothing is stranded today.

**`H-R-04`, `INV-01`** — a recurring series wrote `periods_completed` with no compare-and-swap against the state it read, so two overlapping runs both billed the same period and the counter advanced once. The Stripe webhook dispatched on `event.type` and never looked at `event.id`, so every handler was re-runnable by a retry the platform does not control.

## Secrets that were never supposed to travel

**`NEW-20`** — `POST /api/lightning/nodes` required a valid BIP-39 mnemonic, validated it, and never used it. The provisioned wallet is custodial: there is no signer and nothing to derive. The only effect was to put the master seed for the entire wallet on the wire. The web page called `wallet.getMnemonic()` and handed the live seed to a component prop; the CLI **prompted for the passphrase to decrypt the stored seed** purely so it could post it.

**`G-1.2-04`** — a 7-day session JWT travelled as `?token=` on the SSE endpoint, landing in proxy/CDN logs, browser history and `Referer`. `EventSource` cannot set headers, which is why — but it does send cookies same-origin, and the session cookie is already httpOnly.

**`F5-L2-01`** — GitHub masks the `ENV_FILE` secret as one blob but has no idea the LNbits admin key and droplet SSH key inside it are secrets too. Each value is now registered with the log masker as it is parsed.

## Claims nobody checked

**`V-04`/`NEW-09`** — `createWallet` asked for no proof of anything, and `importWallet` verified ownership only inside `if (public_key_secp256k1)` while the schema requires just *one* of two keys. `wallet_addresses` is globally unique on `(address, chain)`, so an unproved registration permanently denies an address to its real owner. Both now share one `verifyKeyOwnership`, deliberately, so they cannot drift apart again.

**`G-1.2-10`** — anyone could start a CLI device authorization and get back a link that pre-filled the approval form. Sent to a signed-in merchant, one click handed the *attacker's* terminal a 7-day session JWT, with an attacker-chosen `client_name` on the page. The pre-filled link is gone; the code must be typed from your own terminal.

**`R4-ID-OAUTH`**, **`NEW-07`**, **`R3-ID-02`**, **`F-1.1-07`**, **`IA-016`**, **`H-R-09`**, **`W-08`**, **`NEW-23`** — login-CSRF, a WebAuthn challenge slot keyed on the *victim's* id, an email-enumeration oracle (message *and* bcrypt timing), a declared-but-unenforced `payouts:create` scope, escrow legs validated by `.min(10)`, payout addresses validated by length alone, a dispute guard that read a discarded error as "no dispute", and SSRF by hostname.

## Sweeps that silently stopped working

`B-03`, `F-1.3-09`, `F-1.3-12`, `H-R-05` were all `.limit(N)` with no `.order()` over sets that never drain. Past N rows the same N are processed forever and the rest never at all — no error, no log, the job reports success. Ordering alone would not fix it; the page has to advance. Now one shared `lib/db/keyset.ts` rather than four copies.

## Queries against things that do not exist

**`B-04`** — filtered `reputation_credentials` on `subject_did` and ordered by `created_at`; it has neither. Returned 500 for every DID ever asked about.
**`L7A-04`** — queried `did_identities`, which does not exist, so the documented pre-transaction impersonation check answered "unverified" to every honest caller. It also tested a `revoked` column; neither that column nor any revocation table exists, so the response now says `revocation_checked: false` out loud rather than dropping the check silently.
**`L5-02`** — `deriveCardanoWallet` returned `addr1_${pubkeyHex.slice(0,40)}...`, ellipsis included. Production issued **five** of these to customers between February and July. Only generation was a stub; the spend path builds real transactions, so the rail was broken at exactly one end.
**`NEW-L5-1`** — a chain constraint written in November allowed 11 chains while the code supports 18.

## Bugs the audit did not list, found while fixing it

- **The published npm SDK's wallet import has never worked.** `signMessage` signs `sha256(message)` while the server verifies over raw bytes — confirmed `false` against the repo's own noble build. Every proof it produced was rejected.
- **Four test files were excluded from the suite for a `ws` ESM problem the config's own alias already fixes.** While `system-wallet.test.ts` sat unrun, its ADA test asserted the shape of the *broken* address — so `L5-02` had a passing-looking test defending it. Restored: **317 → 323 files, 4468 → 4573 tests.**
- **An invalid Ethereum address in the repo's own fixtures** (44 hex chars, not 40), caught the moment payout addresses were format-checked.

## Migrations

`20260819170000` (idempotency indexes), `20260819180000` (Stripe webhook events), `20260819190000` (collection chain constraint). All three applied to production and verified; the last was checked for violating rows first so it could be validated immediately.

## Not fixed, and why

- **`WW-03` is partial.** The recipient is bound on every chain, but the *amount* is still unbound on BCH (bitcoinjs-lib does not handle its SIGHASH_FORKID variant) and Solana (the amount sits in program-specific instruction data). Refusing outright would take those chains offline, so the broadcast proceeds and the gap is logged and recorded on the row.
- **`F5-L1-06` is partial.** `sweep-balances.mjs` was truncated and had failed `node --check` since December 2025 — the documented emergency fund-recovery procedure has never run. It now parses and the discovery half works. `--execute` deliberately refuses: broadcasting sweeps would be new, untested, multi-chain fund-moving code, and shipping that unexercised risks sending funds somewhere unrecoverable. `hexToWIF` is completed and verified against the canonical Bitcoin test vector.

## Breaking changes

- `/api/web-wallet/create` now requires `proof_of_ownership`. Both in-repo SDKs send it; a published SDK older than this cannot create wallets. The browser extension registers via `/import` and is unaffected.
- OAuth clients sending neither `state` nor PKCE get a 400. 278 of 318 live authorization codes already carry PKCE, so this rejects the unprotected minority.
- CLI builds older than this print a login link that no longer pre-fills the code. The code is still shown and still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
