### PR TITLE
feat: close the remaining audit gaps — escrow arbitration, durable webhooks, installer pinning

### DIFF
--- a/TODO-vulns.md
+++ b/TODO-vulns.md
@@ -288,6 +288,34 @@ fired. All 6 wallets holding an LNbits admin key hold their own — they have bo
 `ln_wallet_adminkey` and `ln_wallet_inkey`, and the fallback path writes only
 the former (`adminkey_only = 0`). The fix is preventive, not remedial.
 
+## Remaining-gaps pass (2026-08-19, after the audit merged)
+
+- **`ESC-NEW-01` `FIXED`.** `dispute_resolution`/`dispute_status` now have a
+  writer: `resolveDispute()` plus an admin-gated
+  `POST /api/admin/escrows/[id]/resolve`. Also fixed the sharper half — refund
+  required `funded`, so raising a dispute *removed* the refund path and left
+  release-by-depositor as the only exit. `disputed` is now refundable, so a
+  beneficiary can concede.
+- **`REC-D-07` `FIXED`.** Durable retry queue (`webhook_deliveries`, migration
+  `20260819210000`) with a dead-letter state. In-process delivery spent its
+  whole budget in ~3 seconds; the queue retries on 1m→12h backoff and marks a
+  row `dead` after 8 attempts rather than dropping the event. Payloads are
+  re-signed per attempt — a stored signature is bound to its timestamp, so
+  replaying one is either rejected or, worse, accepted indefinitely.
+- **`W-01` `FIXED`.** Auto-upgrade from a mutable ref is now opt-in
+  (`COINPAY_AUTO_UPGRADE_UNPINNED=1`). Pinned installs keep it, since a tag can
+  only ever re-install the same code. Previously any merge to master executed on
+  every operator host within five minutes, unattended.
+- **Issuer cleanup — DONE (reversible).** Deactivated 5 of 18: `evilpoc`,
+  `poc2`, `OutHunt` (all `.example`, RFC 2606 — cannot resolve), `X`/`X`, and
+  `Tounes` claiming `Coinpayportal.com`. Verified first that only `ugig.net`
+  (14,333 receipts) and `d0rz.com` (5) have *ever* produced anything, so none of
+  the deactivated rows could break live traffic. `active = true` restores any.
+
+  Still open: 6 `*.trycloudflare.com` issuers (ephemeral tunnel hostnames are a
+  weak identity by construction) and the cleartext `api_key` column on 17 rows.
+  Rotating those needs the integrators told, so it stays Anthony's.
+
 ## Priority 5 verification sweep (2026-08-19)
 
 142 findings across `5a` (35), `5b` (25) and `5c` (82). The audit's own framing

--- a/public/install.sh
+++ b/public/install.sh
@@ -30,6 +30,10 @@
 #   COINPAY_HOME=/path           install dir          (default: $HOME/.coinpay)
 #   COINPAY_BIN=/path/dir        wrapper bin dir      (default: $HOME/.local/bin)
 #   COINPAY_REF=branch|tag|sha   git ref to install   (default: master)
+#   COINPAY_AUTO_UPGRADE_UNPINNED=1  schedule auto-upgrade even on a mutable
+#                                    ref. Off by default: following master
+#                                    unattended means any merge runs here
+#                                    within 5 minutes (W-01).
 #   COINPAY_NO_AUTOUPGRADE=1     skip the 5-min poll setup
 #   COINPAY_API_URL=https://…    pin API base         (default: https://coinpayportal.com)
 #
@@ -578,6 +582,29 @@ schedule_auto_upgrade() {
         info "COINPAY_NO_AUTOUPGRADE=1 — skipping auto-upgrade scheduling"
         return 0
     fi
+
+    # W-01: following a MUTABLE ref unattended is now opt-in.
+    #
+    # With COINPAY_REF unpinned the ref is `master`, and this timer polls every
+    # ${UPGRADE_INTERVAL_SEC}s. That means anything merged to master executes on
+    # every installed operator host within five minutes, with no human between
+    # the merge and the execution — a single bad merge, or a single compromised
+    # push, reaches the whole fleet automatically.
+    #
+    # Pinned installs keep auto-upgrade on by default: a tag or SHA is immutable,
+    # so the timer can only ever re-install the same code it already has, and
+    # moving to a new version stays a deliberate act.
+    #
+    # An operator who genuinely wants to track master can still have it, by
+    # asking for it explicitly. Refusing outright would push people to write
+    # their own cron job, which is worse.
+    if [ "$COINPAY_REF_PINNED" = "0" ] && [ "${COINPAY_AUTO_UPGRADE_UNPINNED:-}" != "1" ]; then
+        warn "auto-upgrade not scheduled: '$COINPAY_REF' is a mutable branch"
+        warn "  pin a release (COINPAY_REF=v0.6.13) to get automatic updates, or"
+        warn "  set COINPAY_AUTO_UPGRADE_UNPINNED=1 to follow master unattended"
+        return 0
+    fi
+
     case "$OS" in
         macos)
             schedule_launchd_agent && return 0

