### PR TITLE
Add /finances: bank and credit card aggregation via SimpleFIN

### DIFF
--- a/src/app/api/finances/accounts/[id]/route.ts
+++ b/src/app/api/finances/accounts/[id]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { isAccountKind } from '@/lib/finances/classify';
+import { toAccountView, type FinanceAccount } from '@/lib/finances/summary';
+
+export const dynamic = 'force-dynamic';
+
+const ACCOUNT_COLUMNS =
+  'id, connection_id, external_id, org_name, org_domain, name, currency, balance, available_balance, balance_date, kind, kind_override, is_hidden, last_seen_at';
+
+/**
+ * PATCH /api/finances/accounts/[id] — operator corrections.
+ *
+ * Only two fields are writable, and neither is imported data. `kind_override`
+ * corrects a misclassified account (SimpleFIN has no account-type field, so the
+ * kind is a guess from the name) and is stored separately from the derived
+ * `kind` so the next sync re-deriving that guess cannot clobber the correction.
+ * `is_hidden` drops a closed or duplicate account out of the totals while
+ * leaving its history intact.
+ *
+ * Balances and transactions are deliberately not writable: they are a record of
+ * what an institution said, and an editable ledger is not a ledger.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const { id } = await params;
+
+  let body: { kind_override?: unknown; is_hidden?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const update: Record<string, unknown> = {};
+
+  if ('kind_override' in body) {
+    // null clears the override and hands the account back to the heuristic.
+    if (body.kind_override === null || body.kind_override === '') {
+      update.kind_override = null;
+    } else if (isAccountKind(body.kind_override)) {
+      update.kind_override = body.kind_override;
+    } else {
+      return NextResponse.json({ error: 'Unknown account kind' }, { status: 400 });
+    }
+  }
+
+  if ('is_hidden' in body) {
+    if (typeof body.is_hidden !== 'boolean') {
+      return NextResponse.json({ error: 'is_hidden must be a boolean' }, { status: 400 });
+    }
+    update.is_hidden = body.is_hidden;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('finance_accounts')
+    .update(update)
+    .eq('id', id)
+    .select(ACCOUNT_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ account: toAccountView(data as unknown as FinanceAccount) });
+}

--- a/src/app/api/finances/accounts/route.ts
+++ b/src/app/api/finances/accounts/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { listAccounts } from '@/lib/finances/summary';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/finances/accounts — every linked account with its current balance.
+ *
+ * `?hidden=1` includes accounts an operator has hidden from the totals.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  try {
+    const accounts = await listAccounts({
+      includeHidden: req.nextUrl.searchParams.get('hidden') === '1',
+    });
+    return NextResponse.json({ accounts }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (err) {
+    console.error('[finances/accounts] failed', err);
+    return NextResponse.json({ error: 'Failed to load accounts' }, { status: 500 });
+  }
+}

--- a/src/app/api/finances/connections/[id]/route.ts
+++ b/src/app/api/finances/connections/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { deleteConnection } from '@/lib/finances/sync';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * DELETE /api/finances/connections/[id] — unlink an institution set.
+ *
+ * Cascades to its accounts and their transactions. Worth stating plainly: the
+ * access URL is destroyed with the row and a SimpleFIN setup token cannot be
+ * re-claimed, so re-linking means generating a fresh token at the bridge.
+ */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const { id } = await params;
+
+  try {
+    await deleteConnection(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[finances/connections] delete failed', err);
+    return NextResponse.json({ error: 'Failed to delete the connection' }, { status: 500 });
+  }
+}

--- a/src/app/api/finances/connections/route.ts
+++ b/src/app/api/finances/connections/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { listConnections, createConnection, bootstrapConnectionFromEnv } from '@/lib/finances/sync';
+import { claimSetupToken, redactAccessUrl } from '@/lib/finances/simplefin';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/finances/connections — linked SimpleFIN connections and their last
+ * sync outcome. Never returns the access URL; there is no route that does.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  try {
+    await bootstrapConnectionFromEnv();
+    return NextResponse.json(
+      { connections: await listConnections() },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (err) {
+    console.error('[finances/connections] failed', err);
+    return NextResponse.json({ error: 'Failed to load connections' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/finances/connections — claim a SimpleFIN setup token.
+ *
+ * Body: `{ setupToken: string, label?: string }`.
+ *
+ * The claim is single-use and irreversible: the bridge returns the access URL
+ * exactly once and answers 403 to every repeat. So the claim and the write are
+ * kept adjacent with nothing fallible between them, and if the write somehow
+ * fails the response says plainly that the token is spent — the alternative is
+ * an operator retrying a token that can never work again.
+ */
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  let body: { setupToken?: unknown; label?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const setupToken = typeof body.setupToken === 'string' ? body.setupToken.trim() : '';
+  if (!setupToken) {
+    return NextResponse.json({ error: 'A SimpleFIN setup token is required' }, { status: 400 });
+  }
+
+  let accessUrl: string;
+  try {
+    accessUrl = await claimSetupToken(setupToken);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Could not claim the setup token' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const connection = await createConnection({
+      accessUrl,
+      label: typeof body.label === 'string' ? body.label : null,
+      createdBy: guard.id,
+    });
+    return NextResponse.json({ connection }, { status: 201 });
+  } catch (err) {
+    console.error('[finances/connections] claimed but could not store', redactAccessUrl(String(err)));
+    return NextResponse.json(
+      {
+        error:
+          'The token was claimed but the credential could not be saved, and a setup token cannot be claimed twice. Generate a new token and try again.',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/finances/summary/route.ts
+++ b/src/app/api/finances/summary/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { getSummary } from '@/lib/finances/summary';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/finances/summary — balance sheet and cashflow headline.
+ *
+ * House financial data, so the admin check is the entire security boundary:
+ * the tables are RLS-enabled with no policies and are reachable only through
+ * the service client behind this guard.
+ *
+ * `?days=` sets the cashflow and category window. Balances ignore it — a
+ * balance is a current fact and has no window.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const params = req.nextUrl.searchParams;
+  const parsedDays = Number.parseInt(params.get('days') ?? '', 10);
+  const windowDays = Number.isFinite(parsedDays) ? parsedDays : 30;
+  const includeHidden = params.get('hidden') === '1';
+
+  try {
+    const summary = await getSummary({ windowDays, includeHidden });
+    return NextResponse.json(
+      { summary },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (err) {
+    console.error('[finances/summary] failed', err);
+    return NextResponse.json({ error: 'Failed to load finance summary' }, { status: 500 });
+  }
+}

--- a/src/app/api/finances/sync/route.ts
+++ b/src/app/api/finances/sync/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { syncAllConnections, syncConnection, DEFAULT_SYNC_DAYS } from '@/lib/finances/sync';
+
+export const dynamic = 'force-dynamic';
+
+// Reading eight institutions is slow — the bridge waits on each of them.
+export const maxDuration = 300;
+
+/**
+ * POST /api/finances/sync — pull fresh balances and transactions.
+ *
+ * Explicitly an action rather than something that happens on page load:
+ * SimpleFIN allows roughly 24 requests per day across the whole connection, so
+ * a sync on every render would exhaust the budget before lunch.
+ *
+ * Body: `{ days?: number, connectionId?: string }`. Omitting `connectionId`
+ * syncs every active connection.
+ */
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  let body: { days?: unknown; connectionId?: unknown } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // An empty body is the common case: sync everything with the default window.
+  }
+
+  const parsedDays = Number.parseInt(String(body.days ?? ''), 10);
+  const days = Number.isFinite(parsedDays) ? parsedDays : DEFAULT_SYNC_DAYS;
+
+  try {
+    const results =
+      typeof body.connectionId === 'string' && body.connectionId
+        ? [await syncConnection(body.connectionId, { days })]
+        : await syncAllConnections({ days });
+
+    if (results.length === 0) {
+      return NextResponse.json(
+        { error: 'No SimpleFIN connection is configured yet' },
+        { status: 400 },
+      );
+    }
+
+    const totals = results.reduce(
+      (acc, r) => ({
+        accounts: acc.accounts + r.accounts,
+        transactionsSeen: acc.transactionsSeen + r.transactionsSeen,
+        transactionsNew: acc.transactionsNew + r.transactionsNew,
+      }),
+      { accounts: 0, transactionsSeen: 0, transactionsNew: 0 },
+    );
+
+    return NextResponse.json({
+      results,
+      totals,
+      // A partial sync is a success with holes in it, not a failure — say so
+      // rather than letting a silently short result read as complete.
+      status: results.some((r) => r.status === 'partial') ? 'partial' : 'ok',
+    });
+  } catch (err) {
+    console.error('[finances/sync] failed', err);
+    // The message is already credential-redacted by the sync layer, and it is
+    // the only way an operator learns that a bank needs re-authenticating.
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Sync failed' },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/finances/transactions/route.ts
+++ b/src/app/api/finances/transactions/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { listTransactions } from '@/lib/finances/summary';
+
+export const dynamic = 'force-dynamic';
+
+/** A date param, or null when absent or unparseable. */
+function parseDate(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * GET /api/finances/transactions — the ledger, newest first.
+ *
+ * Filters: `account`, `search`, `category` (`uncategorised` for the null
+ * bucket), `start`, `end`, `pending=0`, plus `limit`/`offset`.
+ */
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const params = req.nextUrl.searchParams;
+
+  const parsedLimit = Number.parseInt(params.get('limit') ?? '', 10);
+  const parsedOffset = Number.parseInt(params.get('offset') ?? '', 10);
+
+  try {
+    const page = await listTransactions({
+      accountId: params.get('account'),
+      search: params.get('search'),
+      category: params.get('category'),
+      startDate: parseDate(params.get('start')),
+      endDate: parseDate(params.get('end')),
+      includePending: params.get('pending') !== '0',
+      limit: Number.isFinite(parsedLimit) ? parsedLimit : 50,
+      offset: Number.isFinite(parsedOffset) ? parsedOffset : 0,
+    });
+
+    return NextResponse.json(page, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (err) {
+    console.error('[finances/transactions] failed', err);
+    return NextResponse.json({ error: 'Failed to load transactions' }, { status: 500 });
+  }
+}

--- a/src/app/finances/FinancesContent.tsx
+++ b/src/app/finances/FinancesContent.tsx
@@ -1,0 +1,777 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { formatMoney, formatCompact, formatDate, formatRelative, percentOf } from '@/lib/finances/format';
+import { ACCOUNT_KINDS, categoryLabel, type AccountKind } from '@/lib/finances/classify';
+
+/**
+ * The /finances console.
+ *
+ * Deliberately one page: balances, accounts, spending and the ledger are the
+ * same question asked at four zoom levels, and splitting them across routes
+ * means reconciling four separately-stale views of the same money.
+ *
+ * Syncing is a button, never an effect. SimpleFIN permits roughly 24 requests
+ * per day for the whole connection, so a sync-on-mount would spend the day's
+ * budget on idle tab reloads.
+ */
+
+type Account = {
+  id: string;
+  name: string;
+  org_name: string | null;
+  currency: string;
+  balance: number | null;
+  available_balance: number | null;
+  balance_date: string | null;
+  effective_kind: AccountKind;
+  kind_override: string | null;
+  is_liability: boolean;
+  display_balance: number | null;
+  is_hidden: boolean;
+};
+
+type Transaction = {
+  id: string;
+  account_id: string;
+  posted: string;
+  amount: number;
+  description: string | null;
+  payee: string | null;
+  memo: string | null;
+  pending: boolean;
+  category: string | null;
+  account_name: string;
+  org_name: string | null;
+  currency: string;
+};
+
+type Summary = {
+  windowDays: number;
+  totals: Array<{ currency: string; assets: number; liabilities: number; net: number; accounts: number }>;
+  primaryCurrency: string | null;
+  byKind: Array<{ kind: AccountKind; currency: string; total: number; accounts: number }>;
+  byInstitution: Array<{ org: string; currency: string; assets: number; liabilities: number; accounts: number }>;
+  cashflow: { currency: string | null; moneyIn: number; moneyOut: number; net: number; transactions: number };
+  topCategories: Array<{ category: string | null; spent: number; received: number; count: number }>;
+  accountCount: number;
+  hiddenCount: number;
+  transactionCount: number;
+  oldestTransaction: string | null;
+  newestTransaction: string | null;
+};
+
+type Connection = {
+  id: string;
+  label: string | null;
+  is_active: boolean;
+  last_synced_at: string | null;
+  last_sync_status: string | null;
+  last_sync_error: string | null;
+  last_sync_accounts: number | null;
+  last_sync_transactions: number | null;
+};
+
+const KIND_LABEL: Record<AccountKind, string> = {
+  checking: 'Checking',
+  savings: 'Savings',
+  credit: 'Credit card',
+  loan: 'Loan',
+  investment: 'Investment',
+  cash: 'Cash',
+  unknown: 'Unclassified',
+};
+
+const KIND_BADGE: Record<AccountKind, string> = {
+  checking: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+  savings: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  credit: 'bg-rose-500/15 text-rose-300 border-rose-500/30',
+  loan: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  investment: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
+  cash: 'bg-teal-500/15 text-teal-300 border-teal-500/30',
+  unknown: 'bg-slate-500/15 text-slate-300 border-slate-500/30',
+};
+
+const WINDOWS = [
+  { days: 30, label: '30 days' },
+  { days: 90, label: '90 days' },
+  { days: 365, label: '12 months' },
+];
+
+const PAGE_SIZE = 50;
+
+function authHeaders(extra?: HeadersInit): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+  const headers: Record<string, string> = { ...(extra as Record<string, string>) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+export default function FinancesContent() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [windowDays, setWindowDays] = useState(30);
+  const [showHidden, setShowHidden] = useState(false);
+
+  const [syncing, setSyncing] = useState(false);
+
+  // Ledger state, paged and filtered server-side.
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [txTotal, setTxTotal] = useState(0);
+  const [txOffset, setTxOffset] = useState(0);
+  const [txLoading, setTxLoading] = useState(false);
+  const [accountFilter, setAccountFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+
+  const [setupToken, setSetupToken] = useState('');
+  const [linking, setLinking] = useState(false);
+  const [showLink, setShowLink] = useState(false);
+
+  const loadOverview = useCallback(async () => {
+    setError(null);
+    try {
+      const query = `days=${windowDays}${showHidden ? '&hidden=1' : ''}`;
+      const [summaryRes, accountsRes, connectionsRes] = await Promise.all([
+        fetch(`/api/finances/summary?${query}`, { headers: authHeaders() }),
+        fetch(`/api/finances/accounts${showHidden ? '?hidden=1' : ''}`, { headers: authHeaders() }),
+        fetch('/api/finances/connections', { headers: authHeaders() }),
+      ]);
+
+      if (summaryRes.status === 401 || summaryRes.status === 403) {
+        setError('This page is restricted to administrators.');
+        return;
+      }
+      if (!summaryRes.ok || !accountsRes.ok) {
+        setError('Failed to load finances.');
+        return;
+      }
+
+      setSummary((await summaryRes.json()).summary);
+      setAccounts((await accountsRes.json()).accounts ?? []);
+      if (connectionsRes.ok) setConnections((await connectionsRes.json()).connections ?? []);
+    } catch {
+      setError('Network error loading finances.');
+    } finally {
+      setLoading(false);
+    }
+  }, [windowDays, showHidden]);
+
+  const loadTransactions = useCallback(async () => {
+    setTxLoading(true);
+    try {
+      const params = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(txOffset) });
+      if (accountFilter) params.set('account', accountFilter);
+      if (categoryFilter) params.set('category', categoryFilter);
+      if (search) params.set('search', search);
+
+      const res = await fetch(`/api/finances/transactions?${params}`, { headers: authHeaders() });
+      if (!res.ok) return;
+
+      const data = await res.json();
+      setTransactions(data.rows ?? []);
+      setTxTotal(data.total ?? 0);
+    } catch {
+      // The ledger failing is not worth blanking the balance sheet above it.
+    } finally {
+      setTxLoading(false);
+    }
+  }, [txOffset, accountFilter, categoryFilter, search]);
+
+  useEffect(() => {
+    loadOverview();
+  }, [loadOverview]);
+
+  useEffect(() => {
+    loadTransactions();
+  }, [loadTransactions]);
+
+  // Debounce the search box so typing does not fire a query per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearch(searchInput.trim());
+      setTxOffset(0);
+    }, 350);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch('/api/finances/sync', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        // No `days`: the server's default window is the largest one SimpleFIN
+        // accepts without capping the request.
+        body: JSON.stringify({}),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || 'Sync failed.');
+        return;
+      }
+
+      const t = data.totals ?? { accounts: 0, transactionsNew: 0 };
+      setNotice(
+        `Synced ${t.accounts} account${t.accounts === 1 ? '' : 's'} · ${t.transactionsNew} new transaction${
+          t.transactionsNew === 1 ? '' : 's'
+        }${data.status === 'partial' ? ' · some institutions reported errors' : ''}`,
+      );
+
+      // Advisories are informational, so they are shown separately from the
+      // error banner rather than dressed up as a failure.
+      const advisories: string[] = (data.results ?? []).flatMap(
+        (r: { notices?: string[] }) => r.notices ?? [],
+      );
+      if (advisories.length > 0) console.info('[finances] SimpleFIN advisories:', advisories);
+
+      await loadOverview();
+      await loadTransactions();
+    } catch {
+      setError('Network error during sync.');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleLink = async () => {
+    if (!setupToken.trim()) return;
+    setLinking(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch('/api/finances/connections', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ setupToken: setupToken.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Could not link the connection.');
+        return;
+      }
+      setSetupToken('');
+      setShowLink(false);
+      setNotice('Connection linked. Run a sync to pull balances.');
+      await loadOverview();
+    } catch {
+      setError('Network error linking the connection.');
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  const updateAccount = async (id: string, patch: Record<string, unknown>) => {
+    try {
+      const res = await fetch(`/api/finances/accounts/${id}`, {
+        method: 'PATCH',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        setError('Could not update the account.');
+        return;
+      }
+      await loadOverview();
+    } catch {
+      setError('Network error updating the account.');
+    }
+  };
+
+  const currency = summary?.primaryCurrency ?? 'USD';
+  const headline = summary?.totals.find((t) => t.currency === currency) ?? null;
+
+  /** Accounts grouped by institution, in the order the API returned them. */
+  const byInstitution = useMemo(() => {
+    const groups = new Map<string, Account[]>();
+    for (const account of accounts) {
+      const key = account.org_name ?? 'Unknown institution';
+      groups.set(key, [...(groups.get(key) ?? []), account]);
+    }
+    return [...groups.entries()];
+  }, [accounts]);
+
+  const spendTotal = useMemo(
+    () => (summary?.topCategories ?? []).reduce((sum, c) => sum + c.spent, 0),
+    [summary],
+  );
+
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const c of summary?.topCategories ?? []) if (c.category) set.add(c.category);
+    return [...set].sort();
+  }, [summary]);
+
+  if (loading) {
+    return <div className="container mx-auto px-4 py-16 text-center text-gray-400">Loading finances…</div>;
+  }
+
+  if (error && !summary) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-red-400 mb-2">{error}</p>
+        <Link href="/dashboard" className="text-purple-400 hover:underline">
+          Back to dashboard →
+        </Link>
+      </div>
+    );
+  }
+
+  const connection = connections[0] ?? null;
+  const hasData = (summary?.accountCount ?? 0) > 0;
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-6xl">
+      <div className="flex flex-wrap items-start justify-between gap-4 mb-2">
+        <div>
+          <h1 className="text-3xl font-bold text-white">Finances</h1>
+          <p className="text-gray-400 mt-1">
+            Bank accounts and credit cards, read-only via SimpleFIN.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleSync}
+            disabled={syncing}
+            className="rounded bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+          >
+            {syncing ? 'Syncing…' : 'Sync now'}
+          </button>
+          <button
+            onClick={() => setShowLink((v) => !v)}
+            className="rounded border border-slate-600 px-4 py-2 text-sm text-gray-300 hover:bg-slate-800"
+          >
+            Link institution
+          </button>
+        </div>
+      </div>
+
+      {connection && (
+        <p className="text-xs text-gray-500 mb-6">
+          Last synced {formatRelative(connection.last_synced_at)}
+          {connection.last_sync_status === 'error' && (
+            <span className="text-red-400"> · last sync failed: {connection.last_sync_error}</span>
+          )}
+          {connection.last_sync_status === 'partial' && (
+            <span className="text-amber-400"> · some institutions reported errors</span>
+          )}
+        </p>
+      )}
+
+      {notice && (
+        <div className="mb-6 rounded border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="mb-6 rounded border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {showLink && (
+        <section className="mb-8 rounded-lg border border-slate-700 bg-slate-900/50 p-6">
+          <h2 className="text-lg font-semibold text-white mb-2">Link an institution</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            Paste a SimpleFIN setup token from{' '}
+            <a
+              href="https://beta-bridge.simplefin.org/"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-purple-400 hover:underline"
+            >
+              beta-bridge.simplefin.org
+            </a>
+            . Setup tokens are single-use — once claimed, the same token cannot be used again.
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              value={setupToken}
+              onChange={(e) => setSetupToken(e.target.value)}
+              placeholder="base64 setup token"
+              className="flex-1 rounded border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-gray-600"
+            />
+            <button
+              onClick={handleLink}
+              disabled={linking || !setupToken.trim()}
+              className="rounded bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+            >
+              {linking ? 'Claiming…' : 'Claim token'}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {!hasData && (
+        <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-8 text-center">
+          <p className="text-gray-300 mb-2">No accounts imported yet.</p>
+          <p className="text-sm text-gray-500">
+            Press <span className="text-gray-300">Sync now</span> to pull balances and the last 90 days
+            of transactions from the linked institutions.
+          </p>
+        </section>
+      )}
+
+      {hasData && summary && (
+        <>
+          {/* ---------------- headline tiles ---------------- */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+            <Tile
+              label="Net position"
+              value={formatCompact(headline?.net ?? 0, currency)}
+              tone={(headline?.net ?? 0) >= 0 ? 'positive' : 'negative'}
+              detail={`${summary.accountCount} account${summary.accountCount === 1 ? '' : 's'}`}
+            />
+            <Tile
+              label="Cash & savings"
+              value={formatCompact(headline?.assets ?? 0, currency)}
+              tone="positive"
+              detail="Across all deposit accounts"
+            />
+            <Tile
+              label="Owed"
+              value={formatCompact(headline?.liabilities ?? 0, currency)}
+              tone="negative"
+              detail="Credit cards and loans"
+            />
+            <Tile
+              label={`Net flow · ${summary.windowDays}d`}
+              value={formatCompact(summary.cashflow.net, currency)}
+              tone={summary.cashflow.net >= 0 ? 'positive' : 'negative'}
+              detail={`${formatCompact(summary.cashflow.moneyIn, currency)} in · ${formatCompact(
+                summary.cashflow.moneyOut,
+                currency,
+              )} out`}
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 mb-8">
+            <span className="text-xs uppercase tracking-wide text-gray-500">Window</span>
+            {WINDOWS.map((w) => (
+              <button
+                key={w.days}
+                onClick={() => setWindowDays(w.days)}
+                className={`rounded px-3 py-1 text-xs border ${
+                  windowDays === w.days
+                    ? 'border-purple-500/40 bg-purple-600/20 text-purple-200'
+                    : 'border-slate-700 text-gray-400 hover:bg-slate-800'
+                }`}
+              >
+                {w.label}
+              </button>
+            ))}
+            <label className="ml-auto flex items-center gap-2 text-xs text-gray-400">
+              <input
+                type="checkbox"
+                checked={showHidden}
+                onChange={(e) => setShowHidden(e.target.checked)}
+                className="accent-purple-500"
+              />
+              Show hidden accounts{summary.hiddenCount > 0 ? ` (${summary.hiddenCount})` : ''}
+            </label>
+          </div>
+
+          {/* ---------------- accounts ---------------- */}
+          <section className="mb-10">
+            <h2 className="text-lg font-semibold text-white mb-4">Accounts</h2>
+            <div className="space-y-6">
+              {byInstitution.map(([org, rows]) => (
+                <div key={org} className="rounded-lg border border-slate-700 bg-slate-900/50 overflow-hidden">
+                  <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+                    <h3 className="text-sm font-semibold text-white">{org}</h3>
+                    <span className="text-xs text-gray-500">
+                      {rows.length} account{rows.length === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <tbody>
+                        {rows.map((account) => (
+                          <tr
+                            key={account.id}
+                            className={`border-b border-slate-800/60 last:border-0 ${
+                              account.is_hidden ? 'opacity-50' : ''
+                            }`}
+                          >
+                            <td className="px-4 py-3">
+                              <div className="text-gray-200">{account.name}</div>
+                              <div className="text-xs text-gray-500">
+                                Balance as of {formatDate(account.balance_date)}
+                              </div>
+                            </td>
+                            <td className="px-4 py-3">
+                              <span
+                                className={`inline-block rounded border px-2 py-0.5 text-xs ${
+                                  KIND_BADGE[account.effective_kind]
+                                }`}
+                              >
+                                {KIND_LABEL[account.effective_kind]}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              <div
+                                className={
+                                  account.is_liability
+                                    ? 'text-rose-300 font-medium'
+                                    : 'text-emerald-300 font-medium'
+                                }
+                              >
+                                {formatMoney(account.display_balance, account.currency)}
+                                {account.is_liability && (
+                                  <span className="ml-1 text-xs text-gray-500">owed</span>
+                                )}
+                              </div>
+                              {account.available_balance !== null &&
+                                account.available_balance !== account.balance && (
+                                  <div className="text-xs text-gray-500">
+                                    {formatMoney(account.available_balance, account.currency)} available
+                                  </div>
+                                )}
+                            </td>
+                            <td className="px-4 py-3 text-right whitespace-nowrap">
+                              <select
+                                value={account.kind_override ?? ''}
+                                onChange={(e) =>
+                                  updateAccount(account.id, {
+                                    kind_override: e.target.value || null,
+                                  })
+                                }
+                                className="rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-gray-300"
+                                aria-label={`Account type for ${account.name}`}
+                              >
+                                <option value="">Auto ({KIND_LABEL[account.effective_kind]})</option>
+                                {ACCOUNT_KINDS.filter((k) => k !== 'unknown').map((k) => (
+                                  <option key={k} value={k}>
+                                    {KIND_LABEL[k]}
+                                  </option>
+                                ))}
+                              </select>
+                              <button
+                                onClick={() =>
+                                  updateAccount(account.id, { is_hidden: !account.is_hidden })
+                                }
+                                className="ml-2 text-xs text-gray-500 hover:text-gray-300"
+                              >
+                                {account.is_hidden ? 'Unhide' : 'Hide'}
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* ---------------- spending ---------------- */}
+          {summary.topCategories.length > 0 && (
+            <section className="mb-10">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                Spending · last {summary.windowDays} days
+              </h2>
+              <div className="rounded-lg border border-slate-700 bg-slate-900/50 p-4 space-y-3">
+                {summary.topCategories
+                  .filter((c) => c.spent > 0)
+                  .map((c) => (
+                    <button
+                      key={c.category ?? 'uncategorised'}
+                      onClick={() => {
+                        setCategoryFilter(c.category ?? 'uncategorised');
+                        setTxOffset(0);
+                      }}
+                      className="block w-full text-left"
+                    >
+                      <div className="flex items-center justify-between text-sm mb-1">
+                        <span className="text-gray-300">{categoryLabel(c.category)}</span>
+                        <span className="text-gray-400">
+                          {formatMoney(c.spent, currency)}
+                          <span className="ml-2 text-xs text-gray-600">{c.count}</span>
+                        </span>
+                      </div>
+                      <div className="h-1.5 w-full rounded bg-slate-800">
+                        <div
+                          className="h-1.5 rounded bg-purple-500/70"
+                          style={{ width: `${percentOf(c.spent, spendTotal)}%` }}
+                        />
+                      </div>
+                    </button>
+                  ))}
+              </div>
+            </section>
+          )}
+
+          {/* ---------------- ledger ---------------- */}
+          <section>
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <h2 className="text-lg font-semibold text-white">Transactions</h2>
+              <span className="text-xs text-gray-500">
+                {summary.transactionCount.toLocaleString()} imported
+                {summary.oldestTransaction && ` · since ${formatDate(summary.oldestTransaction)}`}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-3 mb-4">
+              <input
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Search description, payee or memo"
+                className="flex-1 min-w-[220px] rounded border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-gray-600"
+              />
+              <select
+                value={accountFilter}
+                onChange={(e) => {
+                  setAccountFilter(e.target.value);
+                  setTxOffset(0);
+                }}
+                className="rounded border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-gray-300"
+                aria-label="Filter by account"
+              >
+                <option value="">All accounts</option>
+                {accounts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.org_name ? `${a.org_name} — ` : ''}
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={categoryFilter}
+                onChange={(e) => {
+                  setCategoryFilter(e.target.value);
+                  setTxOffset(0);
+                }}
+                className="rounded border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-gray-300"
+                aria-label="Filter by category"
+              >
+                <option value="">All categories</option>
+                {categoryOptions.map((c) => (
+                  <option key={c} value={c}>
+                    {categoryLabel(c)}
+                  </option>
+                ))}
+                <option value="uncategorised">Uncategorised</option>
+              </select>
+            </div>
+
+            <div className="rounded-lg border border-slate-700 bg-slate-900/50 overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-800 text-left text-xs uppercase tracking-wide text-gray-500">
+                    <th className="px-4 py-3 font-medium">Date</th>
+                    <th className="px-4 py-3 font-medium">Description</th>
+                    <th className="px-4 py-3 font-medium">Account</th>
+                    <th className="px-4 py-3 font-medium">Category</th>
+                    <th className="px-4 py-3 font-medium text-right">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {txLoading && transactions.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                        Loading…
+                      </td>
+                    </tr>
+                  )}
+                  {!txLoading && transactions.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                        No transactions match these filters.
+                      </td>
+                    </tr>
+                  )}
+                  {transactions.map((tx) => (
+                    <tr key={tx.id} className="border-b border-slate-800/60 last:border-0">
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-400">
+                        {formatDate(tx.posted)}
+                        {tx.pending && (
+                          <span className="ml-2 rounded bg-amber-500/15 px-1.5 py-0.5 text-xs text-amber-300">
+                            pending
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-gray-200">
+                        {tx.payee || tx.description || '—'}
+                        {tx.payee && tx.description && tx.description !== tx.payee && (
+                          <div className="text-xs text-gray-600 truncate max-w-md">{tx.description}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 text-xs">{tx.account_name}</td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">{categoryLabel(tx.category)}</td>
+                      <td
+                        className={`px-4 py-3 text-right whitespace-nowrap font-medium ${
+                          tx.amount >= 0 ? 'text-emerald-300' : 'text-gray-200'
+                        }`}
+                      >
+                        {formatMoney(tx.amount, tx.currency, { signed: true })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {txTotal > PAGE_SIZE && (
+              <div className="flex items-center justify-between mt-4 text-sm">
+                <button
+                  onClick={() => setTxOffset(Math.max(txOffset - PAGE_SIZE, 0))}
+                  disabled={txOffset === 0}
+                  className="rounded border border-slate-700 px-3 py-1 text-gray-300 disabled:opacity-40"
+                >
+                  ← Newer
+                </button>
+                <span className="text-xs text-gray-500">
+                  {txOffset + 1}–{Math.min(txOffset + PAGE_SIZE, txTotal)} of {txTotal.toLocaleString()}
+                </span>
+                <button
+                  onClick={() => setTxOffset(txOffset + PAGE_SIZE)}
+                  disabled={txOffset + PAGE_SIZE >= txTotal}
+                  className="rounded border border-slate-700 px-3 py-1 text-gray-300 disabled:opacity-40"
+                >
+                  Older →
+                </button>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  tone: 'positive' | 'negative';
+}) {
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900/50 p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+      <div
+        className={`mt-1 text-2xl font-semibold ${
+          tone === 'positive' ? 'text-emerald-300' : 'text-rose-300'
+        }`}
+      >
+        {value}
+      </div>
+      {detail && <div className="mt-1 text-xs text-gray-500">{detail}</div>}
+    </div>
+  );
+}

--- a/src/app/finances/page.tsx
+++ b/src/app/finances/page.tsx
@@ -1,0 +1,21 @@
+import { requireAdminPage } from '@/lib/auth/admin-guard';
+import FinancesContent from './FinancesContent';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Finances · CoinPay',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * /finances — the house balance sheet.
+ *
+ * Gated server-side rather than in the client component, so the page never
+ * renders for a non-admin even for the moment before a fetch resolves. The API
+ * routes behind it repeat the check; this one is about what reaches the browser.
+ */
+export default async function FinancesPage() {
+  await requireAdminPage('/finances');
+  return <FinancesContent />;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -187,13 +187,22 @@ export default function Header() {
                           Settings
                         </Link>
                         {isAdmin && (
-                          <Link
-                            href="/admin"
-                            className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
-                            onClick={() => setUserMenuOpen(false)}
-                          >
-                            Admin
-                          </Link>
+                          <>
+                            <Link
+                              href="/finances"
+                              className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
+                              onClick={() => setUserMenuOpen(false)}
+                            >
+                              Finances
+                            </Link>
+                            <Link
+                              href="/admin"
+                              className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
+                              onClick={() => setUserMenuOpen(false)}
+                            >
+                              Admin
+                            </Link>
+                          </>
                         )}
                         <button
                           onClick={handleLogout}
@@ -328,13 +337,22 @@ export default function Header() {
                     Settings
                   </Link>
                   {isAdmin && (
-                    <Link
-                      href="/admin"
-                      className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
-                      onClick={() => setMobileMenuOpen(false)}
-                    >
-                      Admin
-                    </Link>
+                    <>
+                      <Link
+                        href="/finances"
+                        className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
+                        onClick={() => setMobileMenuOpen(false)}
+                      >
+                        Finances
+                      </Link>
+                      <Link
+                        href="/admin"
+                        className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
+                        onClick={() => setMobileMenuOpen(false)}
+                      >
+                        Admin
+                      </Link>
+                    </>
                   )}
                   <button
                     onClick={() => {

--- a/src/lib/finances/classify.test.ts
+++ b/src/lib/finances/classify.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferAccountKind,
+  effectiveKind,
+  isLiabilityKind,
+  isAccountKind,
+  categorizeTransaction,
+  categoryLabel,
+} from './classify';
+
+/**
+ * The account names below are the real ones the live connection returns. They
+ * are the point of this file: "DCU Cash Rewards" and "Coastal Cash Visa
+ * Signature" are credit cards whose names contain deposit-account words, and a
+ * naive keyword pass puts both on the wrong side of the balance sheet.
+ */
+describe('inferAccountKind', () => {
+  it('classifies deposit accounts from their names', () => {
+    expect(inferAccountKind('Free Checking (0849)', 'Digital Federal Credit Union')).toBe('checking');
+    expect(inferAccountKind('BASIC CHECKING (0011)', 'Technology Credit Union')).toBe('checking');
+    expect(inferAccountKind('Primary Savings (6266)', 'Digital Federal Credit Union')).toBe('savings');
+    expect(inferAccountKind('Money Market (4026)', 'Digital Federal Credit Union')).toBe('savings');
+    expect(inferAccountKind('A L Checking (XXXX4989)', 'Bay Federal Credit Union')).toBe('checking');
+  });
+
+  it('classifies cards by network and product name', () => {
+    expect(inferAccountKind('VISA SIGNATURE (0001)', 'Technology Credit Union')).toBe('credit');
+    expect(inferAccountKind('Chase Sapphire Preferred (2674)', 'Chase Bank')).toBe('credit');
+    expect(inferAccountKind('Discover it (2069)', 'Capital One')).toBe('credit');
+    expect(
+      inferAccountKind('Costco Anywhere Visa® Card by Citi-4294 (4294)', 'Citibank'),
+    ).toBe('credit');
+    expect(
+      inferAccountKind('Graphite™ Business Cash Unlimited Card (1009)', 'American Express'),
+    ).toBe('credit');
+  });
+
+  it('does not let a card name containing "cash" read as a deposit account', () => {
+    // The trap: both names contain "Cash", and one also contains "Signature".
+    expect(inferAccountKind('DCU Cash Rewards (0061)', 'Digital Federal Credit Union')).toBe('credit');
+    expect(
+      inferAccountKind('Coastal Cash Visa Signature (XXXX9731)', 'Bay Federal Credit Union'),
+    ).toBe('credit');
+  });
+
+  it('falls back to the institution when the account is named after its holder', () => {
+    // Apple Card arrives as org "Apple Card (Updated Monthly)" with the
+    // account simply named after the cardholder.
+    expect(inferAccountKind('Anthony', 'Apple Card (Updated Monthly)')).toBe('credit');
+  });
+
+  it('uses a negative balance only to break a tie', () => {
+    expect(inferAccountKind('Unlabelled account', null, -500)).toBe('credit');
+    // An overdrawn checking account must stay checking.
+    expect(inferAccountKind('Free Checking (0849)', 'DCU', -42)).toBe('checking');
+  });
+
+  it('returns unknown rather than guessing', () => {
+    expect(inferAccountKind('', null, null)).toBe('unknown');
+    expect(inferAccountKind('Account 12345', null, 100)).toBe('unknown');
+  });
+
+  it('recognises loans and investments', () => {
+    expect(inferAccountKind('Auto Loan 4432', 'DCU')).toBe('loan');
+    expect(inferAccountKind('Roth IRA', 'Fidelity')).toBe('investment');
+    expect(inferAccountKind('Brokerage', 'Schwab')).toBe('investment');
+  });
+});
+
+describe('effectiveKind', () => {
+  it('prefers the operator override over the derived kind', () => {
+    expect(effectiveKind({ kind: 'credit', kind_override: 'loan' })).toBe('loan');
+  });
+
+  it('falls back to the derived kind when there is no override', () => {
+    expect(effectiveKind({ kind: 'savings', kind_override: null })).toBe('savings');
+  });
+
+  it('ignores an override that is not a known kind', () => {
+    expect(effectiveKind({ kind: 'checking', kind_override: 'nonsense' })).toBe('checking');
+  });
+
+  it('degrades to unknown rather than throwing on junk', () => {
+    expect(effectiveKind({ kind: null, kind_override: null })).toBe('unknown');
+  });
+});
+
+describe('isLiabilityKind / isAccountKind', () => {
+  it('treats only credit and loan as debt', () => {
+    expect(isLiabilityKind('credit')).toBe(true);
+    expect(isLiabilityKind('loan')).toBe(true);
+    expect(isLiabilityKind('checking')).toBe(false);
+    expect(isLiabilityKind('unknown')).toBe(false);
+  });
+
+  it('validates kind strings', () => {
+    expect(isAccountKind('savings')).toBe(true);
+    expect(isAccountKind('crypto')).toBe(false);
+    expect(isAccountKind(null)).toBe(false);
+  });
+});
+
+describe('categorizeTransaction', () => {
+  it('prefers the MCC over the description text', () => {
+    // MCC 5411 is a grocery store, whatever the description says.
+    expect(
+      categorizeTransaction({ mcc: '5411', description: 'AMAZON MKTPL', amount: -30 }),
+    ).toBe('groceries');
+    expect(categorizeTransaction({ mcc: 5812, description: 'unknown', amount: -22 })).toBe('dining');
+    expect(categorizeTransaction({ mcc: '5541', description: '', amount: -60 })).toBe('fuel');
+  });
+
+  it('ignores an MCC that is not a real code', () => {
+    expect(categorizeTransaction({ mcc: 'abc', payee: 'Starbucks', amount: -6 })).toBe('dining');
+    expect(categorizeTransaction({ mcc: '', payee: 'Starbucks', amount: -6 })).toBe('dining');
+  });
+
+  it('matches card payments and transfers before anything else', () => {
+    expect(
+      categorizeTransaction({ description: 'PAYMENT THANK YOU - WEB', amount: 500 }),
+    ).toBe('payment');
+    expect(categorizeTransaction({ description: 'AUTOPAY 4294 - THANK YOU', amount: 300 })).toBe(
+      'payment',
+    );
+    // Zelle to a person is a transfer, not a card payment — "payment" here is
+    // reserved for settling a card balance, which must not be counted as spend.
+    expect(categorizeTransaction({ description: 'Zelle payment to J Smith', amount: -100 })).toBe(
+      'transfer',
+    );
+    expect(categorizeTransaction({ description: 'TRANSFER TO SHARE 0001', amount: -50 })).toBe(
+      'transfer',
+    );
+  });
+
+  it('recognises income only on a credit', () => {
+    expect(categorizeTransaction({ description: 'DIRECT DEP PAYROLL', amount: 4200 })).toBe('income');
+    // A debit that mentions payroll is not income; better to fall through than
+    // to record negative income.
+    expect(categorizeTransaction({ description: 'PAYROLL FEE', amount: -12 })).toBe('fees');
+  });
+
+  it('categorises software and infrastructure spend', () => {
+    expect(categorizeTransaction({ payee: 'AWS', amount: -220 })).toBe('software');
+    expect(categorizeTransaction({ payee: 'ANTHROPIC', amount: -20 })).toBe('software');
+    expect(categorizeTransaction({ payee: 'Railway', amount: -25 })).toBe('software');
+  });
+
+  it('returns null when nothing matches, rather than inventing "other"', () => {
+    expect(categorizeTransaction({ description: 'XYZ 4471 REF 99', amount: -18 })).toBeNull();
+    expect(categorizeTransaction({ amount: -18 })).toBeNull();
+    expect(categorizeTransaction({ description: '   ', amount: -18 })).toBeNull();
+  });
+});
+
+describe('categoryLabel', () => {
+  it('names the null bucket explicitly', () => {
+    expect(categoryLabel(null)).toBe('Uncategorised');
+    expect(categoryLabel(undefined)).toBe('Uncategorised');
+    expect(categoryLabel('groceries')).toBe('Groceries');
+  });
+});

--- a/src/lib/finances/classify.ts
+++ b/src/lib/finances/classify.ts
@@ -1,0 +1,317 @@
+/**
+ * Deriving what SimpleFIN does not tell us.
+ *
+ * The protocol has no account-type field and no transaction category, so both
+ * are inferred here. Everything in this file is pure so it can be tested
+ * against real institution names without touching a bank.
+ *
+ * The guiding rule for both inferences: prefer `unknown`/`null` over a
+ * confident guess. A blank category is visibly missing and gets fixed; a wrong
+ * one silently distorts the spend breakdown, and `kind` decides which side of
+ * the balance sheet an account lands on.
+ */
+
+export type AccountKind =
+  | 'checking'
+  | 'savings'
+  | 'credit'
+  | 'loan'
+  | 'investment'
+  | 'cash'
+  | 'unknown';
+
+export const ACCOUNT_KINDS: AccountKind[] = [
+  'checking',
+  'savings',
+  'credit',
+  'loan',
+  'investment',
+  'cash',
+  'unknown',
+];
+
+/** Kinds whose balance is a debt: shown positive as "owed", summed as a liability. */
+const LIABILITY_KINDS = new Set<AccountKind>(['credit', 'loan']);
+
+export function isLiabilityKind(kind: AccountKind): boolean {
+  return LIABILITY_KINDS.has(kind);
+}
+
+export function isAccountKind(value: unknown): value is AccountKind {
+  return typeof value === 'string' && (ACCOUNT_KINDS as string[]).includes(value);
+}
+
+/**
+ * Ordered because the first match wins and the names overlap: "DCU Cash
+ * Rewards" is a credit card despite containing "cash", and "Coastal Cash Visa
+ * Signature" is one despite containing both "cash" and "checking"-adjacent
+ * words. Card signals are therefore tested before deposit-account signals.
+ */
+const KIND_PATTERNS: Array<{ kind: AccountKind; pattern: RegExp }> = [
+  // Card networks and issuer product names are the strongest signal there is.
+  {
+    kind: 'credit',
+    pattern:
+      /\b(visa|mastercard|master card|amex|american express|discover it|discover card|credit card|creditcard|charge card)\b/i,
+  },
+  {
+    kind: 'credit',
+    pattern:
+      /\b(sapphire|freedom|platinum card|gold card|quicksilver|venture|savor|blue cash|cash rewards|rewards card|apple card|graphite|costco anywhere)\b/i,
+  },
+  { kind: 'credit', pattern: /\bcredit\b/i },
+
+  { kind: 'loan', pattern: /\b(loan|mortgage|heloc|auto ?loan|student|line of credit|lease)\b/i },
+
+  {
+    kind: 'investment',
+    pattern: /\b(brokerage|invest(ment)?|ira|roth|401\s?k|403\s?b|hsa|529|portfolio|securities|trading)\b/i,
+  },
+
+  { kind: 'checking', pattern: /\b(checking|chequing|draft|share draft|debit)\b/i },
+  { kind: 'savings', pattern: /\b(savings|saving|money market|mmkt|certificate|share cert|cd\b|time deposit)\b/i },
+
+  { kind: 'cash', pattern: /\b(cash management|wallet|cash account)\b/i },
+];
+
+/**
+ * Infer an account kind from its name, institution and balance.
+ *
+ * The balance is a tiebreaker only. A negative balance is strong evidence of a
+ * liability, but an overdrawn checking account is negative too — so it is used
+ * to promote `unknown` to `credit`, never to override a name that already
+ * said "checking".
+ *
+ * @param name  the account name as the institution renders it
+ * @param orgName  the institution name, checked second ("Apple Card" arrives
+ *                 as an org whose accounts are named after their holder)
+ * @param balance  current balance, or null when unknown
+ */
+export function inferAccountKind(
+  name: string | null | undefined,
+  orgName?: string | null,
+  balance?: number | null,
+): AccountKind {
+  const haystacks = [name ?? '', orgName ?? ''];
+
+  for (const haystack of haystacks) {
+    if (!haystack.trim()) continue;
+    for (const { kind, pattern } of KIND_PATTERNS) {
+      if (pattern.test(haystack)) return kind;
+    }
+  }
+
+  if (typeof balance === 'number' && balance < 0) return 'credit';
+
+  return 'unknown';
+}
+
+/** The kind actually in force: an operator override always beats the guess. */
+export function effectiveKind(row: {
+  kind?: string | null;
+  kind_override?: string | null;
+}): AccountKind {
+  if (isAccountKind(row.kind_override)) return row.kind_override;
+  if (isAccountKind(row.kind)) return row.kind;
+  return 'unknown';
+}
+
+export type SpendCategory =
+  | 'income'
+  | 'transfer'
+  | 'payment'
+  | 'fees'
+  | 'groceries'
+  | 'dining'
+  | 'transport'
+  | 'fuel'
+  | 'travel'
+  | 'shopping'
+  | 'utilities'
+  | 'software'
+  | 'health'
+  | 'entertainment'
+  | 'insurance'
+  | 'taxes'
+  | 'cash'
+  | 'other';
+
+/**
+ * MCC ranges, checked before any text. An institution that supplies an MCC is
+ * telling us what the merchant actually is, which beats guessing from a
+ * description that has been truncated and mangled by three systems.
+ *
+ * Ranges rather than a full table: the ISO groupings are contiguous by design,
+ * and a partial table of exact codes would silently mis-bucket everything it
+ * omitted.
+ */
+const MCC_RANGES: Array<{ from: number; to: number; category: SpendCategory }> = [
+  { from: 3000, to: 3299, category: 'travel' },   // airlines
+  { from: 3300, to: 3499, category: 'transport' },// car rental
+  { from: 3500, to: 3999, category: 'travel' },   // lodging
+  { from: 4111, to: 4131, category: 'transport' },
+  { from: 4411, to: 4457, category: 'travel' },
+  { from: 4468, to: 4468, category: 'travel' },
+  { from: 4511, to: 4511, category: 'travel' },
+  { from: 4582, to: 4582, category: 'travel' },
+  { from: 4722, to: 4723, category: 'travel' },
+  { from: 4784, to: 4784, category: 'transport' },
+  { from: 4789, to: 4789, category: 'transport' },
+  { from: 4812, to: 4816, category: 'utilities' },
+  { from: 4821, to: 4821, category: 'utilities' },
+  { from: 4899, to: 4900, category: 'utilities' },
+  { from: 5411, to: 5422, category: 'groceries' },
+  { from: 5441, to: 5451, category: 'groceries' },
+  { from: 5462, to: 5499, category: 'groceries' },
+  { from: 5541, to: 5542, category: 'fuel' },
+  { from: 5983, to: 5983, category: 'fuel' },
+  { from: 5812, to: 5814, category: 'dining' },
+  { from: 5912, to: 5912, category: 'health' },
+  { from: 5960, to: 5960, category: 'insurance' },
+  { from: 6300, to: 6300, category: 'insurance' },
+  { from: 6010, to: 6012, category: 'cash' },
+  { from: 6051, to: 6051, category: 'cash' },
+  { from: 7011, to: 7011, category: 'travel' },
+  { from: 7512, to: 7513, category: 'transport' },
+  { from: 7523, to: 7523, category: 'transport' },
+  { from: 7832, to: 7841, category: 'entertainment' },
+  { from: 7911, to: 7999, category: 'entertainment' },
+  { from: 8011, to: 8099, category: 'health' },
+  { from: 8211, to: 8299, category: 'other' },
+  { from: 9211, to: 9311, category: 'taxes' },
+  { from: 9399, to: 9399, category: 'taxes' },
+  { from: 5734, to: 5734, category: 'software' },
+  { from: 7372, to: 7372, category: 'software' },
+  { from: 5999, to: 5999, category: 'shopping' },
+  { from: 5300, to: 5399, category: 'shopping' },
+  { from: 5600, to: 5699, category: 'shopping' },
+  { from: 5700, to: 5733, category: 'shopping' },
+  { from: 5735, to: 5811, category: 'shopping' },
+];
+
+function categoryFromMcc(mcc: unknown): SpendCategory | null {
+  const raw = typeof mcc === 'number' ? String(mcc) : typeof mcc === 'string' ? mcc.trim() : '';
+  if (!/^\d{3,4}$/.test(raw)) return null;
+  const code = Number(raw);
+  for (const range of MCC_RANGES) {
+    if (code >= range.from && code <= range.to) return range.category;
+  }
+  return null;
+}
+
+/**
+ * Text rules, in priority order. Transfers and card payments are matched first:
+ * they are the highest-volume rows and the most damaging to miscategorise,
+ * because a card payment counted as spending double-counts every purchase it
+ * settles.
+ */
+const TEXT_RULES: Array<{ category: SpendCategory; pattern: RegExp }> = [
+  {
+    category: 'payment',
+    pattern:
+      /\b(payment thank you|autopay|auto ?pay|online payment|payment received|card payment|pymt|electronic payment)\b/i,
+  },
+  {
+    category: 'transfer',
+    pattern:
+      /\b(transfer|xfer|zelle|venmo|cash app|cashapp|paypal transfer|wire|ach (credit|debit)|internal|to share|from share)\b/i,
+  },
+  {
+    category: 'income',
+    pattern: /\b(payroll|direct dep|direct deposit|salary|dividend|interest (paid|earned)|refund|reimburse)\b/i,
+  },
+  {
+    category: 'fees',
+    pattern: /\b(fee|overdraft|nsf|service charge|late charge|finance charge|annual membership|interest charge)\b/i,
+  },
+  { category: 'cash', pattern: /\b(atm|cash withdrawal|withdrawal)\b/i },
+  {
+    category: 'groceries',
+    pattern:
+      /\b(grocer|safeway|trader joe|whole ?foods|costco|kroger|albertsons|aldi|publix|wegmans|sprouts|food ?4 ?less|market)\b/i,
+  },
+  {
+    category: 'dining',
+    pattern:
+      /\b(restaurant|cafe|coffee|starbucks|peet|doordash|uber ?eats|grubhub|postmates|pizza|taco|sushi|bar & grill|brewing|bakery|deli)\b/i,
+  },
+  {
+    category: 'fuel',
+    pattern: /\b(chevron|shell|exxon|mobil|arco|valero|76 gas|gas station|fuel|bp )\b/i,
+  },
+  {
+    category: 'transport',
+    pattern: /\b(uber|lyft|transit|parking|toll|bart|caltrain|metro|dmv|smog)\b/i,
+  },
+  {
+    category: 'travel',
+    pattern: /\b(airline|airlines|united air|delta air|southwest|alaska air|hotel|motel|airbnb|expedia|marriott|hilton|hyatt|booking\.com)\b/i,
+  },
+  {
+    category: 'software',
+    pattern:
+      /\b(aws|amazon web services|google cloud|gcp|digitalocean|railway|vercel|netlify|heroku|github|gitlab|openai|anthropic|cloudflare|namecheap|godaddy|jetbrains|adobe|figma|slack|notion|atlassian|twilio|stripe|supabase|hosting|domain)\b/i,
+  },
+  {
+    category: 'utilities',
+    pattern:
+      /\b(pg&e|pge|electric|water dept|comcast|xfinity|at&?t|verizon|t-?mobile|spectrum|internet|utility|waste|sewer|gas company)\b/i,
+  },
+  {
+    category: 'entertainment',
+    pattern: /\b(netflix|spotify|hulu|disney|hbo|max\.com|youtube|prime video|steam|playstation|xbox|cinema|theatre|theater)\b/i,
+  },
+  {
+    category: 'health',
+    pattern: /\b(pharmacy|cvs|walgreens|rite aid|medical|dental|dentist|doctor|clinic|hospital|vision|optometr)\b/i,
+  },
+  { category: 'insurance', pattern: /\b(insurance|geico|state farm|allstate|progressive|policy premium)\b/i },
+  { category: 'taxes', pattern: /\b(irs|franchise tax|tax payment|treasury|ftb)\b/i },
+  {
+    category: 'shopping',
+    pattern: /\b(amazon|amzn|target|walmart|best buy|home depot|lowes|ikea|etsy|ebay|apple\.com|store)\b/i,
+  },
+];
+
+/**
+ * Categorise one transaction.
+ *
+ * @returns a category, or `null` when nothing matched — deliberately not
+ *          `'other'`, so "we could not tell" is distinguishable in the data
+ *          from "this genuinely belongs in other".
+ */
+export function categorizeTransaction(input: {
+  description?: string | null;
+  payee?: string | null;
+  memo?: string | null;
+  mcc?: string | number | null;
+  amount?: number | null;
+}): SpendCategory | null {
+  const fromMcc = categoryFromMcc(input.mcc);
+  if (fromMcc) return fromMcc;
+
+  const text = [input.payee, input.description, input.memo]
+    .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+    .join(' ');
+
+  if (!text.trim()) return null;
+
+  for (const { category, pattern } of TEXT_RULES) {
+    if (pattern.test(text)) {
+      // "Refund" and "interest earned" read as income, but only a credit can
+      // actually be income. A debit matching an income word is something else
+      // entirely (a fee reversal that failed, a transfer out), so fall through
+      // rather than record a negative income row.
+      if (category === 'income' && typeof input.amount === 'number' && input.amount < 0) continue;
+      return category;
+    }
+  }
+
+  return null;
+}
+
+/** Display label for a category, including the null "uncategorised" case. */
+export function categoryLabel(category: string | null | undefined): string {
+  if (!category) return 'Uncategorised';
+  return category.charAt(0).toUpperCase() + category.slice(1);
+}

--- a/src/lib/finances/format.test.ts
+++ b/src/lib/finances/format.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatMoney, formatCompact, formatDate, formatRelative, percentOf } from './format';
+
+describe('formatMoney', () => {
+  it('formats positive and negative amounts', () => {
+    expect(formatMoney(1234.5, 'USD')).toBe('$1,234.50');
+    expect(formatMoney(-2653.49, 'USD')).toBe('-$2,653.49');
+  });
+
+  it('never renders negative zero as a debt', () => {
+    // -0 through Intl gives "-$0.00", which reads as owing money that is not owed.
+    expect(formatMoney(-0, 'USD')).toBe('$0.00');
+    expect(formatMoney(0, 'USD')).toBe('$0.00');
+  });
+
+  it('adds an explicit plus only when asked', () => {
+    expect(formatMoney(20, 'USD', { signed: true })).toBe('+$20.00');
+    expect(formatMoney(-20, 'USD', { signed: true })).toBe('-$20.00');
+    expect(formatMoney(20, 'USD')).toBe('$20.00');
+  });
+
+  it('renders an em dash for missing values', () => {
+    expect(formatMoney(null)).toBe('—');
+    expect(formatMoney(undefined)).toBe('—');
+    expect(formatMoney(Number.NaN)).toBe('—');
+  });
+
+  it('falls back rather than throwing on an unknown currency code', () => {
+    expect(formatMoney(10, 'NOTACURRENCY')).toContain('10.00');
+  });
+});
+
+describe('formatCompact', () => {
+  it('stays exact below the compact threshold', () => {
+    expect(formatCompact(999.5, 'USD')).toBe('$999.50');
+  });
+
+  it('compacts larger amounts and keeps the sign', () => {
+    expect(formatCompact(33998.35, 'USD')).toBe('$34K');
+    expect(formatCompact(-33998.35, 'USD')).toBe('-$34K');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats an ISO instant as a UTC calendar day', () => {
+    expect(formatDate('2026-08-19T00:00:00.000Z')).toBe('19 Aug 2026');
+  });
+
+  it('handles missing and unparseable input', () => {
+    expect(formatDate(null)).toBe('—');
+    expect(formatDate('not a date')).toBe('—');
+  });
+});
+
+describe('formatRelative', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('describes recent instants in the largest sensible unit', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-19T12:00:00.000Z'));
+
+    expect(formatRelative('2026-08-19T11:59:30.000Z')).toBe('just now');
+    expect(formatRelative('2026-08-19T11:00:00.000Z')).toBe('1 hour ago');
+    expect(formatRelative('2026-08-17T12:00:00.000Z')).toBe('2 days ago');
+    expect(formatRelative('2026-08-05T12:00:00.000Z')).toBe('2 weeks ago');
+  });
+
+  it('says never for a connection that has not synced', () => {
+    expect(formatRelative(null)).toBe('never');
+  });
+});
+
+describe('percentOf', () => {
+  it('computes a bounded percentage', () => {
+    expect(percentOf(25, 100)).toBe(25);
+    expect(percentOf(150, 100)).toBe(100);
+  });
+
+  it('returns 0 instead of NaN when the total is zero', () => {
+    // A NaN width silently collapses every bar in the chart.
+    expect(percentOf(10, 0)).toBe(0);
+    expect(percentOf(Number.NaN, 100)).toBe(0);
+  });
+});

--- a/src/lib/finances/format.ts
+++ b/src/lib/finances/format.ts
@@ -1,0 +1,107 @@
+/**
+ * Display helpers for money and dates on /finances.
+ *
+ * Pure and separate from the components so the rounding and sign rules can be
+ * tested directly — a balance sheet that renders "-$0.00" or drops a minus sign
+ * is worse than no balance sheet.
+ */
+
+/**
+ * Format an amount in its own currency.
+ *
+ * Falls back to a plain fixed-decimal string when the currency code is not one
+ * `Intl` recognises, rather than throwing and taking the page down with it.
+ */
+export function formatMoney(
+  amount: number | null | undefined,
+  currency = 'USD',
+  { signed = false }: { signed?: boolean } = {},
+): string {
+  if (amount === null || amount === undefined || !Number.isFinite(amount)) return '—';
+
+  // Negative zero renders as "-$0.00", which reads as a debt that isn't there.
+  const value = Object.is(amount, -0) ? 0 : amount;
+
+  let formatted: string;
+  try {
+    formatted = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency || 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(Math.abs(value));
+  } catch {
+    formatted = `${currency || ''} ${Math.abs(value).toFixed(2)}`.trim();
+  }
+
+  if (value < 0) return `-${formatted}`;
+  if (signed && value > 0) return `+${formatted}`;
+  return formatted;
+}
+
+/** Compact form for headline tiles: $33.9k, $1.2M. */
+export function formatCompact(amount: number | null | undefined, currency = 'USD'): string {
+  if (amount === null || amount === undefined || !Number.isFinite(amount)) return '—';
+  const abs = Math.abs(amount);
+  if (abs < 10_000) return formatMoney(amount, currency);
+
+  try {
+    const formatted = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency || 'USD',
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(Math.abs(amount));
+    return amount < 0 ? `-${formatted}` : formatted;
+  } catch {
+    return formatMoney(amount, currency);
+  }
+}
+
+/** `2026-08-19` → `19 Aug 2026`. Dates only; these are calendar days, not instants. */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+/** "3 hours ago" / "just now", for sync freshness. */
+export function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'never';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'never';
+
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+
+  const units: Array<[number, string]> = [
+    [60, 'minute'],
+    [3600, 'hour'],
+    [86400, 'day'],
+    [604800, 'week'],
+  ];
+
+  let label = 'minute';
+  let divisor = 60;
+  for (const [unitSeconds, unitLabel] of units) {
+    if (seconds >= unitSeconds) {
+      divisor = unitSeconds;
+      label = unitLabel;
+    }
+  }
+
+  const count = Math.floor(seconds / divisor);
+  return `${count} ${label}${count === 1 ? '' : 's'} ago`;
+}
+
+/** Percentage of a whole, guarding the zero-total case that would give NaN. */
+export function percentOf(part: number, total: number): number {
+  if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return 0;
+  return Math.min(Math.max((part / total) * 100, 0), 100);
+}

--- a/src/lib/finances/simplefin.test.ts
+++ b/src/lib/finances/simplefin.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  parseAccessUrl,
+  decodeSetupToken,
+  redactAccessUrl,
+  parseAmount,
+  unixToIso,
+  collectErrors,
+  claimSetupToken,
+} from './simplefin';
+
+describe('parseAccessUrl', () => {
+  it('splits credentials from the endpoint', () => {
+    const parsed = parseAccessUrl('https://user123:pass456@beta-bridge.simplefin.org/simplefin');
+    expect(parsed.username).toBe('user123');
+    expect(parsed.password).toBe('pass456');
+    expect(parsed.baseUrl).toBe('https://beta-bridge.simplefin.org/simplefin');
+  });
+
+  it('keeps a password containing @ intact', () => {
+    // Only the LAST @ in the authority separates credentials from host, so a
+    // password with an @ in it must survive. Splitting on the first @ would
+    // silently produce a wrong password and a 401 nobody could explain.
+    const parsed = parseAccessUrl('https://user:p@ss@host.example/simplefin');
+    expect(parsed.username).toBe('user');
+    expect(parsed.password).toBe('p@ss');
+    expect(parsed.baseUrl).toBe('https://host.example/simplefin');
+  });
+
+  it('keeps a password containing a colon intact', () => {
+    const parsed = parseAccessUrl('https://user:a:b:c@host.example/simplefin');
+    expect(parsed.password).toBe('a:b:c');
+  });
+
+  it('does not percent-decode the credential', () => {
+    // `new URL()` would turn %2F into '/' and corrupt the secret.
+    const parsed = parseAccessUrl('https://user:a%2Fb%40c@host.example/simplefin');
+    expect(parsed.password).toBe('a%2Fb%40c');
+  });
+
+  it('strips a trailing slash so paths join cleanly', () => {
+    expect(parseAccessUrl('https://u:p@host.example/simplefin/').baseUrl).toBe(
+      'https://host.example/simplefin',
+    );
+  });
+
+  it('rejects a URL with no credentials', () => {
+    expect(() => parseAccessUrl('https://host.example/simplefin')).toThrow(/credentials/i);
+  });
+
+  it('rejects a URL with no scheme', () => {
+    expect(() => parseAccessUrl('u:p@host.example/simplefin')).toThrow(/scheme/i);
+  });
+});
+
+describe('redactAccessUrl', () => {
+  it('removes the credential from anything loggable', () => {
+    expect(redactAccessUrl('failed GET https://user:secret@host/simplefin/accounts')).toBe(
+      'failed GET https://***:***@host/simplefin/accounts',
+    );
+  });
+
+  it('leaves a credential-free string alone', () => {
+    expect(redactAccessUrl('https://host/simplefin')).toBe('https://host/simplefin');
+  });
+});
+
+describe('decodeSetupToken', () => {
+  it('decodes base64 to a claim URL', () => {
+    const url = 'https://beta-bridge.simplefin.org/simplefin/claim/ABC123';
+    expect(decodeSetupToken(Buffer.from(url).toString('base64'))).toBe(url);
+  });
+
+  it('tolerates whitespace from a paste', () => {
+    const url = 'https://bridge.example/simplefin/claim/XYZ';
+    const token = Buffer.from(url).toString('base64');
+    expect(decodeSetupToken(`  ${token.slice(0, 10)}\n${token.slice(10)}  `)).toBe(url);
+  });
+
+  it('rejects a token that does not decode to a URL', () => {
+    expect(() => decodeSetupToken(Buffer.from('not a url').toString('base64'))).toThrow(/https/i);
+  });
+
+  it('rejects an empty token', () => {
+    expect(() => decodeSetupToken('   ')).toThrow(/empty/i);
+  });
+});
+
+describe('parseAmount', () => {
+  it('parses the decimal strings SimpleFIN sends', () => {
+    expect(parseAmount('-2653.49')).toBe(-2653.49);
+    expect(parseAmount('0.00')).toBe(0);
+    expect(parseAmount('1,234.56')).toBe(1234.56);
+  });
+
+  it('returns null rather than NaN for junk', () => {
+    // NaN would propagate into every sum downstream and turn one bad row into
+    // a blank balance sheet.
+    expect(parseAmount('n/a')).toBeNull();
+    expect(parseAmount('')).toBeNull();
+    expect(parseAmount(null)).toBeNull();
+    expect(parseAmount(undefined)).toBeNull();
+  });
+
+  it('accepts a number as-is', () => {
+    expect(parseAmount(12.5)).toBe(12.5);
+    expect(parseAmount(Number.NaN)).toBeNull();
+  });
+});
+
+describe('unixToIso', () => {
+  it('converts UNIX seconds', () => {
+    expect(unixToIso(1787140800)).toBe(new Date(1787140800000).toISOString());
+  });
+
+  it('rejects zero, negatives and non-numbers', () => {
+    expect(unixToIso(0)).toBeNull();
+    expect(unixToIso(-5)).toBeNull();
+    expect(unixToIso('1787140800')).toBeNull();
+    expect(unixToIso(undefined)).toBeNull();
+  });
+});
+
+describe('collectErrors', () => {
+  it('reads the v1 `errors` spelling', () => {
+    expect(collectErrors({ accounts: [], errors: ['Chase needs reauth'] })).toEqual([
+      'Chase needs reauth',
+    ]);
+  });
+
+  it('reads the v2 `errlist` spelling, including object form', () => {
+    expect(
+      collectErrors({
+        accounts: [],
+        errlist: ['plain', { message: 'from object' }, { detail: 'from detail' }],
+      }),
+    ).toEqual(['plain', 'from object', 'from detail']);
+  });
+
+  it('ignores blanks and unrecognised shapes', () => {
+    expect(collectErrors({ accounts: [], errors: ['  '], errlist: [{ nope: 1 }] })).toEqual([]);
+  });
+});
+
+describe('claimSetupToken', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const token = Buffer.from('https://bridge.example/simplefin/claim/TOKEN').toString('base64');
+
+  it('POSTs the decoded claim URL and returns the access URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'https://user:pass@bridge.example/simplefin\n',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(claimSetupToken(token)).resolves.toBe('https://user:pass@bridge.example/simplefin');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://bridge.example/simplefin/claim/TOKEN');
+    expect(init.method).toBe('POST');
+  });
+
+  it('explains that a 403 means the token is already spent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => '' }));
+    await expect(claimSetupToken(token)).rejects.toThrow(/already been claimed/i);
+  });
+
+  it('rejects a response that is not an access URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'Server error' }),
+    );
+    await expect(claimSetupToken(token)).rejects.toThrow(/did not return an access URL/i);
+  });
+
+  it('rejects an access URL with no credentials, while the operator can still act', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => 'https://bridge.example/simplefin',
+      }),
+    );
+    await expect(claimSetupToken(token)).rejects.toThrow(/credentials/i);
+  });
+});

--- a/src/lib/finances/simplefin.ts
+++ b/src/lib/finances/simplefin.ts
@@ -1,0 +1,347 @@
+/**
+ * SimpleFIN protocol client — https://www.simplefin.org/protocol.html
+ *
+ * SimpleFIN is a read-only aggregation protocol: it hands out balances and
+ * transactions and can never move money. The whole surface is two calls.
+ *
+ *   1. `claimSetupToken(token)` — a setup token is a base64-encoded *claim URL*.
+ *      POSTing to it returns an access URL. This is one-shot: the second POST
+ *      gets a 403, and there is no way to recover the access URL afterwards, so
+ *      callers must persist the return value before doing anything else.
+ *
+ *   2. `fetchAccountSet(accessUrl, opts)` — GET /accounts. The access URL
+ *      carries HTTP Basic credentials inline; they are split out and sent as an
+ *      Authorization header rather than left in the request URL, so they never
+ *      reach a log line, a redirect target or an error message.
+ *
+ * The server is rate limited to roughly 24 requests per day across all
+ * accounts, which is the reason sync is an explicit action rather than
+ * something that runs on page load.
+ */
+
+/** A financial institution, as SimpleFIN repeats it on every account. */
+export interface SimpleFinOrg {
+  id?: string;
+  name?: string;
+  domain?: string;
+  url?: string;
+  'sfin-url'?: string;
+}
+
+/** One transaction. Amounts are decimal strings, timestamps UNIX seconds. */
+export interface SimpleFinTransaction {
+  id: string;
+  posted: number;
+  amount: string;
+  description?: string;
+  payee?: string;
+  memo?: string;
+  transacted_at?: number;
+  mcc?: string | number | null;
+  pending?: boolean;
+  extra?: Record<string, unknown>;
+}
+
+export interface SimpleFinAccount {
+  id: string;
+  name: string;
+  currency: string;
+  balance: string;
+  'available-balance'?: string;
+  'balance-date'?: number;
+  org?: SimpleFinOrg;
+  transactions?: SimpleFinTransaction[];
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * The /accounts response. `errors` is the v1 spelling and `errlist` the v2
+ * one; both are accepted because the bridge answers with whichever matches the
+ * requested version, and a caller that only reads one will silently treat a
+ * failed institution as an institution with no accounts.
+ */
+export interface SimpleFinAccountSet {
+  accounts: SimpleFinAccount[];
+  errors?: string[];
+  errlist?: unknown[];
+  'x-api-message'?: string[];
+}
+
+export interface FetchAccountsOptions {
+  /** Only transactions posted on or after this instant. */
+  startDate?: Date;
+  /** Only transactions posted before this instant. */
+  endDate?: Date;
+  /** Include not-yet-posted transactions. */
+  pending?: boolean;
+  /** Skip transactions entirely — much cheaper when only balances are wanted. */
+  balancesOnly?: boolean;
+  /** Restrict to specific SimpleFIN account ids. */
+  accountIds?: string[];
+  /** Abort the request after this many milliseconds. */
+  timeoutMs?: number;
+}
+
+/** Credentials and endpoint pulled apart from an access URL. */
+interface ParsedAccessUrl {
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
+/**
+ * Split `https://user:pass@host/path` into an endpoint plus credentials.
+ *
+ * Done by hand rather than through `new URL()` because SimpleFIN passwords are
+ * opaque and routinely contain characters that `URL` percent-decodes on the way
+ * out, which would corrupt the credential. Only the last `@` before the path is
+ * treated as the separator, so a password containing `@` survives.
+ *
+ * @throws {Error} when the URL carries no credentials — an access URL always does.
+ */
+export function parseAccessUrl(accessUrl: string): ParsedAccessUrl {
+  const trimmed = accessUrl.trim();
+  const schemeSplit = trimmed.indexOf('://');
+  if (schemeSplit === -1) {
+    throw new Error('SimpleFIN access URL is missing a scheme');
+  }
+
+  const scheme = trimmed.slice(0, schemeSplit);
+  const rest = trimmed.slice(schemeSplit + 3);
+
+  // The authority ends at the first '/', '?' or '#'. Anything after that is
+  // path and cannot contain the credential separator.
+  const authorityEnd = rest.search(/[/?#]/);
+  const authority = authorityEnd === -1 ? rest : rest.slice(0, authorityEnd);
+  const path = authorityEnd === -1 ? '' : rest.slice(authorityEnd);
+
+  const at = authority.lastIndexOf('@');
+  if (at === -1) {
+    throw new Error('SimpleFIN access URL is missing credentials');
+  }
+
+  const credentials = authority.slice(0, at);
+  const host = authority.slice(at + 1);
+
+  const colon = credentials.indexOf(':');
+  const username = colon === -1 ? credentials : credentials.slice(0, colon);
+  const password = colon === -1 ? '' : credentials.slice(colon + 1);
+
+  if (!host) {
+    throw new Error('SimpleFIN access URL is missing a host');
+  }
+
+  return {
+    baseUrl: `${scheme}://${host}${path}`.replace(/\/+$/, ''),
+    username,
+    password,
+  };
+}
+
+/** `Basic base64(user:pass)` for an access URL. */
+function basicAuthHeader({ username, password }: ParsedAccessUrl): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+/**
+ * Redact the credential out of anything that might carry one, so an access URL
+ * cannot reach a log, an error response or the browser.
+ */
+export function redactAccessUrl(value: string): string {
+  return value.replace(/\/\/[^/@\s]*@/g, '//***:***@');
+}
+
+/**
+ * Decode a setup token to its claim URL without claiming it.
+ *
+ * @throws {Error} when the token is not base64 of an https URL.
+ */
+export function decodeSetupToken(setupToken: string): string {
+  const cleaned = setupToken.trim().replace(/\s+/g, '');
+  if (!cleaned) throw new Error('Setup token is empty');
+
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cleaned, 'base64').toString('utf8').trim();
+  } catch {
+    throw new Error('Setup token is not valid base64');
+  }
+
+  if (!/^https:\/\/\S+$/i.test(decoded)) {
+    throw new Error('Setup token did not decode to an https URL');
+  }
+
+  return decoded;
+}
+
+/**
+ * Exchange a setup token for an access URL. **Single use** — the caller owns
+ * persisting the result, because a repeat claim returns 403 and the credential
+ * is then unrecoverable.
+ *
+ * @param setupToken base64 setup token as pasted by the user
+ * @returns the access URL, credentials included
+ * @throws {Error} when the token is malformed, already claimed, or the bridge fails
+ */
+export async function claimSetupToken(
+  setupToken: string,
+  { timeoutMs = 30_000 }: { timeoutMs?: number } = {},
+): Promise<string> {
+  const claimUrl = decodeSetupToken(setupToken);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(claimUrl, {
+      method: 'POST',
+      headers: { 'Content-Length': '0' },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error('Timed out claiming the SimpleFIN setup token');
+    }
+    throw new Error(
+      `Could not reach the SimpleFIN bridge: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 403) {
+    throw new Error(
+      'This setup token has already been claimed. Setup tokens are single-use — generate a new one.',
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(`SimpleFIN bridge rejected the claim (HTTP ${response.status})`);
+  }
+
+  const accessUrl = (await response.text()).trim();
+  if (!/^https:\/\//i.test(accessUrl)) {
+    throw new Error('SimpleFIN bridge did not return an access URL');
+  }
+
+  // Fail here rather than at the first sync, while the operator still has the
+  // context to fix it — the token is spent either way.
+  parseAccessUrl(accessUrl);
+
+  return accessUrl;
+}
+
+/** UNIX seconds, which is what SimpleFIN's date parameters take. */
+function toUnixSeconds(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+/**
+ * GET /accounts.
+ *
+ * @throws {Error} on auth failure, rate limiting, or an unparseable response
+ */
+export async function fetchAccountSet(
+  accessUrl: string,
+  options: FetchAccountsOptions = {},
+): Promise<SimpleFinAccountSet> {
+  const parsed = parseAccessUrl(accessUrl);
+
+  const params = new URLSearchParams();
+  if (options.startDate) params.set('start-date', String(toUnixSeconds(options.startDate)));
+  if (options.endDate) params.set('end-date', String(toUnixSeconds(options.endDate)));
+  if (options.pending) params.set('pending', '1');
+  if (options.balancesOnly) params.set('balances-only', '1');
+  for (const id of options.accountIds ?? []) params.append('account', id);
+
+  const query = params.toString();
+  const url = `${parsed.baseUrl}/accounts${query ? `?${query}` : ''}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? 120_000);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: basicAuthHeader(parsed), Accept: 'application/json' },
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error('Timed out reading accounts from SimpleFIN');
+    }
+    throw new Error(
+      `Could not reach SimpleFIN: ${redactAccessUrl(err instanceof Error ? err.message : 'unknown error')}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error('SimpleFIN rejected the stored credentials — the connection needs re-linking');
+  }
+  if (response.status === 429) {
+    throw new Error('SimpleFIN rate limit reached (about 24 requests per day). Try again later.');
+  }
+  if (!response.ok) {
+    throw new Error(`SimpleFIN returned HTTP ${response.status}`);
+  }
+
+  const body = await response.text();
+  let parsedBody: unknown;
+  try {
+    parsedBody = JSON.parse(body);
+  } catch {
+    throw new Error('SimpleFIN returned a response that was not JSON');
+  }
+
+  const set = parsedBody as SimpleFinAccountSet;
+  if (!set || !Array.isArray(set.accounts)) {
+    throw new Error('SimpleFIN response did not contain an accounts array');
+  }
+
+  return set;
+}
+
+/**
+ * Normalise the two error spellings into one list of strings, so a partially
+ * failed sync can say which institution stopped answering.
+ */
+export function collectErrors(set: SimpleFinAccountSet): string[] {
+  const out: string[] = [];
+  for (const e of set.errors ?? []) {
+    if (typeof e === 'string' && e.trim()) out.push(e.trim());
+  }
+  for (const e of set.errlist ?? []) {
+    if (typeof e === 'string' && e.trim()) out.push(e.trim());
+    else if (e && typeof e === 'object') {
+      const rec = e as Record<string, unknown>;
+      const message = rec.message ?? rec.error ?? rec.detail;
+      if (typeof message === 'string' && message.trim()) out.push(message.trim());
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a SimpleFIN decimal string.
+ *
+ * Returns `null` rather than `NaN` for anything unparseable so a bad value
+ * lands in the database as NULL instead of poisoning every sum downstream.
+ */
+export function parseAmount(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/,/g, '');
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** UNIX seconds to an ISO instant, tolerating null/0/garbage. */
+export function unixToIso(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return new Date(value * 1000).toISOString();
+}

--- a/src/lib/finances/summary.test.ts
+++ b/src/lib/finances/summary.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { toAccountView, aggregateAccounts, type FinanceAccount } from './summary';
+
+function account(partial: Partial<FinanceAccount>): FinanceAccount {
+  return {
+    id: partial.id ?? 'acc-1',
+    connection_id: 'conn-1',
+    external_id: 'ACT-1',
+    // `in` rather than `??`, so a test can pass an explicit null and mean it.
+    org_name: 'org_name' in partial ? (partial.org_name ?? null) : 'Test Bank',
+    org_domain: null,
+    name: partial.name ?? 'Account',
+    currency: partial.currency ?? 'USD',
+    balance: 'balance' in partial ? (partial.balance ?? null) : 0,
+    available_balance: partial.available_balance ?? null,
+    balance_date: null,
+    kind: partial.kind ?? 'unknown',
+    kind_override: partial.kind_override ?? null,
+    is_hidden: partial.is_hidden ?? false,
+    last_seen_at: '2026-08-19T00:00:00.000Z',
+  } as FinanceAccount;
+}
+
+describe('toAccountView', () => {
+  it('states a card balance as a positive amount owed', () => {
+    // SimpleFIN reports a $2,653.49 card debt as -2653.49.
+    const view = toAccountView(account({ kind: 'credit', balance: -2653.49 }));
+    expect(view.is_liability).toBe(true);
+    expect(view.display_balance).toBe(2653.49);
+  });
+
+  it('leaves a deposit balance alone', () => {
+    const view = toAccountView(account({ kind: 'checking', balance: 1673.86 }));
+    expect(view.is_liability).toBe(false);
+    expect(view.display_balance).toBe(1673.86);
+  });
+
+  it('shows an overpaid card as a negative amount owed, not a positive one', () => {
+    // A credit balance on a card is stored positive. `Math.abs` would report it
+    // as money owed; negating states the truth — the card owes you.
+    const view = toAccountView(account({ kind: 'credit', balance: 120 }));
+    expect(view.display_balance).toBe(-120);
+  });
+
+  it('lets an override move an account across the balance sheet', () => {
+    const view = toAccountView(account({ kind: 'checking', kind_override: 'loan', balance: -500 }));
+    expect(view.effective_kind).toBe('loan');
+    expect(view.is_liability).toBe(true);
+    expect(view.display_balance).toBe(500);
+  });
+
+  it('passes a null balance through untouched', () => {
+    expect(toAccountView(account({ balance: null })).display_balance).toBeNull();
+  });
+});
+
+describe('aggregateAccounts', () => {
+  it('splits assets from debt and nets them', () => {
+    const accounts = [
+      account({ id: 'a', kind: 'checking', balance: 1000 }),
+      account({ id: 'b', kind: 'savings', balance: 9530.78 }),
+      account({ id: 'c', kind: 'credit', balance: -2653.49 }),
+      account({ id: 'd', kind: 'credit', balance: -617.49 }),
+    ].map(toAccountView);
+
+    const { totals, primaryCurrency } = aggregateAccounts(accounts);
+    expect(primaryCurrency).toBe('USD');
+    expect(totals).toHaveLength(1);
+    expect(totals[0].assets).toBeCloseTo(10530.78, 2);
+    expect(totals[0].liabilities).toBeCloseTo(3270.98, 2);
+    expect(totals[0].net).toBeCloseTo(7259.8, 2);
+    expect(totals[0].accounts).toBe(4);
+  });
+
+  it('counts an unclassified negative balance as debt, not a negative asset', () => {
+    // Netting is identical either way; the reported assets and debt are not.
+    const { totals } = aggregateAccounts([
+      account({ id: 'a', kind: 'checking', balance: 500 }),
+      account({ id: 'b', kind: 'unknown', balance: -200 }),
+    ].map(toAccountView));
+
+    expect(totals[0].assets).toBe(500);
+    expect(totals[0].liabilities).toBe(200);
+    expect(totals[0].net).toBe(300);
+  });
+
+  it('never sums across currencies', () => {
+    const { totals, primaryCurrency } = aggregateAccounts([
+      account({ id: 'a', currency: 'USD', kind: 'checking', balance: 100 }),
+      account({ id: 'b', currency: 'USD', kind: 'checking', balance: 200 }),
+      account({ id: 'c', currency: 'EUR', kind: 'checking', balance: 50 }),
+    ].map(toAccountView));
+
+    expect(totals).toHaveLength(2);
+    // The currency with the most accounts leads, and holds the headline figures.
+    expect(primaryCurrency).toBe('USD');
+    expect(totals.find((t) => t.currency === 'USD')?.assets).toBe(300);
+    expect(totals.find((t) => t.currency === 'EUR')?.assets).toBe(50);
+  });
+
+  it('groups by institution with debt stated positive', () => {
+    const { byInstitution } = aggregateAccounts([
+      account({ id: 'a', org_name: 'Chase Bank', kind: 'credit', balance: -617.49 }),
+      account({ id: 'b', org_name: 'Chase Bank', kind: 'credit', balance: -33998.35 }),
+      account({ id: 'c', org_name: 'Bay Federal', kind: 'savings', balance: 9530.78 }),
+    ].map(toAccountView));
+
+    const chase = byInstitution.find((i) => i.org === 'Chase Bank');
+    expect(chase?.liabilities).toBeCloseTo(34615.84, 2);
+    expect(chase?.assets).toBe(0);
+    expect(chase?.accounts).toBe(2);
+    // Sorted by total exposure, so the largest position leads.
+    expect(byInstitution[0].org).toBe('Chase Bank');
+  });
+
+  it('handles an empty account set without producing NaN', () => {
+    const { totals, primaryCurrency, byKind } = aggregateAccounts([]);
+    expect(totals).toEqual([]);
+    expect(primaryCurrency).toBeNull();
+    expect(byKind).toEqual([]);
+  });
+
+  it('names accounts with no institution rather than dropping them', () => {
+    const { byInstitution } = aggregateAccounts([
+      toAccountView(account({ org_name: null, kind: 'checking', balance: 10 })),
+    ]);
+    expect(byInstitution[0].org).toBe('Unknown institution');
+  });
+});

--- a/src/lib/finances/summary.ts
+++ b/src/lib/finances/summary.ts
@@ -1,0 +1,456 @@
+import 'server-only';
+import { getSupabaseAdmin } from '../supabase/server';
+import { effectiveKind, isLiabilityKind, type AccountKind } from './classify';
+
+/**
+ * Reading the finance tables.
+ *
+ * Two rules shape everything here.
+ *
+ * **Totals are keyed by currency, never summed across one.** Every account is
+ * USD today, but a single foreign account would silently corrupt a bare
+ * `sum(balance)` and nothing would look wrong. Grouping by currency costs one
+ * map and makes that impossible.
+ *
+ * **Liability sign is normalised once, at the boundary.** SimpleFIN reports a
+ * card you owe $2,653 on as `-2653.49`. That sign is preserved in the database
+ * (it is the only account-type signal the protocol gives) but every figure
+ * leaving this module is stated the way a person would: `liabilities` is a
+ * positive amount owed, and `net` is assets minus liabilities.
+ */
+
+/** Supabase caps a single select at 1000 rows; anything unbounded pages. */
+const PAGE_SIZE = 1000;
+
+/** Ceiling on rows pulled into memory for an aggregate. */
+const MAX_AGGREGATE_ROWS = 50_000;
+
+export interface FinanceAccount {
+  id: string;
+  connection_id: string;
+  external_id: string;
+  org_name: string | null;
+  org_domain: string | null;
+  name: string;
+  currency: string;
+  balance: number | null;
+  available_balance: number | null;
+  balance_date: string | null;
+  kind: AccountKind;
+  kind_override: string | null;
+  is_hidden: boolean;
+  last_seen_at: string;
+}
+
+export interface FinanceTransaction {
+  id: string;
+  account_id: string;
+  posted: string;
+  transacted_at: string | null;
+  amount: number;
+  description: string | null;
+  payee: string | null;
+  memo: string | null;
+  mcc: string | null;
+  pending: boolean;
+  category: string | null;
+}
+
+/** An account as the UI consumes it: kind resolved, liability sign flipped. */
+export interface AccountView extends FinanceAccount {
+  /** `kind_override` when set, otherwise the derived `kind`. */
+  effective_kind: AccountKind;
+  /** True when this account's balance is a debt. */
+  is_liability: boolean;
+  /**
+   * The balance as a person would state it: positive for money held, positive
+   * for money owed. Read alongside `is_liability` — never summed on its own.
+   */
+  display_balance: number | null;
+}
+
+export interface CurrencyTotals {
+  currency: string;
+  assets: number;
+  liabilities: number;
+  net: number;
+  accounts: number;
+}
+
+export interface CategoryTotal {
+  category: string | null;
+  spent: number;
+  received: number;
+  count: number;
+}
+
+export interface InstitutionTotal {
+  org: string;
+  currency: string;
+  assets: number;
+  liabilities: number;
+  accounts: number;
+}
+
+export interface FinanceSummary {
+  /** Window in days that the cashflow and category figures cover. */
+  windowDays: number;
+  totals: CurrencyTotals[];
+  /** The currency holding the most accounts — what the headline figures use. */
+  primaryCurrency: string | null;
+  byKind: Array<{ kind: AccountKind; currency: string; total: number; accounts: number }>;
+  byInstitution: InstitutionTotal[];
+  cashflow: {
+    currency: string | null;
+    moneyIn: number;
+    moneyOut: number;
+    net: number;
+    transactions: number;
+  };
+  topCategories: CategoryTotal[];
+  accountCount: number;
+  hiddenCount: number;
+  transactionCount: number;
+  oldestTransaction: string | null;
+  newestTransaction: string | null;
+}
+
+/**
+ * Page through a table until it is exhausted or the cap is hit.
+ *
+ * Without this, every aggregate would silently describe only the first 1000
+ * rows — which reads as a working feature right up until the data outgrows it.
+ */
+async function fetchAllRows<T>(
+  build: () => ReturnType<ReturnType<typeof getSupabaseAdmin>['from']>,
+  { max = MAX_AGGREGATE_ROWS }: { max?: number } = {},
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let offset = 0; offset < max; offset += PAGE_SIZE) {
+    const query = build() as unknown as {
+      range: (from: number, to: number) => Promise<{ data: T[] | null; error: { message: string } | null }>;
+    };
+    const { data, error } = await query.range(offset, offset + PAGE_SIZE - 1);
+    if (error) throw new Error(error.message);
+    const rows = data ?? [];
+    out.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+  }
+  return out;
+}
+
+/** Turn a stored row into the shape the UI wants. */
+export function toAccountView(row: FinanceAccount): AccountView {
+  const kind = effectiveKind(row);
+  const liability = isLiabilityKind(kind);
+  const balance = row.balance;
+
+  return {
+    ...row,
+    kind,
+    effective_kind: kind,
+    is_liability: liability,
+    // A liability's stored balance is negative; state it as a positive amount
+    // owed. `Math.abs` would also flip a credit *balance* on an overpaid card,
+    // so negate rather than abs — an overpaid card correctly shows as owing a
+    // negative amount, which is true and visible.
+    display_balance: balance === null ? null : liability ? -balance : balance,
+  };
+}
+
+export async function listAccounts({
+  includeHidden = false,
+}: { includeHidden?: boolean } = {}): Promise<AccountView[]> {
+  const supabase = getSupabaseAdmin();
+  let query = supabase
+    .from('finance_accounts')
+    .select(
+      'id, connection_id, external_id, org_name, org_domain, name, currency, balance, available_balance, balance_date, kind, kind_override, is_hidden, last_seen_at',
+    )
+    .order('org_name', { ascending: true })
+    .order('name', { ascending: true });
+
+  if (!includeHidden) query = query.eq('is_hidden', false);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Could not load accounts: ${error.message}`);
+
+  return (data ?? []).map((row) => toAccountView(row as unknown as FinanceAccount));
+}
+
+/**
+ * Roll a set of accounts up into the balance sheet.
+ *
+ * Pure and exported so the sign handling can be tested directly — it is the
+ * one piece of arithmetic here where being wrong produces a plausible-looking
+ * number rather than an obvious error.
+ */
+export function aggregateAccounts(accounts: AccountView[]): {
+  totals: CurrencyTotals[];
+  primaryCurrency: string | null;
+  byKind: Array<{ kind: AccountKind; currency: string; total: number; accounts: number }>;
+  byInstitution: InstitutionTotal[];
+} {
+  const totalsByCurrency = new Map<string, CurrencyTotals>();
+  const kindTotals = new Map<
+    string,
+    { kind: AccountKind; currency: string; total: number; accounts: number }
+  >();
+  const institutionTotals = new Map<string, InstitutionTotal>();
+
+  for (const account of accounts) {
+    const currency = account.currency || 'USD';
+    const balance = account.balance ?? 0;
+
+    const totals =
+      totalsByCurrency.get(currency) ?? { currency, assets: 0, liabilities: 0, net: 0, accounts: 0 };
+    totals.accounts += 1;
+
+    // Classify by kind first, and only fall back to the sign of the balance for
+    // accounts we could not type. Without that fallback an untyped card would
+    // be counted as a negative asset — which nets out to the same figure but
+    // understates both assets and debt, and those are the two numbers anyone
+    // actually reads.
+    const isDebt = account.is_liability || (account.effective_kind === 'unknown' && balance < 0);
+
+    if (isDebt) totals.liabilities += -balance;
+    else totals.assets += balance;
+
+    totals.net = totals.assets - totals.liabilities;
+    totalsByCurrency.set(currency, totals);
+
+    const kindKey = `${account.effective_kind}::${currency}`;
+    const kindEntry =
+      kindTotals.get(kindKey) ?? { kind: account.effective_kind, currency, total: 0, accounts: 0 };
+    kindEntry.total += isDebt ? -balance : balance;
+    kindEntry.accounts += 1;
+    kindTotals.set(kindKey, kindEntry);
+
+    const org = account.org_name ?? 'Unknown institution';
+    const orgKey = `${org}::${currency}`;
+    const orgEntry =
+      institutionTotals.get(orgKey) ?? { org, currency, assets: 0, liabilities: 0, accounts: 0 };
+    if (isDebt) orgEntry.liabilities += -balance;
+    else orgEntry.assets += balance;
+    orgEntry.accounts += 1;
+    institutionTotals.set(orgKey, orgEntry);
+  }
+
+  const totals = [...totalsByCurrency.values()].sort((a, b) => b.accounts - a.accounts);
+
+  return {
+    totals,
+    primaryCurrency: totals[0]?.currency ?? null,
+    byKind: [...kindTotals.values()].sort((a, b) => Math.abs(b.total) - Math.abs(a.total)),
+    byInstitution: [...institutionTotals.values()].sort(
+      (a, b) => b.assets + b.liabilities - (a.assets + a.liabilities),
+    ),
+  };
+}
+
+export interface TransactionFilters {
+  accountId?: string | null;
+  search?: string | null;
+  category?: string | null;
+  startDate?: Date | null;
+  endDate?: Date | null;
+  includePending?: boolean;
+  includeHiddenAccounts?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface TransactionPage {
+  rows: Array<FinanceTransaction & { account_name: string; org_name: string | null; currency: string }>;
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * One page of the ledger, newest first, with the account joined on.
+ *
+ * Hidden accounts are excluded by filtering on their ids rather than through a
+ * join, because PostgREST cannot filter a parent by an embedded child's column
+ * without changing the row shape.
+ */
+export async function listTransactions(filters: TransactionFilters = {}): Promise<TransactionPage> {
+  const supabase = getSupabaseAdmin();
+
+  const limit = Math.min(Math.max(filters.limit ?? 50, 1), 500);
+  const offset = Math.max(filters.offset ?? 0, 0);
+
+  const accounts = await listAccounts({ includeHidden: filters.includeHiddenAccounts ?? false });
+  const accountById = new Map(accounts.map((a) => [a.id, a]));
+
+  const visibleIds = filters.accountId
+    ? accounts.filter((a) => a.id === filters.accountId).map((a) => a.id)
+    : accounts.map((a) => a.id);
+
+  if (visibleIds.length === 0) {
+    return { rows: [], total: 0, limit, offset };
+  }
+
+  let query = supabase
+    .from('finance_transactions')
+    .select(
+      'id, account_id, posted, transacted_at, amount, description, payee, memo, mcc, pending, category',
+      { count: 'exact' },
+    )
+    .in('account_id', visibleIds)
+    .order('posted', { ascending: false })
+    .order('id', { ascending: false });
+
+  if (filters.startDate) query = query.gte('posted', filters.startDate.toISOString());
+  if (filters.endDate) query = query.lte('posted', filters.endDate.toISOString());
+  if (filters.includePending === false) query = query.eq('pending', false);
+  if (filters.category === 'uncategorised') query = query.is('category', null);
+  else if (filters.category) query = query.eq('category', filters.category);
+
+  const search = filters.search?.trim();
+  if (search) {
+    // Commas and parentheses are PostgREST `or()` syntax, not text — passing
+    // them through unescaped turns a search box into a filter-injection point.
+    const safe = search.replace(/[,()*]/g, ' ').trim();
+    if (safe) {
+      query = query.or(
+        `description.ilike.%${safe}%,payee.ilike.%${safe}%,memo.ilike.%${safe}%`,
+      );
+    }
+  }
+
+  const { data, error, count } = await query.range(offset, offset + limit - 1);
+  if (error) throw new Error(`Could not load transactions: ${error.message}`);
+
+  const rows = (data ?? []).map((row) => {
+    const tx = row as unknown as FinanceTransaction;
+    const account = accountById.get(tx.account_id);
+    return {
+      ...tx,
+      account_name: account?.name ?? 'Unknown account',
+      org_name: account?.org_name ?? null,
+      currency: account?.currency ?? 'USD',
+    };
+  });
+
+  return { rows, total: count ?? rows.length, limit, offset };
+}
+
+/**
+ * The headline figures.
+ *
+ * @param windowDays how far back cashflow and categories look; balances are
+ *        always current, since a balance has no window.
+ */
+export async function getSummary({
+  windowDays = 30,
+  includeHidden = false,
+}: { windowDays?: number; includeHidden?: boolean } = {}): Promise<FinanceSummary> {
+  const supabase = getSupabaseAdmin();
+  const days = Math.min(Math.max(Math.floor(windowDays) || 30, 1), 3650);
+
+  const accounts = await listAccounts({ includeHidden });
+  const allAccounts = includeHidden ? accounts : await listAccounts({ includeHidden: true });
+  const hiddenCount = allAccounts.filter((a) => a.is_hidden).length;
+
+  const { totals, primaryCurrency, byKind, byInstitution } = aggregateAccounts(accounts);
+
+  // --- cashflow and categories ---------------------------------------------
+  const since = new Date(Date.now() - days * 86_400_000);
+  const visibleIds = accounts.map((a) => a.id);
+  const currencyByAccount = new Map(accounts.map((a) => [a.id, a.currency || 'USD']));
+
+  let moneyIn = 0;
+  let moneyOut = 0;
+  let transactionsInWindow = 0;
+  const categoryTotals = new Map<string, CategoryTotal>();
+
+  if (visibleIds.length > 0) {
+    const rows = await fetchAllRows<{
+      account_id: string;
+      amount: number;
+      category: string | null;
+    }>(() =>
+      supabase
+        .from('finance_transactions')
+        .select('account_id, amount, category')
+        .in('account_id', visibleIds)
+        .gte('posted', since.toISOString())
+        .order('posted', { ascending: false }) as never,
+    );
+
+    for (const row of rows) {
+      // Only the primary currency contributes to the headline cashflow;
+      // mixing currencies into one in/out figure would be meaningless.
+      if (primaryCurrency && currencyByAccount.get(row.account_id) !== primaryCurrency) continue;
+
+      const amount = Number(row.amount);
+      if (!Number.isFinite(amount)) continue;
+
+      transactionsInWindow += 1;
+      if (amount >= 0) moneyIn += amount;
+      else moneyOut += -amount;
+
+      const key = row.category ?? '__uncategorised__';
+      const entry =
+        categoryTotals.get(key) ??
+        { category: row.category, spent: 0, received: 0, count: 0 };
+      if (amount < 0) entry.spent += -amount;
+      else entry.received += amount;
+      entry.count += 1;
+      categoryTotals.set(key, entry);
+    }
+  }
+
+  // --- corpus extent --------------------------------------------------------
+  let transactionCount = 0;
+  let oldestTransaction: string | null = null;
+  let newestTransaction: string | null = null;
+
+  if (visibleIds.length > 0) {
+    const { count } = await supabase
+      .from('finance_transactions')
+      .select('id', { count: 'exact', head: true })
+      .in('account_id', visibleIds);
+    transactionCount = count ?? 0;
+
+    const { data: oldest } = await supabase
+      .from('finance_transactions')
+      .select('posted')
+      .in('account_id', visibleIds)
+      .order('posted', { ascending: true })
+      .limit(1);
+    oldestTransaction = (oldest?.[0]?.posted as string) ?? null;
+
+    const { data: newest } = await supabase
+      .from('finance_transactions')
+      .select('posted')
+      .in('account_id', visibleIds)
+      .order('posted', { ascending: false })
+      .limit(1);
+    newestTransaction = (newest?.[0]?.posted as string) ?? null;
+  }
+
+  return {
+    windowDays: days,
+    totals,
+    primaryCurrency,
+    byKind,
+    byInstitution,
+    cashflow: {
+      currency: primaryCurrency,
+      moneyIn,
+      moneyOut,
+      net: moneyIn - moneyOut,
+      transactions: transactionsInWindow,
+    },
+    topCategories: [...categoryTotals.values()]
+      .sort((a, b) => b.spent - a.spent)
+      .slice(0, 12),
+    accountCount: accounts.length,
+    hiddenCount,
+    transactionCount,
+    oldestTransaction,
+    newestTransaction,
+  };
+}

--- a/src/lib/finances/sync.test.ts
+++ b/src/lib/finances/sync.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: () => ({}) }));
+
+import { isAdvisory, DEFAULT_SYNC_DAYS, MAX_SYNC_DAYS } from './sync';
+
+describe('isAdvisory', () => {
+  it('treats the bridge’s range notices as advisories, not failures', () => {
+    // Both of these are real messages the bridge returned during development,
+    // and both arrive in the same array as genuine institution errors.
+    expect(
+      isAdvisory('Requested date range exceeds recommended range of 45 days. In the future, this may be capped.'),
+    ).toBe(true);
+    expect(isAdvisory('Requested date range exceeds limit of 90 days and was capped.')).toBe(true);
+  });
+
+  it('leaves a real institution failure alone', () => {
+    // The signal that must never be swallowed: a bank that stopped answering.
+    expect(isAdvisory('Connection to Chase Bank needs to be re-authenticated')).toBe(false);
+    expect(isAdvisory('Account temporarily unavailable')).toBe(false);
+    expect(isAdvisory('')).toBe(false);
+  });
+});
+
+describe('sync windows', () => {
+  it('defaults inside the range the bridge recommends', () => {
+    expect(DEFAULT_SYNC_DAYS).toBeLessThanOrEqual(45);
+  });
+
+  it('never allows a request that would trip the 90-day cap', () => {
+    expect(MAX_SYNC_DAYS).toBeLessThan(90);
+  });
+});

--- a/src/lib/finances/sync.ts
+++ b/src/lib/finances/sync.ts
@@ -1,0 +1,434 @@
+import 'server-only';
+import { getSupabaseAdmin } from '../supabase/server';
+import { encrypt, decrypt } from '../crypto/encryption';
+import { requireEncryptionKey } from '../crypto/require-key';
+import {
+  fetchAccountSet,
+  collectErrors,
+  parseAmount,
+  unixToIso,
+  parseAccessUrl,
+  redactAccessUrl,
+  type SimpleFinAccount,
+} from './simplefin';
+import { inferAccountKind, categorizeTransaction } from './classify';
+
+/**
+ * Pulling SimpleFIN into Postgres.
+ *
+ * Everything here is idempotent by construction: accounts key on
+ * `(connection_id, external_id)` and transactions on `(account_id,
+ * external_id)`, so re-syncing an already-imported window changes nothing but
+ * `updated_at`. That matters because overlap is the normal case — a pending
+ * transaction is rewritten when it posts, and each sync deliberately re-reads a
+ * window it has read before so late-posting card charges are not missed.
+ */
+
+/**
+ * How far back a sync reads when the caller does not say.
+ *
+ * 45 rather than 90: the bridge answers anything longer with `Requested date
+ * range exceeds recommended range of 45 days. In the future, this may be
+ * capped.` A rolling window this size is ample for a running view, and history
+ * already imported is never removed — the tables only ever accumulate.
+ */
+export const DEFAULT_SYNC_DAYS = 45;
+
+/**
+ * The hard ceiling for an explicitly requested window.
+ *
+ * SimpleFIN's limit is 90 days, but asking for exactly 90 trips it: the window
+ * is measured against the server's clock when the request lands, a fraction of
+ * a second after the start date is computed. The bridge then answers
+ * `Requested date range exceeds limit of 90 days and was capped`. 89 leaves
+ * room for the round trip.
+ */
+export const MAX_SYNC_DAYS = 89;
+
+/**
+ * Messages the bridge returns that describe an adjustment it made, not an
+ * institution that failed.
+ *
+ * These arrive in the same `errors` array as "Chase needs reauthentication",
+ * and treating them alike marks a complete sync as `partial` — which trains
+ * the operator to ignore the one signal that means a bank has actually stopped
+ * answering. Matching is deliberately narrow: anything not recognised here
+ * stays a real error.
+ */
+const ADVISORY_PATTERNS = [
+  /exceeds (the )?recommended range/i,
+  /and was capped/i,
+];
+
+export function isAdvisory(message: string): boolean {
+  return ADVISORY_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/** PostgREST rejects very large payloads; upserts go up in chunks of this size. */
+const UPSERT_CHUNK = 500;
+
+export interface SyncResult {
+  connectionId: string;
+  accounts: number;
+  transactionsSeen: number;
+  transactionsNew: number;
+  /** Institution-level failures SimpleFIN reported without failing the request. */
+  errors: string[];
+  /** Advisories from the bridge — informational, and not a failure. */
+  notices: string[];
+  status: 'ok' | 'partial';
+}
+
+export interface FinanceConnectionRow {
+  id: string;
+  provider: string;
+  label: string | null;
+  is_active: boolean;
+  created_at: string;
+  last_synced_at: string | null;
+  last_sync_status: string | null;
+  last_sync_error: string | null;
+  last_sync_accounts: number | null;
+  last_sync_transactions: number | null;
+}
+
+/** Columns safe to return to a client — never the encrypted access URL. */
+const CONNECTION_COLUMNS =
+  'id, provider, label, is_active, created_at, last_synced_at, last_sync_status, last_sync_error, last_sync_accounts, last_sync_transactions';
+
+/**
+ * Store a freshly claimed access URL.
+ *
+ * Encryption is not optional: `requireEncryptionKey` throws rather than falling
+ * back to a constant, because this credential is a live read feed into
+ * somebody's bank and a setup token cannot be re-claimed to rotate it.
+ */
+export async function createConnection(params: {
+  accessUrl: string;
+  label?: string | null;
+  createdBy?: string | null;
+}): Promise<FinanceConnectionRow> {
+  // Reject a malformed URL before it is encrypted and becomes hard to inspect.
+  parseAccessUrl(params.accessUrl);
+
+  const key = requireEncryptionKey('finance connection storage');
+  const supabase = getSupabaseAdmin();
+
+  const { data, error } = await supabase
+    .from('finance_connections')
+    .insert({
+      provider: 'simplefin',
+      label: params.label?.trim() || null,
+      access_url_encrypted: encrypt(params.accessUrl, key),
+      created_by: params.createdBy ?? null,
+    })
+    .select(CONNECTION_COLUMNS)
+    .single();
+
+  if (error) throw new Error(`Could not save the SimpleFIN connection: ${error.message}`);
+  return data as FinanceConnectionRow;
+}
+
+/**
+ * Adopt `SIMPLEFIN_ACCESS_URL` as a connection when the table is empty.
+ *
+ * The access URL for this deployment was claimed out of band, and a claim
+ * cannot be repeated — so the environment holds the only copy. This promotes it
+ * into the database once, encrypted, and then the env var is only a backup.
+ * Returns null when there is nothing to do, which is the steady state.
+ */
+export async function bootstrapConnectionFromEnv(): Promise<FinanceConnectionRow | null> {
+  const envUrl = process.env.SIMPLEFIN_ACCESS_URL?.trim();
+  if (!envUrl) return null;
+
+  const supabase = getSupabaseAdmin();
+  const { count, error } = await supabase
+    .from('finance_connections')
+    .select('id', { count: 'exact', head: true });
+
+  if (error) throw new Error(`Could not read finance connections: ${error.message}`);
+  if ((count ?? 0) > 0) return null;
+
+  return createConnection({ accessUrl: envUrl, label: 'SimpleFIN (from environment)' });
+}
+
+/** Active connections, without their credentials. */
+export async function listConnections(): Promise<FinanceConnectionRow[]> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('finance_connections')
+    .select(CONNECTION_COLUMNS)
+    .order('created_at', { ascending: true });
+
+  if (error) throw new Error(`Could not list finance connections: ${error.message}`);
+  return (data ?? []) as FinanceConnectionRow[];
+}
+
+/**
+ * Decrypt one connection's access URL.
+ *
+ * Falls back to `SIMPLEFIN_ACCESS_URL` only when decryption fails *and* the env
+ * var is present — which is what happens if `ENCRYPTION_KEY` is rotated without
+ * re-encrypting. Without that, a key rotation would permanently orphan a
+ * credential that can never be re-claimed.
+ */
+async function getAccessUrl(connectionId: string): Promise<string> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('finance_connections')
+    .select('id, access_url_encrypted')
+    .eq('id', connectionId)
+    .single();
+
+  if (error || !data) throw new Error('Finance connection not found');
+
+  const key = requireEncryptionKey('finance connection access');
+  try {
+    return decrypt(data.access_url_encrypted as string, key);
+  } catch (err) {
+    const envUrl = process.env.SIMPLEFIN_ACCESS_URL?.trim();
+    if (envUrl) return envUrl;
+    throw new Error(
+      `Stored SimpleFIN credential could not be decrypted (${
+        err instanceof Error ? err.message : 'unknown error'
+      }). ENCRYPTION_KEY may have changed.`,
+    );
+  }
+}
+
+/** Shape written to `finance_accounts`; omitted columns survive an update. */
+function toAccountRow(connectionId: string, account: SimpleFinAccount, now: string) {
+  const balance = parseAmount(account.balance);
+  const org = account.org ?? {};
+  const orgName = org.name ?? org.domain ?? null;
+
+  return {
+    connection_id: connectionId,
+    external_id: account.id,
+    org_id: org.id ?? null,
+    org_name: orgName,
+    org_domain: org.domain ?? null,
+    org_url: org.url ?? org['sfin-url'] ?? null,
+    name: account.name || 'Unnamed account',
+    currency: (account.currency || 'USD').toUpperCase(),
+    balance,
+    available_balance: parseAmount(account['available-balance']),
+    balance_date: unixToIso(account['balance-date']),
+    // Re-derived every sync so a renamed account reclassifies itself.
+    // `kind_override` is deliberately absent from this payload: it is the
+    // operator's correction and must survive every re-derivation.
+    kind: inferAccountKind(account.name, orgName, balance),
+    last_seen_at: now,
+  };
+}
+
+async function chunkedUpsert(
+  table: string,
+  rows: Record<string, unknown>[],
+  onConflict: string,
+): Promise<void> {
+  const supabase = getSupabaseAdmin();
+  for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
+    const chunk = rows.slice(i, i + UPSERT_CHUNK);
+    const { error } = await supabase.from(table).upsert(chunk, { onConflict });
+    if (error) throw new Error(`Could not write ${table}: ${error.message}`);
+  }
+}
+
+/**
+ * Sync one connection.
+ *
+ * @param connectionId the connection to read
+ * @param days how far back to read transactions, clamped to SimpleFIN's 90-day window
+ * @throws {Error} when the whole request fails; per-institution failures are
+ *         reported in `errors` with status `partial` instead, because one
+ *         bank being down should not discard the other seven.
+ */
+export async function syncConnection(
+  connectionId: string,
+  { days = DEFAULT_SYNC_DAYS }: { days?: number } = {},
+): Promise<SyncResult> {
+  const supabase = getSupabaseAdmin();
+  const windowDays = Math.min(Math.max(Math.floor(days) || DEFAULT_SYNC_DAYS, 1), MAX_SYNC_DAYS);
+
+  try {
+    const accessUrl = await getAccessUrl(connectionId);
+    const startDate = new Date(Date.now() - windowDays * 86_400_000);
+
+    const set = await fetchAccountSet(accessUrl, { startDate, pending: true });
+    const reported = collectErrors(set);
+    const errors = reported.filter((message) => !isAdvisory(message));
+    const notices = reported.filter(isAdvisory);
+    const now = new Date().toISOString();
+
+    // --- accounts -----------------------------------------------------------
+    const accountRows = set.accounts.map((a) => toAccountRow(connectionId, a, now));
+    if (accountRows.length > 0) {
+      await chunkedUpsert('finance_accounts', accountRows, 'connection_id,external_id');
+    }
+
+    // Map SimpleFIN account ids to our uuids for the transaction foreign key.
+    const { data: stored, error: storedError } = await supabase
+      .from('finance_accounts')
+      .select('id, external_id')
+      .eq('connection_id', connectionId);
+    if (storedError) throw new Error(`Could not read finance accounts: ${storedError.message}`);
+
+    const idByExternal = new Map<string, string>();
+    for (const row of stored ?? []) idByExternal.set(row.external_id as string, row.id as string);
+
+    // --- transactions -------------------------------------------------------
+    const txRows: Record<string, unknown>[] = [];
+    for (const account of set.accounts) {
+      const accountId = idByExternal.get(account.id);
+      if (!accountId) continue;
+
+      for (const tx of account.transactions ?? []) {
+        const amount = parseAmount(tx.amount);
+        const posted = unixToIso(tx.posted);
+        // A row with no amount or no post date cannot be summed or ordered;
+        // importing it would only corrupt totals.
+        if (amount === null || !posted) continue;
+
+        const mcc =
+          tx.mcc === null || tx.mcc === undefined || tx.mcc === '' ? null : String(tx.mcc);
+
+        txRows.push({
+          account_id: accountId,
+          external_id: tx.id,
+          posted,
+          transacted_at: unixToIso(tx.transacted_at),
+          amount,
+          description: tx.description ?? null,
+          payee: tx.payee ?? null,
+          memo: tx.memo ?? null,
+          mcc,
+          pending: tx.pending === true,
+          category: categorizeTransaction({
+            description: tx.description,
+            payee: tx.payee,
+            memo: tx.memo,
+            mcc,
+            amount,
+          }),
+          updated_at: now,
+        });
+      }
+    }
+
+    // Count genuinely new rows before writing, since an upsert cannot say
+    // whether it inserted or updated.
+    const transactionsNew = await countNewTransactions(
+      txRows,
+      [...idByExternal.values()],
+      startDate.toISOString(),
+    );
+
+    if (txRows.length > 0) {
+      await chunkedUpsert('finance_transactions', txRows, 'account_id,external_id');
+    }
+
+    const status: SyncResult['status'] = errors.length > 0 ? 'partial' : 'ok';
+
+    await supabase
+      .from('finance_connections')
+      .update({
+        last_synced_at: now,
+        last_sync_status: status,
+        last_sync_error: errors.length > 0 ? errors.join('; ').slice(0, 2000) : null,
+        last_sync_accounts: accountRows.length,
+        last_sync_transactions: txRows.length,
+      })
+      .eq('id', connectionId);
+
+    return {
+      connectionId,
+      accounts: accountRows.length,
+      transactionsSeen: txRows.length,
+      transactionsNew,
+      errors,
+      notices,
+      status,
+    };
+  } catch (err) {
+    const message = redactAccessUrl(err instanceof Error ? err.message : 'Unknown sync failure');
+    await supabase
+      .from('finance_connections')
+      .update({
+        last_synced_at: new Date().toISOString(),
+        last_sync_status: 'error',
+        last_sync_error: message.slice(0, 2000),
+      })
+      .eq('id', connectionId);
+    throw new Error(message);
+  }
+}
+
+/**
+ * How many of these transactions we have never seen.
+ *
+ * Reads the external ids we already hold for these accounts over the same
+ * window and diffs in memory. The obvious implementation — asking Postgres
+ * `where external_id in (...)` — puts hundreds of 40-character ids into a
+ * query string and the request dies as a bare `TypeError: fetch failed`, with
+ * nothing to suggest the URL length was the problem. Paging a bounded window
+ * keeps every request small regardless of how many transactions came back.
+ */
+async function countNewTransactions(
+  rows: Record<string, unknown>[],
+  accountIds: string[],
+  sinceIso: string,
+): Promise<number> {
+  if (rows.length === 0 || accountIds.length === 0) return 0;
+  const supabase = getSupabaseAdmin();
+
+  const known = new Set<string>();
+  for (let offset = 0; ; offset += 1000) {
+    const { data, error } = await supabase
+      .from('finance_transactions')
+      .select('account_id, external_id')
+      .in('account_id', accountIds)
+      .gte('posted', sinceIso)
+      .range(offset, offset + 999);
+
+    if (error) throw new Error(`Could not count existing transactions: ${error.message}`);
+
+    const page = data ?? [];
+    for (const row of page) known.add(`${row.account_id}::${row.external_id}`);
+    if (page.length < 1000) break;
+  }
+
+  let fresh = 0;
+  for (const row of rows) {
+    if (!known.has(`${row.account_id}::${row.external_id}`)) fresh += 1;
+  }
+  return fresh;
+}
+
+/**
+ * Sync every active connection, bootstrapping one from the environment first if
+ * the table is empty.
+ */
+export async function syncAllConnections({
+  days = DEFAULT_SYNC_DAYS,
+}: { days?: number } = {}): Promise<SyncResult[]> {
+  await bootstrapConnectionFromEnv();
+
+  const connections = (await listConnections()).filter((c) => c.is_active);
+  const results: SyncResult[] = [];
+
+  // Sequential on purpose: SimpleFIN allows roughly 24 requests per day, and
+  // parallel requests would spend that budget in bursts for no gain.
+  for (const connection of connections) {
+    results.push(await syncConnection(connection.id, { days }));
+  }
+
+  return results;
+}
+
+/** Deactivate a connection and drop its accounts and transactions. */
+export async function deleteConnection(connectionId: string): Promise<void> {
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('finance_connections').delete().eq('id', connectionId);
+  if (error) throw new Error(`Could not delete the connection: ${error.message}`);
+}

--- a/supabase/migrations/20260819210000_finances_simplefin.sql
+++ b/supabase/migrations/20260819210000_finances_simplefin.sql
@@ -1,0 +1,196 @@
+-- /finances — bank account and credit card aggregation via SimpleFIN.
+--
+-- CoinPay knows what it *earns* (payments, invoices, escrows) but nothing about
+-- where that money lands or what it is spent against. This is the other side of
+-- the ledger: read-only balances and transactions pulled from the institutions
+-- themselves through SimpleFIN (https://www.simplefin.org/protocol.html).
+--
+-- Design notes:
+--
+--  * This is house financial data, not merchant data. Every table is RLS-enabled
+--    with **no policies at all**, so `anon` and `authenticated` can read nothing
+--    even if a key leaks; the app reaches it only through the service client
+--    behind `requireAdmin()`. That is the same posture as the admin-only
+--    Postgres functions, and it is why there are no `merchant_id` columns to
+--    scope on — there is nothing to scope, the whole table is privileged.
+--
+--  * The access URL is the whole credential — it carries HTTP Basic
+--    credentials inline (`https://user:pass@host/simplefin`) and is
+--    non-recoverable, since a SimpleFIN setup token can be claimed exactly
+--    once. It is stored AES-256-GCM encrypted under `ENCRYPTION_KEY` rather
+--    than in the clear, so a database dump alone does not hand over a live
+--    read feed into someone's bank.
+--
+--  * Amounts are `numeric(20,4)`, never float. SimpleFIN sends amounts as
+--    decimal *strings* precisely so they survive the trip; parsing them into a
+--    double here would undo that. Unlike the crypto money columns elsewhere in
+--    this schema, these are all in `currency` (ISO 4217) and a same-currency
+--    sum is meaningful.
+--
+--  * Sign convention is SimpleFIN's and is preserved verbatim: a credit card
+--    balance is **negative** when money is owed, and a transaction amount is
+--    negative for a withdrawal. Normalising signs at import would destroy the
+--    only thing that distinguishes an asset from a liability, since SimpleFIN
+--    has no account-type field at all.
+--
+--  * `(account_id, external_id)` is unique so a re-sync is idempotent. Overlap
+--    is the normal case, not the exception: pending transactions get rewritten
+--    when they post, and every sync deliberately re-reads a window that has
+--    already been read.
+
+-- ---------------------------------------------------------------------------
+-- Connections — one row per claimed SimpleFIN access URL.
+-- ---------------------------------------------------------------------------
+create table if not exists public.finance_connections (
+  id                 uuid primary key default gen_random_uuid(),
+
+  provider           text not null default 'simplefin'
+                       check (provider in ('simplefin')),
+
+  -- Human label for the console; the access URL itself is never displayed.
+  label              text,
+
+  -- AES-256-GCM, format `iv:authTag:ciphertext` — see src/lib/crypto/encryption.ts.
+  access_url_encrypted text not null,
+
+  -- Which admin added it. `set null` rather than cascade: losing the operator
+  -- must not silently delete the connection feeding the balance sheet.
+  created_by         uuid references public.merchants(id) on delete set null,
+
+  is_active          boolean not null default true,
+
+  created_at         timestamptz not null default now(),
+  last_synced_at     timestamptz,
+  last_sync_status   text check (last_sync_status in ('ok', 'partial', 'error')),
+  last_sync_error    text,
+
+  -- Cheap "what did the last run do" counters for the UI, so the common case
+  -- needs no join against a run-history table.
+  last_sync_accounts     integer,
+  last_sync_transactions integer
+);
+
+comment on table public.finance_connections is
+  'SimpleFIN access URLs (encrypted). Admin-only; RLS on with no policies.';
+
+-- ---------------------------------------------------------------------------
+-- Accounts — one row per account the connection exposes.
+-- ---------------------------------------------------------------------------
+create table if not exists public.finance_accounts (
+  id             uuid primary key default gen_random_uuid(),
+  connection_id  uuid not null references public.finance_connections(id) on delete cascade,
+
+  -- SimpleFIN's account id. Unique within a connection, not globally.
+  external_id    text not null,
+
+  -- Institution, denormalised from the per-account `org` object SimpleFIN
+  -- repeats on every response. Kept flat because there is no stable org table
+  -- to key against and the fields are display-only.
+  org_id         text,
+  org_name       text,
+  org_domain     text,
+  org_url        text,
+
+  name           text not null,
+  currency       text not null default 'USD',
+
+  balance            numeric(20,4),
+  available_balance  numeric(20,4),
+  balance_date       timestamptz,
+
+  -- SimpleFIN carries no account type, so `kind` is *derived* on every sync
+  -- from the account name, the institution and the sign of the balance.
+  -- `kind_override` is the operator's correction and always wins; keeping them
+  -- in separate columns means re-deriving never clobbers a manual fix.
+  kind           text not null default 'unknown'
+                   check (kind in ('checking','savings','credit','loan','investment','cash','unknown')),
+  kind_override  text
+                   check (kind_override in ('checking','savings','credit','loan','investment','cash','unknown')),
+
+  -- Hidden accounts stay synced but drop out of totals and listings — for
+  -- closed cards and duplicates that would otherwise distort net worth.
+  is_hidden      boolean not null default false,
+
+  first_seen_at  timestamptz not null default now(),
+  last_seen_at   timestamptz not null default now(),
+
+  unique (connection_id, external_id)
+);
+
+create index if not exists finance_accounts_connection_idx
+  on public.finance_accounts (connection_id);
+
+comment on column public.finance_accounts.balance is
+  'SimpleFIN sign convention: negative means money owed (credit cards, loans).';
+
+-- ---------------------------------------------------------------------------
+-- Transactions.
+-- ---------------------------------------------------------------------------
+create table if not exists public.finance_transactions (
+  id            uuid primary key default gen_random_uuid(),
+  account_id    uuid not null references public.finance_accounts(id) on delete cascade,
+
+  external_id   text not null,
+
+  -- `posted` is when the institution booked it; `transacted_at` is when it
+  -- actually happened. They differ by days on card purchases, so both are kept
+  -- and `posted` is what the ledger orders by.
+  posted        timestamptz not null,
+  transacted_at timestamptz,
+
+  amount        numeric(20,4) not null,
+
+  description   text,
+  payee         text,
+  memo          text,
+
+  -- Merchant Category Code, when the institution supplies one. The single most
+  -- reliable categorisation signal available; string, not int, because leading
+  -- zeros are significant.
+  mcc           text,
+
+  pending       boolean not null default false,
+
+  -- Derived at import from mcc + payee/description. Nullable: an
+  -- uncategorisable row is honest, an 'other' bucket pretending to be a
+  -- decision is not.
+  category      text,
+
+  imported_at   timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+
+  unique (account_id, external_id)
+);
+
+-- The ledger view: one account, newest first.
+create index if not exists finance_transactions_account_posted_idx
+  on public.finance_transactions (account_id, posted desc);
+
+-- The cross-account cashflow view, and every date-windowed aggregate.
+create index if not exists finance_transactions_posted_idx
+  on public.finance_transactions (posted desc);
+
+create index if not exists finance_transactions_category_idx
+  on public.finance_transactions (category)
+  where category is not null;
+
+-- ---------------------------------------------------------------------------
+-- Lock everything down.
+--
+-- RLS on with zero policies denies every browser-side role outright. The
+-- explicit revokes matter as well: Supabase's default privileges grant new
+-- public-schema objects to `anon`/`authenticated` directly, and RLS is the only
+-- thing standing between those grants and the data. Belt and braces, because
+-- the failure mode here is somebody's bank feed.
+-- ---------------------------------------------------------------------------
+alter table public.finance_connections  enable row level security;
+alter table public.finance_accounts     enable row level security;
+alter table public.finance_transactions enable row level security;
+
+revoke all on public.finance_connections  from public, anon, authenticated;
+revoke all on public.finance_accounts     from public, anon, authenticated;
+revoke all on public.finance_transactions from public, anon, authenticated;
+
+grant select, insert, update, delete on public.finance_connections  to service_role;
+grant select, insert, update, delete on public.finance_accounts     to service_role;
+grant select, insert, update, delete on public.finance_transactions to service_role;


### PR DESCRIPTION
Adds an admin-only `/finances` console that pulls read-only balances and transactions from linked banks and credit cards via [SimpleFIN](https://www.simplefin.org/protocol.html). CoinPay tracked what it earned but nothing about where the money landed or what it was spent against; this is the other side of the ledger.

## What's here

- **Protocol client** — setup-token claim (single-use) and `GET /accounts`. The access URL carries HTTP Basic credentials inline, so it's parsed by hand rather than through `new URL()` (which percent-decodes and would corrupt the secret), credentials go in a header rather than the request URL, and every error path is redacted.
- **Schema** — `finance_connections` / `finance_accounts` / `finance_transactions`. RLS enabled with **no policies** plus explicit revokes from `anon`/`authenticated`; reachable only through the service client behind `requireAdmin()`. The access URL is AES-256-GCM encrypted under `ENCRYPTION_KEY`. Amounts are `numeric(20,4)` and SimpleFIN's sign convention is preserved verbatim, since a negative balance is the only account-type signal the protocol gives.
- **Derived classification** — SimpleFIN has no account-type or category field. Account kind is inferred from name, institution and balance sign; `kind_override` is a separate column so re-deriving on every sync can't clobber an operator's correction. Both inferences prefer `unknown`/`null` over a confident guess.
- **UI** — net position / cash / owed / net-flow tiles, accounts grouped by institution, spend-by-category, and a filterable paged ledger.

## Notes

Sync is an explicit action, not an effect — the bridge allows roughly 24 requests/day. Bridge advisories ("exceeds recommended range") are separated from real institution failures, so a complete sync doesn't report as `partial` and train the operator to ignore the one signal that matters.

## Verification

Migration applied to prod (`mlywdeoogwsebabohskk`); RLS confirmed on with 0 policies and `anon`/`authenticated` denied. Against the live connection: **20 accounts across 8 institutions classified with no unknowns**, 1065 transactions imported, repeat syncs adding zero rows (idempotent). Totals reconcile against an independent SQL aggregate.

Full suite green (332 files / 4673 tests), `tsc --noEmit` clean, production build compiles all 7 routes plus the page.

`SIMPLEFIN_ACCESS_URL` is set on the Railway service and recorded in the logicsrc vault `coinpayportal--prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