--- a/src/app/api/admin/escrows/[id]/resolve/route.ts
+++ b/src/app/api/admin/escrows/[id]/resolve/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '@/lib/auth/admin-guard';
+import { resolveDispute } from '@/lib/escrow/service';
+
+/**
+ * POST /api/admin/escrows/[id]/resolve — arbitrate a disputed escrow.
+ *
+ * ESC-NEW-01: `dispute_resolution` and `dispute_status` existed in the schema
+ * with no writer anywhere, and a disputed escrow had no exit. Release required
+ * the depositor — the party who had just been disputed against, or who had just
+ * disputed — and refund required `funded`, so raising a dispute *removed* the
+ * refund path. Whoever raised one made their own position worse and the escrow
+ * sat until somebody gave up.
+ *
+ * Admin-gated on purpose. The two parties disagree by definition, so neither
+ * can be the one who decides; the platform is the arbiter of record, which is
+ * the role `arbiter_address` names for the multisig model. `requireAdmin` is
+ * the whole security boundary here — this moves other people's money.
+ *
+ * Body: `{ "resolution": "release" | "refund", "note": "..." }`
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const guard = await requireAdmin(req);
+  if (guard instanceof NextResponse) return guard;
+
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const resolution = body?.resolution;
+  const note = typeof body?.note === 'string' ? body.note : '';
+
+  if (resolution !== 'release' && resolution !== 'refund') {
+    return NextResponse.json(
+      { success: false, error: "resolution must be 'release' or 'refund'" },
+      { status: 400 }
+    );
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    return NextResponse.json({ success: false, error: 'Server configuration error' }, { status: 500 });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const result = await resolveDispute(supabase, id, {
+    resolution,
+    note,
+    // Recorded as the actor on the event, so an arbitration is always
+    // attributable to a person rather than to "system".
+    resolvedBy: guard.email ?? guard.id,
+  });
+
+  if (!result.success) {
+    return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  }
+
+  console.log(
+    `[Admin] Escrow ${id} dispute resolved as ${resolution} by ${guard.email ?? guard.id}`
+  );
+
+  return NextResponse.json({ success: true, escrow: result.escrow });
+}

--- a/src/app/api/cron/monitor-payments/route.ts
+++ b/src/app/api/cron/monitor-payments/route.ts
@@ -19,6 +19,8 @@ import { monitorEmails } from './email-monitor';
 import { runInvoiceMonitorCycle, runInvoiceSchedulerCycle } from '@/lib/payments/monitor-invoices';
 import { expireEndedSubscriptions } from '@/lib/subscriptions/service';
 import { isCronSecret } from '@/lib/auth/secret-compare';
+import { processWebhookRetryQueue } from '@/lib/webhooks/retry-queue';
+import { redeliverQueuedWebhook } from '@/lib/webhooks/service';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -87,6 +89,16 @@ export async function GET(request: NextRequest) {
     // Process recurring invoice schedules
     const invoiceSchedulerStats = await runInvoiceSchedulerCycle(supabase, now);
 
+    // REC-D-07: work the durable webhook retry queue.
+    //
+    // In-process delivery spends its whole retry budget inside one request over
+    // roughly three seconds, so anything that fails there is handed here and
+    // retried on a backoff measured in minutes. Rows that exhaust their budget
+    // become dead-letters rather than disappearing.
+    const webhookRetryStats = await processWebhookRetryQueue(supabase, (row) =>
+      redeliverQueuedWebhook(supabase, row)
+    );
+
     // Downgrade merchants whose paid period has ended. isPaidTier also checks
     // the end date on every read, so a missed sweep cannot extend a plan — this
     // keeps the stored state honest as well.
@@ -103,6 +115,7 @@ export async function GET(request: NextRequest) {
       emails: emailStats,
       invoices: invoiceStats,
       invoiceScheduler: invoiceSchedulerStats,
+      webhookRetries: webhookRetryStats,
       subscriptionExpiry,
     };
 

--- a/src/lib/escrow/resolve-dispute.test.ts
+++ b/src/lib/escrow/resolve-dispute.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveDispute, refundEscrow } from './service';
+
+vi.mock('../webhooks/service', () => ({ sendEscrowWebhook: vi.fn() }));
+
+/**
+ * Regression tests for ESC-NEW-01 (2026-08-19 audit).
+ *
+ * `dispute_resolution` and `dispute_status` exist in the production schema and
+ * had no writer anywhere. `disputeEscrow` set `status = 'disputed'` and
+ * `dispute_reason` and stopped, so a dispute recorded a grievance and changed
+ * nothing else.
+ *
+ * The consequence was worse than a missing audit field: a disputed escrow could
+ * only be *released*, and only by the depositor. Refund required `funded`, so
+ * raising a dispute removed the refund path — whoever raised one made their own
+ * position strictly worse, and the escrow sat until someone gave up.
+ */
+
+function supabaseWith(escrow: Record<string, unknown> | null, updated: unknown = { id: 'esc-1' }) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    update: vi.fn(() => chain),
+    insert: vi.fn(() => Promise.resolve({ error: null })),
+    eq: vi.fn(() => chain),
+    single: vi.fn().mockResolvedValue(
+      escrow ? { data: escrow, error: null } : { data: null, error: { message: 'not found' } }
+    ),
+  };
+  // The update chain ends in .select().single(); make that answer `updated`.
+  let seenUpdate = false;
+  chain.update = vi.fn(() => {
+    seenUpdate = true;
+    return chain;
+  });
+  chain.single = vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      seenUpdate
+        ? { data: updated, error: null }
+        : escrow
+          ? { data: escrow, error: null }
+          : { data: null, error: { message: 'not found' } }
+    )
+  );
+  return { from: vi.fn(() => chain), _chain: chain } as any;
+}
+
+const DISPUTED = {
+  id: 'esc-1',
+  status: 'disputed',
+  business_id: 'biz-1',
+  depositor_address: '0xdep',
+  beneficiary_address: '0xben',
+  release_token: 'esc_tok',
+  beneficiary_token: 'esc_ben',
+  expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+};
+
+describe('resolveDispute', () => {
+  it('settles a disputed escrow to the beneficiary', async () => {
+    const db = supabaseWith(DISPUTED);
+    const r = await resolveDispute(db, 'esc-1', {
+      resolution: 'release',
+      note: 'Work delivered and verified against the brief.',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(r.success).toBe(true);
+    expect(db._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'released', dispute_status: 'resolved' })
+    );
+  });
+
+  it('returns a disputed escrow to the depositor', async () => {
+    const db = supabaseWith(DISPUTED);
+    const r = await resolveDispute(db, 'esc-1', {
+      resolution: 'refund',
+      note: 'Nothing was delivered within the agreed window.',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(r.success).toBe(true);
+    expect(db._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'refunded', dispute_status: 'resolved' })
+    );
+  });
+
+  it('writes the resolution note — the column that never had a writer', async () => {
+    const db = supabaseWith(DISPUTED);
+    await resolveDispute(db, 'esc-1', {
+      resolution: 'refund',
+      note: 'Beneficiary conceded in writing.',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(db._chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ dispute_resolution: 'Beneficiary conceded in writing.' })
+    );
+  });
+
+  it('requires a substantive note', async () => {
+    // The note is the record of why someone else's money moved. An empty one
+    // makes the arbitration unauditable.
+    const db = supabaseWith(DISPUTED);
+    const r = await resolveDispute(db, 'esc-1', {
+      resolution: 'refund',
+      note: 'nope',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(r.success).toBe(false);
+    expect(db.from).not.toHaveBeenCalled();
+  });
+
+  it('refuses an escrow that is not disputed', async () => {
+    // This exit exists only to break the deadlock. Pointing it at a funded
+    // escrow would be a way to move money with no counterparty involvement.
+    const db = supabaseWith({ ...DISPUTED, status: 'funded' });
+    const r = await resolveDispute(db, 'esc-1', {
+      resolution: 'release',
+      note: 'Trying to short-circuit the normal flow.',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Only a disputed escrow');
+  });
+
+  it('rejects an unknown resolution', async () => {
+    const db = supabaseWith(DISPUTED);
+    const r = await resolveDispute(db, 'esc-1', {
+      resolution: 'keep' as unknown as 'refund',
+      note: 'Neither party gets it, apparently.',
+      resolvedBy: 'admin@example.com',
+    });
+
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('refundEscrow from disputed (ESC-NEW-01)', () => {
+  it('lets the beneficiary concede after a dispute is raised', async () => {
+    // Refund required `funded`, so raising a dispute removed the cooperative
+    // exit: a beneficiary who wanted to hand the money back could not.
+    const db = supabaseWith(DISPUTED);
+    const r = await refundEscrow(db, 'esc-1', 'esc_ben');
+
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/lib/escrow/service.ts
+++ b/src/lib/escrow/service.ts
@@ -670,6 +670,114 @@ export async function setEscrowAutoRelease(
 }
 
 /**
+ * Resolve a disputed escrow as arbiter.
+ *
+ * ESC-NEW-01: `dispute_resolution` and `dispute_status` exist in the production
+ * schema and, until this function, **had no writer anywhere in the codebase**.
+ * `disputeEscrow` set `status = 'disputed'` and `dispute_reason` and stopped
+ * there, so a dispute recorded a grievance and changed nothing else.
+ *
+ * The consequence was worse than a missing audit field. A disputed escrow could
+ * only be *released* — and only by the depositor, the party who had just been
+ * disputed against or had just disputed. Refund required `funded`, so raising a
+ * dispute removed the refund path entirely. Whoever raised it had made their
+ * own position strictly worse, and the beneficiary had no path at all. In
+ * practice a disputed escrow sat until someone gave up.
+ *
+ * This is the missing third exit. It is deliberately not self-service: the two
+ * parties disagree by definition, so neither can be the one who decides. The
+ * route that calls this is admin-gated, which makes the platform the arbiter of
+ * record — the same role `arbiter_address` describes for the multisig model,
+ * played by the only party with standing here.
+ *
+ * The money movement reuses the existing paths rather than inventing a third:
+ * `release` settles to the beneficiary, `refund` returns to the depositor, and
+ * both are picked up by the settlement monitor exactly as a cooperative
+ * outcome would be.
+ */
+export async function resolveDispute(
+  supabase: SupabaseClient,
+  escrowId: string,
+  input: {
+    /** Which way the dispute was decided. */
+    resolution: 'release' | 'refund';
+    /** Why — recorded on the escrow and in the event log. */
+    note: string;
+    /** Identifies the human who decided, for the audit trail. */
+    resolvedBy: string;
+  }
+): Promise<EscrowActionResult> {
+  const note = (input.note || '').trim();
+  if (note.length < 10) {
+    return {
+      success: false,
+      error: 'A resolution note of at least 10 characters is required — it is the record of why this was decided.',
+    };
+  }
+
+  if (input.resolution !== 'release' && input.resolution !== 'refund') {
+    return { success: false, error: "resolution must be 'release' or 'refund'" };
+  }
+
+  const { data, error } = await supabase
+    .from('escrows')
+    .select('*')
+    .eq('id', escrowId)
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: 'Escrow not found' };
+  }
+
+  const escrow = data as Escrow;
+
+  if (escrow.status !== 'disputed') {
+    return {
+      success: false,
+      error: `Only a disputed escrow can be arbitrated; this one is ${escrow.status}.`,
+    };
+  }
+
+  const nextStatus = input.resolution === 'release' ? 'released' : 'refunded';
+  const timestampField = input.resolution === 'release' ? 'released_at' : 'refunded_at';
+
+  // Conditioned on the escrow still being disputed, so two arbiters acting at
+  // once cannot both apply an outcome to the same escrow.
+  const { data: updated } = await supabase
+    .from('escrows')
+    .update({
+      status: nextStatus,
+      [timestampField]: new Date().toISOString(),
+      dispute_status: 'resolved',
+      dispute_resolution: note,
+    })
+    .eq('id', escrowId)
+    .eq('status', 'disputed')
+    .select()
+    .single();
+
+  if (!updated) {
+    return { success: false, error: 'Escrow was resolved by someone else while this request was in flight.' };
+  }
+
+  await logEvent(supabase, escrowId, nextStatus === 'released' ? 'released' : 'refunded', input.resolvedBy, {
+    arbitrated: true,
+    resolution: input.resolution,
+    note,
+  });
+
+  await sendEscrowWebhook(
+    supabase,
+    escrow.business_id,
+    escrowId,
+    nextStatus === 'released' ? 'escrow.released' : 'escrow.refunded',
+    updated as Escrow
+  );
+
+  return { success: true, escrow: stripTokens(updated as Escrow) };
+}
+
+/**
  * Request refund (depositor only, before release).
  * Only allowed in 'funded' status.
  */
@@ -731,8 +839,14 @@ export async function refundEscrow(
     }
   }
 
-  // Only funded escrows can be refunded (not yet released)
-  if (escrow.status !== 'funded') {
+  // ESC-NEW-01: `disputed` is refundable, not a dead end.
+  //
+  // This required `funded`, while `releaseEscrow` accepts `funded` or
+  // `disputed`. So raising a dispute removed the refund path entirely: the only
+  // remaining exit was the depositor releasing the money to the beneficiary,
+  // which is the opposite of what someone raising a dispute wants. A
+  // beneficiary who concedes could not hand the funds back.
+  if (escrow.status !== 'funded' && escrow.status !== 'disputed') {
     return { success: false, error: `Cannot refund escrow in status: ${escrow.status}` };
   }
 
@@ -743,7 +857,7 @@ export async function refundEscrow(
       refunded_at: new Date().toISOString(),
     })
     .eq('id', escrowId)
-    .eq('status', 'funded')
+    .eq('status', escrow.status) // optimistic lock on what was read
     .select()
     .single();
 

--- a/src/lib/webhooks/retry-queue.test.ts
+++ b/src/lib/webhooks/retry-queue.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  backoffMinutesForAttempt,
+  enqueueFailedDelivery,
+  processWebhookRetryQueue,
+} from './retry-queue';
+
+/**
+ * Regression tests for REC-D-07 (2026-08-19 audit).
+ *
+ * `deliverWebhook` retried three times in-process with exponential backoff,
+ * spending the whole budget inside one request over roughly three seconds. A
+ * merchant endpoint down for four — a deploy, a restart, a brief network fault
+ * — lost the event permanently, as did anything in flight when our own process
+ * was recycled. Merchants reconcile against these, so a lost
+ * `payment.confirmed` is a payment the merchant never hears about.
+ */
+
+function queueDb(rows: any[]) {
+  const updates: any[] = [];
+  const inserts: any[] = [];
+
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    lte: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    insert: vi.fn(async (row: any) => {
+      inserts.push(row);
+      return { error: null };
+    }),
+    update: vi.fn((patch: any) => {
+      updates.push(patch);
+      return chain;
+    }),
+    limit: vi.fn(async () => ({ data: rows, error: null })),
+    then: (resolve: any) => resolve({ data: [{ id: 'claimed' }], error: null }),
+  };
+
+  return { supabase: { from: vi.fn(() => chain) } as any, updates, inserts, chain };
+}
+
+const ROW = {
+  id: 'wd-1',
+  business_id: 'biz-1',
+  event: 'payment.confirmed',
+  webhook_url: 'https://merchant.example/hook',
+  payload: { hello: 'world' },
+  attempts: 0,
+  max_attempts: 8,
+};
+
+describe('backoffMinutesForAttempt', () => {
+  it('grows, then holds at the ceiling', () => {
+    expect(backoffMinutesForAttempt(0)).toBe(1);
+    expect(backoffMinutesForAttempt(1)).toBe(5);
+    expect(backoffMinutesForAttempt(3)).toBe(60);
+    // Past the table it must not fall off the end into undefined/NaN, which
+    // would write an invalid next_attempt_at and strand the row.
+    expect(backoffMinutesForAttempt(99)).toBe(720);
+  });
+
+  it('is measured in minutes, not seconds', () => {
+    // The whole point: the in-process budget was ~3 seconds. If this were
+    // seconds again the queue would add nothing.
+    expect(backoffMinutesForAttempt(0)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('enqueueFailedDelivery', () => {
+  it('records a failed delivery as pending work', async () => {
+    const { supabase, inserts } = queueDb([]);
+    const r = await enqueueFailedDelivery(supabase, {
+      businessId: 'biz-1',
+      event: 'payment.confirmed',
+      webhookUrl: 'https://merchant.example/hook',
+      payload: { a: 1 },
+      lastError: 'HTTP 502',
+    });
+
+    expect(r.queued).toBe(true);
+    expect(inserts[0]).toMatchObject({
+      business_id: 'biz-1',
+      event: 'payment.confirmed',
+      status: 'pending',
+      last_error: 'HTTP 502',
+    });
+  });
+
+  it('never throws into the caller', async () => {
+    // This runs inside a payment path. Turning a missed notification into an
+    // exception there would convert it into a failed payment.
+    const supabase = {
+      from: () => ({
+        insert: () => {
+          throw new Error('database on fire');
+        },
+      }),
+    } as any;
+
+    await expect(
+      enqueueFailedDelivery(supabase, {
+        businessId: 'biz-1',
+        event: 'payment.confirmed',
+        webhookUrl: 'https://merchant.example/hook',
+        payload: {},
+      })
+    ).resolves.toMatchObject({ queued: false });
+  });
+});
+
+describe('processWebhookRetryQueue', () => {
+  it('marks a successful redelivery delivered', async () => {
+    const { supabase, updates } = queueDb([{ ...ROW }]);
+    const deliver = vi.fn().mockResolvedValue({ success: true, statusCode: 200 });
+
+    const stats = await processWebhookRetryQueue(supabase, deliver);
+
+    expect(stats.delivered).toBe(1);
+    expect(updates.some((u) => u.status === 'delivered')).toBe(true);
+  });
+
+  it('reschedules a failure that still has attempts left', async () => {
+    const { supabase, updates } = queueDb([{ ...ROW, attempts: 1 }]);
+    const deliver = vi.fn().mockResolvedValue({ success: false, error: 'HTTP 503' });
+
+    const stats = await processWebhookRetryQueue(supabase, deliver);
+
+    expect(stats.rescheduled).toBe(1);
+    expect(stats.dead).toBe(0);
+    expect(updates.some((u) => u.status === 'pending' && u.last_error === 'HTTP 503')).toBe(true);
+  });
+
+  it('dead-letters once the attempt budget is exhausted', async () => {
+    // The dead-letter is the point: an abandoned event becomes a durable row an
+    // operator can find, rather than something that silently evaporated.
+    const { supabase, updates } = queueDb([{ ...ROW, attempts: 7, max_attempts: 8 }]);
+    const deliver = vi.fn().mockResolvedValue({ success: false, error: 'connection refused' });
+
+    const stats = await processWebhookRetryQueue(supabase, deliver);
+
+    expect(stats.dead).toBe(1);
+    expect(updates.some((u) => u.status === 'dead')).toBe(true);
+  });
+
+  it('survives a delivery function that throws', async () => {
+    const { supabase } = queueDb([{ ...ROW }]);
+    const deliver = vi.fn().mockRejectedValue(new Error('socket hang up'));
+
+    const stats = await processWebhookRetryQueue(supabase, deliver);
+
+    expect(stats.attempted).toBe(1);
+    expect(stats.rescheduled).toBe(1);
+  });
+
+  it('claims a row before delivering it', async () => {
+    // Two overlapping cron runs would otherwise both deliver the same row, and
+    // a duplicate payment.confirmed is a real problem for a merchant
+    // reconciling against it.
+    const { supabase, updates } = queueDb([{ ...ROW }]);
+    const order: string[] = [];
+    const deliver = vi.fn(async () => {
+      order.push('deliver');
+      return { success: true };
+    });
+
+    await processWebhookRetryQueue(supabase, deliver);
+
+    // The claim is the first update, and it happens before any delivery.
+    expect(updates[0]).toHaveProperty('attempts', 1);
+    expect(order[0]).toBe('deliver');
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    const { supabase } = queueDb([]);
+    const deliver = vi.fn();
+
+    const stats = await processWebhookRetryQueue(supabase, deliver);
+
+    expect(stats.attempted).toBe(0);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/webhooks/retry-queue.ts
+++ b/src/lib/webhooks/retry-queue.ts
@@ -1,0 +1,198 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Durable webhook retry, with a dead-letter state.
+ *
+ * REC-D-07: `deliverWebhook` retries three times in-process with exponential
+ * backoff, which spends the entire retry budget inside one request over roughly
+ * three seconds. A merchant endpoint down for four seconds — a deploy, a
+ * restart, a brief network fault — loses the event permanently, as does any
+ * delivery in flight when our own process is recycled. Merchants reconcile
+ * against these, so a lost `payment.confirmed` is a payment the merchant never
+ * hears about.
+ *
+ * This is the part that survives the process: an exhausted in-process attempt
+ * is written to `webhook_deliveries` and retried later by the cron, on a
+ * backoff measured in minutes rather than seconds. After `max_attempts` the row
+ * becomes `dead` — the dead-letter — which is a durable record an operator can
+ * find, rather than an event that silently evaporated.
+ */
+
+/** 1m, 5m, 15m, 1h, 3h, 6h, 12h — then dead. Roughly a day of grace. */
+const BACKOFF_MINUTES = [1, 5, 15, 60, 180, 360, 720];
+
+export function backoffMinutesForAttempt(attempt: number): number {
+  return BACKOFF_MINUTES[Math.min(attempt, BACKOFF_MINUTES.length - 1)];
+}
+
+export interface EnqueueInput {
+  businessId: string;
+  event: string;
+  webhookUrl: string;
+  payload: unknown;
+  paymentId?: string | null;
+  escrowId?: string | null;
+  lastError?: string;
+  lastStatusCode?: number;
+}
+
+/**
+ * Record a delivery that the in-process attempts could not complete.
+ *
+ * Deliberately best-effort: it must never throw into the caller. The webhook
+ * has already failed at this point, and turning that into an exception inside a
+ * payment path would convert a missed notification into a failed payment.
+ */
+export async function enqueueFailedDelivery(
+  supabase: SupabaseClient,
+  input: EnqueueInput
+): Promise<{ queued: boolean; error?: string }> {
+  const nextAttemptAt = new Date(Date.now() + backoffMinutesForAttempt(0) * 60_000).toISOString();
+
+  try {
+    const { error } = await supabase.from('webhook_deliveries').insert({
+      business_id: input.businessId,
+      payment_id: input.paymentId ?? null,
+      escrow_id: input.escrowId ?? null,
+      event: input.event,
+      webhook_url: input.webhookUrl,
+      payload: input.payload ?? {},
+      status: 'pending',
+      // The in-process attempts already happened; the queue counts its own.
+      attempts: 0,
+      next_attempt_at: nextAttemptAt,
+      last_error: input.lastError ?? null,
+      last_status_code: input.lastStatusCode ?? null,
+    });
+
+    if (error) {
+      console.error('[Webhook] Could not queue failed delivery for retry:', error.message);
+      return { queued: false, error: error.message };
+    }
+
+    console.warn(
+      `[Webhook] Queued ${input.event} for ${input.businessId} after in-process delivery failed; ` +
+        `first retry in ${backoffMinutesForAttempt(0)}m`
+    );
+    return { queued: true };
+  } catch (err) {
+    console.error('[Webhook] Could not queue failed delivery for retry:', err);
+    return { queued: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface RetryQueueStats {
+  attempted: number;
+  delivered: number;
+  rescheduled: number;
+  dead: number;
+  errors: number;
+}
+
+/**
+ * Work the queue: retry everything whose backoff has elapsed.
+ *
+ * @param deliver - performs one delivery. Injected so this module owns the
+ *   scheduling and the caller owns the signing and transport, and so the
+ *   scheduling is testable without a network.
+ */
+export async function processWebhookRetryQueue(
+  supabase: SupabaseClient,
+  deliver: (row: {
+    business_id: string;
+    event: string;
+    webhook_url: string;
+    payload: unknown;
+  }) => Promise<{ success: boolean; statusCode?: number; error?: string }>,
+  opts: { limit?: number } = {}
+): Promise<RetryQueueStats> {
+  const stats: RetryQueueStats = { attempted: 0, delivered: 0, rescheduled: 0, dead: 0, errors: 0 };
+  const limit = opts.limit ?? 100;
+
+  const { data: due, error } = await supabase
+    .from('webhook_deliveries')
+    .select('id, business_id, event, webhook_url, payload, attempts, max_attempts')
+    .eq('status', 'pending')
+    .lte('next_attempt_at', new Date().toISOString())
+    .order('next_attempt_at', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    console.error('[Webhook] Could not read the retry queue:', error.message);
+    stats.errors++;
+    return stats;
+  }
+
+  if (!due?.length) return stats;
+
+  for (const row of due) {
+    stats.attempted++;
+
+    // Claim before delivering, conditioned on the attempt count we read. Two
+    // overlapping cron runs would otherwise both deliver the same row, and a
+    // duplicate `payment.confirmed` is a real problem for a merchant
+    // reconciling against it.
+    const attempts = (row.attempts ?? 0) + 1;
+    const { data: claimed } = await supabase
+      .from('webhook_deliveries')
+      .update({
+        attempts,
+        next_attempt_at: new Date(Date.now() + backoffMinutesForAttempt(attempts) * 60_000).toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', row.id)
+      .eq('attempts', row.attempts ?? 0)
+      .eq('status', 'pending')
+      .select('id');
+
+    if (!claimed || claimed.length === 0) continue;
+
+    let result: { success: boolean; statusCode?: number; error?: string };
+    try {
+      result = await deliver(row);
+    } catch (err) {
+      result = { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    if (result.success) {
+      await supabase
+        .from('webhook_deliveries')
+        .update({
+          status: 'delivered',
+          delivered_at: new Date().toISOString(),
+          last_status_code: result.statusCode ?? null,
+          last_error: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', row.id);
+      stats.delivered++;
+      continue;
+    }
+
+    const exhausted = attempts >= (row.max_attempts ?? 8);
+
+    await supabase
+      .from('webhook_deliveries')
+      .update({
+        status: exhausted ? 'dead' : 'pending',
+        last_error: result.error ?? 'delivery failed',
+        last_status_code: result.statusCode ?? null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', row.id);
+
+    if (exhausted) {
+      stats.dead++;
+      // Loud on purpose: this is the point at which the platform gives up on
+      // telling a merchant something happened to their money.
+      console.error(
+        `[Webhook] DEAD-LETTER: ${row.event} for business ${row.business_id} abandoned after ` +
+          `${attempts} attempts — last error: ${result.error}`
+      );
+    } else {
+      stats.rescheduled++;
+    }
+  }
+
+  return stats;
+}

--- a/src/lib/webhooks/service.ts
+++ b/src/lib/webhooks/service.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { resolveWebhookSecret } from './secret';
 import { safeFetch, isBlockedAddress } from '@/lib/security/ssrf';
 import { isIP } from 'net';
+import { enqueueFailedDelivery } from './retry-queue';
 
 /**
  * Synchronous SSRF pre-check on a webhook URL.
@@ -618,6 +619,25 @@ export async function sendPaymentWebhook(
       console.log(`[Webhook] Successfully delivered ${event} webhook for payment ${paymentId}`);
     } else {
       console.error(`[Webhook] Failed to deliver ${event} webhook for payment ${paymentId}: ${result.error}`);
+
+      // REC-D-07: the three in-process attempts spent their whole budget inside
+      // this request, over roughly three seconds. An endpoint down for four —
+      // a deploy, a restart, a brief network fault — lost the event for good,
+      // and so did anything in flight when our own process was recycled.
+      // Merchants reconcile against these, so a lost `payment.confirmed` is a
+      // payment the merchant never hears about.
+      //
+      // Hand it to the durable queue, which retries on a backoff measured in
+      // minutes and dead-letters after a day rather than after three seconds.
+      await enqueueFailedDelivery(supabase, {
+        businessId,
+        event,
+        webhookUrl: business.webhook_url,
+        payload,
+        paymentId,
+        lastError: result.error,
+        lastStatusCode: result.statusCode,
+      });
     }
 
     return {
@@ -631,6 +651,62 @@ export async function sendPaymentWebhook(
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }
+}
+
+/**
+ * Re-deliver a webhook that the durable queue is retrying.
+ *
+ * REC-D-07: the queue stores the payload but deliberately not the signature.
+ * A signature is bound to a timestamp, so replaying a stored one would either
+ * be rejected by a merchant enforcing a freshness window or, if they are not,
+ * would hand them a credential to accept indefinitely. The payload is re-signed
+ * with a current timestamp on every attempt instead.
+ *
+ * The secret is re-read rather than cached with the row: a merchant who rotates
+ * their webhook secret while a delivery is queued should have the retry signed
+ * with the new one, and a merchant who has removed their webhook entirely
+ * should stop receiving attempts.
+ */
+export async function redeliverQueuedWebhook(
+  supabase: SupabaseClient,
+  row: { business_id: string; event: string; webhook_url: string; payload: unknown }
+): Promise<{ success: boolean; statusCode?: number; error?: string }> {
+  const { data: business, error } = await supabase
+    .from('businesses')
+    .select('webhook_url, webhook_secret, merchant_id')
+    .eq('id', row.business_id)
+    .single();
+
+  if (error || !business) {
+    return { success: false, error: 'Business not found' };
+  }
+
+  // Configuration removed since the delivery was queued. Report success so the
+  // row is closed rather than retried to death against an endpoint the merchant
+  // has deliberately taken away.
+  if (!business.webhook_url || !business.webhook_secret) {
+    return { success: true };
+  }
+
+  const plaintextSecret = resolveWebhookSecret(business.webhook_secret, business.merchant_id);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const payloadString = JSON.stringify(row.payload);
+  const signature = signWebhookPayload(row.payload as Record<string, unknown>, plaintextSecret, timestamp);
+
+  const result = await deliverWebhookDirect(business.webhook_url, payloadString, signature, 1);
+
+  await logWebhookAttempt(supabase, {
+    business_id: row.business_id,
+    event: row.event as WebhookEvent,
+    webhook_url: business.webhook_url,
+    payload: row.payload as Record<string, unknown>,
+    success: result.success,
+    status_code: result.statusCode,
+    error_message: result.error,
+    attempt_number: result.attempts || 1,
+  });
+
+  return { success: result.success, statusCode: result.statusCode, error: result.error };
 }
 
 /**

--- a/supabase/migrations/20260819210000_webhook_delivery_queue.sql
+++ b/supabase/migrations/20260819210000_webhook_delivery_queue.sql
@@ -1,0 +1,67 @@
+-- REC-D-07: durable webhook retry with a dead-letter state.
+--
+-- `deliverWebhook` retries three times in-process with exponential backoff, so
+-- the whole retry budget is spent inside a single request over roughly three
+-- seconds. A merchant endpoint that is down for four seconds — a deploy, a
+-- restart, a brief network fault — loses the event permanently, and so does any
+-- delivery in flight when our own process is recycled. Nothing records that it
+-- happened beyond one `webhook_logs` row saying the last attempt failed.
+--
+-- `webhook_logs` is the audit trail (what was attempted, and how it went). This
+-- table is the work queue (what still needs attempting). They are deliberately
+-- separate: one is append-only history, the other is mutable state with a
+-- claim on it.
+--
+-- Terminal states are `delivered` and `dead`. `dead` is the dead-letter: the
+-- attempt budget is exhausted and no further automatic delivery will happen, so
+-- the row is a durable record an operator can find and act on rather than an
+-- event that silently evaporated.
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    business_id     UUID NOT NULL REFERENCES businesses(id) ON DELETE CASCADE,
+    payment_id      UUID,
+    escrow_id       UUID,
+    event           TEXT NOT NULL,
+    webhook_url     TEXT NOT NULL,
+    payload         JSONB NOT NULL,
+
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'delivered', 'dead')),
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    max_attempts    INTEGER NOT NULL DEFAULT 8,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error      TEXT,
+    last_status_code INTEGER,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at    TIMESTAMPTZ
+);
+
+-- The sweep's only query: pending rows whose backoff has elapsed, oldest first.
+-- Partial, because delivered and dead rows are the overwhelming majority over
+-- time and never need scanning.
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+    ON webhook_deliveries (next_attempt_at)
+    WHERE status = 'pending';
+
+-- For the operator question "what has been abandoned for this business?"
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_dead
+    ON webhook_deliveries (business_id, updated_at DESC)
+    WHERE status = 'dead';
+
+ALTER TABLE webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Written only by the delivery path and the cron, both of which use the service
+-- role. RLS on with a service-role-only policy means anon and authenticated are
+-- denied outright — a queue carrying merchant payloads is not browser-facing.
+-- Stated explicitly rather than left to the absence of a grant, which is the
+-- trap `reputation_receipts` was sitting in.
+DROP POLICY IF EXISTS "Service role manages webhook deliveries" ON webhook_deliveries;
+CREATE POLICY "Service role manages webhook deliveries"
+    ON webhook_deliveries
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
The three product gaps left open after #279, plus a production issuer cleanup.

## `ESC-NEW-01` — disputed escrows had no exit

`dispute_resolution` and `dispute_status` existed in the production schema **with no writer anywhere**. `disputeEscrow` set `status='disputed'` and a reason, and stopped.

The sharper half was the exits. A disputed escrow could only be *released*, and only by the depositor — the party who had just been disputed against, or who had just disputed. Refund required `funded`, so **raising a dispute removed the refund path**. Whoever raised one made their own position strictly worse, the beneficiary had no path at all, and the escrow sat until somebody gave up.

- `disputed` is now refundable, so a beneficiary can concede
- `resolveDispute()` + admin-gated `POST /api/admin/escrows/[id]/resolve` is the arbiter exit

Admin-gated deliberately: the two parties disagree by definition, so neither can be the one who decides. A resolution note of ≥10 chars is required — it is the record of why someone else's money moved.

## `REC-D-07` — three seconds of retry, then the event is gone

`deliverWebhook` retried 3× in-process with backoff, spending the entire budget inside one request over ~3 seconds. An endpoint down for **four** — a deploy, a restart, a brief network fault — lost the event permanently, as did anything in flight when our own process was recycled. Merchants reconcile against these, so a lost `payment.confirmed` is a payment the merchant never hears about.

New `webhook_deliveries` queue (migration `20260819210000`, applied and verified):

- 1m → 12h backoff, ~a day of grace
- **dead-letter** after 8 attempts, so an abandoned event is a row an operator can find rather than something that evaporated
- rows are **claimed before delivery**, conditioned on the attempt count read — two overlapping cron runs cannot both send the same webhook, and a duplicate `payment.confirmed` is a real problem for a merchant

Payloads are **re-signed per attempt** rather than replaying a stored signature: a signature is bound to its timestamp, so a stored one is either rejected by a merchant enforcing freshness or — worse, if they are not — accepted indefinitely. The secret is re-read too, so a rotation mid-queue is honoured and a removed webhook stops being retried.

## `W-01` — a merge reached every host in five minutes

Unpinned, the installer follows `master` and the timer polls every 300s, so anything merged executed on every operator host within five minutes with **no human between the merge and the execution**.

Unattended auto-upgrade from a mutable ref is now opt-in (`COINPAY_AUTO_UPGRADE_UNPINNED=1`). Pinned installs keep it, since a tag can only ever re-install the same code it already has. Verified the gate's truth table across all five pinned/opt-in/disabled combinations.

## Production issuer cleanup (done, reversible)

Deactivated 5 of 18 reputation issuers. An issuer key provisions merchant accounts and issues invoices on other people's behalf:

- `evilpoc`, `poc2`, `OutHunt` — all on `.example`, which is RFC 2606 reserved and cannot resolve
- `X` / domain `X` — not a domain
- **`Tounes` / `Coinpayportal.com`** — a third party registered an issuer claiming the platform's own domain, verified by nothing

Checked first that only `ugig.net` (14,333 receipts) and `d0rz.com` (5) have **ever** produced anything, so none of the deactivated rows could break live traffic. `active = true` restores any of them.

Still open and deliberately untouched: 6 `*.trycloudflare.com` issuers (ephemeral tunnel hostnames are a weak identity by construction) and the cleartext `api_key` column on 17 rows — rotating those needs the integrators told.

## Tests

334 files / 4690 tests, up from 327/4600. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)