### PR TITLE
Make /finances a per-merchant feature

### DIFF
--- a/src/app/api/finances/accounts/[id]/route.ts
+++ b/src/app/api/finances/accounts/[id]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { isAccountKind } from '@/lib/finances/classify';
-import { toAccountView, type FinanceAccount } from '@/lib/finances/summary';
+import { toAccountView, merchantOwnsAccount, type FinanceAccount } from '@/lib/finances/summary';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,7 +23,7 @@ const ACCOUNT_COLUMNS =
  * what an institution said, and an editable ledger is not a ledger.
  */
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   const { id } = await params;
@@ -57,6 +57,15 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
   if (Object.keys(update).length === 0) {
     return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  // Ownership runs through the account's connection, so it has to be checked
+  // explicitly — the update below filters on the account id alone, and without
+  // this a merchant could rename or hide a stranger's account by guessing a
+  // uuid. Reported as not-found rather than forbidden: whether that id exists
+  // is not this caller's business.
+  if (!(await merchantOwnsAccount(id, guard.id))) {
+    return NextResponse.json({ error: 'Account not found' }, { status: 404 });
   }
 
   const supabase = getSupabaseAdmin();

--- a/src/app/api/finances/accounts/route.ts
+++ b/src/app/api/finances/accounts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { listAccounts } from '@/lib/finances/summary';
 
 export const dynamic = 'force-dynamic';
@@ -10,11 +10,11 @@ export const dynamic = 'force-dynamic';
  * `?hidden=1` includes accounts an operator has hidden from the totals.
  */
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   try {
-    const accounts = await listAccounts({
+    const accounts = await listAccounts(guard.id, {
       includeHidden: req.nextUrl.searchParams.get('hidden') === '1',
     });
     return NextResponse.json({ accounts }, { headers: { 'Cache-Control': 'no-store' } });

--- a/src/app/api/finances/connections/[id]/route.ts
+++ b/src/app/api/finances/connections/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { deleteConnection } from '@/lib/finances/sync';
 
 export const dynamic = 'force-dynamic';
@@ -12,13 +12,13 @@ export const dynamic = 'force-dynamic';
  * re-claimed, so re-linking means generating a fresh token at the bridge.
  */
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   const { id } = await params;
 
   try {
-    await deleteConnection(id);
+    await deleteConnection(id, guard.id);
     return NextResponse.json({ success: true });
   } catch (err) {
     console.error('[finances/connections] delete failed', err);

--- a/src/app/api/finances/connections/route.ts
+++ b/src/app/api/finances/connections/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
-import { listConnections, createConnection, bootstrapConnectionFromEnv } from '@/lib/finances/sync';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
+import { listConnections, createConnection } from '@/lib/finances/sync';
 import { claimSetupToken, redactAccessUrl } from '@/lib/finances/simplefin';
 
 export const dynamic = 'force-dynamic';
@@ -10,13 +10,12 @@ export const dynamic = 'force-dynamic';
  * sync outcome. Never returns the access URL; there is no route that does.
  */
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   try {
-    await bootstrapConnectionFromEnv();
     return NextResponse.json(
-      { connections: await listConnections() },
+      { connections: await listConnections(guard.id) },
       { headers: { 'Cache-Control': 'no-store' } },
     );
   } catch (err) {
@@ -37,7 +36,7 @@ export async function GET(req: NextRequest) {
  * an operator retrying a token that can never work again.
  */
 export async function POST(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   let body: { setupToken?: unknown; label?: unknown };
@@ -64,9 +63,9 @@ export async function POST(req: NextRequest) {
 
   try {
     const connection = await createConnection({
+      merchantId: guard.id,
       accessUrl,
       label: typeof body.label === 'string' ? body.label : null,
-      createdBy: guard.id,
     });
     return NextResponse.json({ connection }, { status: 201 });
   } catch (err) {

--- a/src/app/api/finances/summary/route.ts
+++ b/src/app/api/finances/summary/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { getSummary } from '@/lib/finances/summary';
 
 export const dynamic = 'force-dynamic';
@@ -7,15 +7,15 @@ export const dynamic = 'force-dynamic';
 /**
  * GET /api/finances/summary — balance sheet and cashflow headline.
  *
- * House financial data, so the admin check is the entire security boundary:
- * the tables are RLS-enabled with no policies and are reachable only through
- * the service client behind this guard.
+ * Somebody's bank balances, so the guard plus the `merchantId` scope is the
+ * entire security boundary: the tables are RLS-enabled with no policies and
+ * are reachable only through the service client behind this route.
  *
  * `?days=` sets the cashflow and category window. Balances ignore it — a
  * balance is a current fact and has no window.
  */
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   const params = req.nextUrl.searchParams;
@@ -24,7 +24,7 @@ export async function GET(req: NextRequest) {
   const includeHidden = params.get('hidden') === '1';
 
   try {
-    const summary = await getSummary({ windowDays, includeHidden });
+    const summary = await getSummary(guard.id, { windowDays, includeHidden });
     return NextResponse.json(
       { summary },
       { headers: { 'Cache-Control': 'no-store' } },

--- a/src/app/api/finances/sync/route.ts
+++ b/src/app/api/finances/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { syncAllConnections, syncConnection, DEFAULT_SYNC_DAYS } from '@/lib/finances/sync';
 
 export const dynamic = 'force-dynamic';
@@ -18,7 +18,7 @@ export const maxDuration = 300;
  * syncs every active connection.
  */
 export async function POST(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   let body: { days?: unknown; connectionId?: unknown } = {};
@@ -34,8 +34,8 @@ export async function POST(req: NextRequest) {
   try {
     const results =
       typeof body.connectionId === 'string' && body.connectionId
-        ? [await syncConnection(body.connectionId, { days })]
-        : await syncAllConnections({ days });
+        ? [await syncConnection(body.connectionId, guard.id, { days })]
+        : await syncAllConnections(guard.id, { days });
 
     if (results.length === 0) {
       return NextResponse.json(

--- a/src/app/api/finances/transactions/route.ts
+++ b/src/app/api/finances/transactions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/auth/admin-guard';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
 import { listTransactions } from '@/lib/finances/summary';
 
 export const dynamic = 'force-dynamic';
@@ -18,7 +18,7 @@ function parseDate(value: string | null): Date | null {
  * bucket), `start`, `end`, `pending=0`, plus `limit`/`offset`.
  */
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(req);
+  const guard = await requireMerchant(req);
   if (guard instanceof NextResponse) return guard;
 
   const params = req.nextUrl.searchParams;
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
   const parsedOffset = Number.parseInt(params.get('offset') ?? '', 10);
 
   try {
-    const page = await listTransactions({
+    const page = await listTransactions(guard.id, {
       accountId: params.get('account'),
       search: params.get('search'),
       category: params.get('category'),

--- a/src/app/finances/FinancesContent.tsx
+++ b/src/app/finances/FinancesContent.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { requireAuth } from '@/lib/auth/client';
 import { formatMoney, formatCompact, formatDate, formatRelative, percentOf } from '@/lib/finances/format';
 import { ACCOUNT_KINDS, categoryLabel, type AccountKind } from '@/lib/finances/classify';
 
@@ -109,6 +111,7 @@ function authHeaders(extra?: HeadersInit): HeadersInit {
 }
 
 export default function FinancesContent() {
+  const router = useRouter();
   const [summary, setSummary] = useState<Summary | null>(null);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [connections, setConnections] = useState<Connection[]>([]);
@@ -136,6 +139,9 @@ export default function FinancesContent() {
   const [showLink, setShowLink] = useState(false);
 
   const loadOverview = useCallback(async () => {
+    // Bounces to /login when there is no session, the same way /dashboard does.
+    if (!requireAuth(router)) return;
+
     setError(null);
     try {
       const query = `days=${windowDays}${showHidden ? '&hidden=1' : ''}`;
@@ -146,7 +152,7 @@ export default function FinancesContent() {
       ]);
 
       if (summaryRes.status === 401 || summaryRes.status === 403) {
-        setError('This page is restricted to administrators.');
+        setError('Your session has expired. Please log in again.');
         return;
       }
       if (!summaryRes.ok || !accountsRes.ok) {
@@ -162,7 +168,7 @@ export default function FinancesContent() {
     } finally {
       setLoading(false);
     }
-  }, [windowDays, showHidden]);
+  }, [windowDays, showHidden, router]);
 
   const loadTransactions = useCallback(async () => {
     setTxLoading(true);
@@ -412,13 +418,80 @@ export default function FinancesContent() {
         </section>
       )}
 
-      {!hasData && (
+      {!hasData && connections.length > 0 && (
         <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-8 text-center">
-          <p className="text-gray-300 mb-2">No accounts imported yet.</p>
+          <p className="text-gray-300 mb-2">Connected, but nothing imported yet.</p>
           <p className="text-sm text-gray-500">
-            Press <span className="text-gray-300">Sync now</span> to pull balances and the last 90 days
-            of transactions from the linked institutions.
+            Press <span className="text-gray-300">Sync now</span> to pull balances and recent
+            transactions from your linked institutions.
           </p>
+        </section>
+      )}
+
+      {!hasData && connections.length === 0 && (
+        <section className="rounded-lg border border-slate-700 bg-slate-900/50 p-8">
+          <h2 className="text-lg font-semibold text-white mb-2">Connect your accounts</h2>
+          <p className="text-sm text-gray-400 mb-6">
+            CoinPay reads your balances and transactions through SimpleFIN, an independent
+            service that holds the bank connections. Access is read-only — nothing here can
+            move money.
+          </p>
+
+          <ol className="space-y-4 text-sm text-gray-300 mb-6">
+            <li className="flex gap-3">
+              <span className="text-purple-400 font-semibold">1.</span>
+              <span>
+                Create an account at{' '}
+                <a
+                  href="https://beta-bridge.simplefin.org/"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-purple-400 hover:underline"
+                >
+                  SimpleFIN Bridge
+                </a>{' '}
+                and link your banks and cards there.{' '}
+                <span className="text-gray-500">
+                  The Bridge is a paid service — $1.50/month or $15/year, billed by them, not by
+                  CoinPay.
+                </span>
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-purple-400 font-semibold">2.</span>
+              <span>
+                On the Bridge, choose <span className="text-gray-200">Connect to an app</span> to
+                generate a <span className="text-gray-200">Setup Token</span> — a long block of
+                base64 text.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-purple-400 font-semibold">3.</span>
+              <span>
+                Paste it below. We exchange it once for a read-only credential and store that
+                encrypted.{' '}
+                <span className="text-gray-500">
+                  Setup tokens are single-use, so generate a fresh one if you need to reconnect.
+                </span>
+              </span>
+            </li>
+          </ol>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              value={setupToken}
+              onChange={(e) => setSetupToken(e.target.value)}
+              placeholder="Paste your SimpleFIN setup token"
+              className="flex-1 rounded border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-gray-600"
+            />
+            <button
+              onClick={handleLink}
+              disabled={linking || !setupToken.trim()}
+              className="rounded bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+            >
+              {linking ? 'Connecting…' : 'Connect'}
+            </button>
+          </div>
         </section>
       )}
 

--- a/src/app/finances/page.tsx
+++ b/src/app/finances/page.tsx
@@ -1,4 +1,3 @@
-import { requireAdminPage } from '@/lib/auth/admin-guard';
 import FinancesContent from './FinancesContent';
 
 export const dynamic = 'force-dynamic';
@@ -9,13 +8,14 @@ export const metadata = {
 };
 
 /**
- * /finances — the house balance sheet.
+ * /finances — a merchant's own bank accounts and credit cards.
  *
- * Gated server-side rather than in the client component, so the page never
- * renders for a non-admin even for the moment before a fetch resolves. The API
- * routes behind it repeat the check; this one is about what reaches the browser.
+ * Any signed-in merchant may reach this; what they see is scoped to the
+ * SimpleFIN connections they own. The client component calls `requireAuth` on
+ * mount the way /dashboard does, and every API route behind it re-checks the
+ * session and scopes by merchant id — the page guard is convenience, the route
+ * guards are the boundary.
  */
-export default async function FinancesPage() {
-  await requireAdminPage('/finances');
+export default function FinancesPage() {
   return <FinancesContent />;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -186,23 +186,21 @@ export default function Header() {
                         >
                           Settings
                         </Link>
+                        <Link
+                          href="/finances"
+                          className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                          onClick={() => setUserMenuOpen(false)}
+                        >
+                          Finances
+                        </Link>
                         {isAdmin && (
-                          <>
-                            <Link
-                              href="/finances"
-                              className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
-                              onClick={() => setUserMenuOpen(false)}
-                            >
-                              Finances
-                            </Link>
-                            <Link
-                              href="/admin"
-                              className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
-                              onClick={() => setUserMenuOpen(false)}
-                            >
-                              Admin
-                            </Link>
-                          </>
+                          <Link
+                            href="/admin"
+                            className="block px-4 py-2 text-sm font-semibold text-purple-700 hover:bg-gray-100"
+                            onClick={() => setUserMenuOpen(false)}
+                          >
+                            Admin
+                          </Link>
                         )}
                         <button
                           onClick={handleLogout}
@@ -336,23 +334,21 @@ export default function Header() {
                   >
                     Settings
                   </Link>
+                  <Link
+                    href="/finances"
+                    className="block px-3 py-2 text-base font-medium text-gray-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
+                    onClick={() => setMobileMenuOpen(false)}
+                  >
+                    Finances
+                  </Link>
                   {isAdmin && (
-                    <>
-                      <Link
-                        href="/finances"
-                        className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
-                        onClick={() => setMobileMenuOpen(false)}
-                      >
-                        Finances
-                      </Link>
-                      <Link
-                        href="/admin"
-                        className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
-                        onClick={() => setMobileMenuOpen(false)}
-                      >
-                        Admin
-                      </Link>
-                    </>
+                    <Link
+                      href="/admin"
+                      className="block px-3 py-2 text-base font-semibold text-purple-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      Admin
+                    </Link>
                   )}
                   <button
                     onClick={() => {

--- a/src/lib/auth/merchant-guard.ts
+++ b/src/lib/auth/merchant-guard.ts
@@ -1,0 +1,71 @@
+import 'server-only';
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyToken } from './jwt';
+import { extractBearerToken } from './middleware';
+import { getSupabaseAdmin } from '../supabase/server';
+
+export type AuthenticatedMerchant = {
+  id: string;
+  email: string;
+};
+
+/**
+ * Verify the request comes from a signed-in merchant, and return which one.
+ *
+ * The sibling of `requireAdmin` in ./admin-guard, minus the `is_admin` check —
+ * for routes every merchant may reach, but only for their own data. It returns
+ * the merchant id precisely so callers are forced to scope by it; a route that
+ * takes this guard and then queries unscoped is visibly wrong at the call site.
+ *
+ * Accepts the JWT from either `Authorization: Bearer ...` or the `token`
+ * cookie, matching the login flow and `requireAdmin`.
+ *
+ * Deliberately does not accept API keys. `authenticateRequest` does, and those
+ * keys are issued to businesses for payment operations; none of them should
+ * carry an implicit grant over the owner's linked bank accounts.
+ */
+export async function requireMerchant(
+  req: NextRequest,
+): Promise<AuthenticatedMerchant | NextResponse> {
+  const headerToken = extractBearerToken(req.headers.get('authorization'));
+  const cookieToken = req.cookies.get('token')?.value ?? null;
+  const token = headerToken || cookieToken;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  let merchantId: string;
+  let email: string;
+  try {
+    const decoded = verifyToken(token, secret);
+    merchantId = decoded.userId;
+    email = decoded.email;
+  } catch {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  if (!merchantId) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  // Confirm the merchant still exists. A valid signature on a deleted account
+  // must not keep working until the token expires.
+  const supabase = getSupabaseAdmin();
+  const { data: merchant, error } = await supabase
+    .from('merchants')
+    .select('id, email')
+    .eq('id', merchantId)
+    .single();
+
+  if (error || !merchant) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  return { id: merchant.id, email: merchant.email ?? email };
+}

--- a/src/lib/finances/scoping.test.ts
+++ b/src/lib/finances/scoping.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+/**
+ * Tenant scoping for /finances.
+ *
+ * These tables hold people's bank balances and the app — not RLS — is what
+ * keeps one merchant out of another's. CoinPay authenticates with its own JWT
+ * rather than Supabase Auth, so `auth.uid()` is null and a policy written
+ * against it would be worse than none. That makes the scoping in `summary.ts`
+ * load-bearing, and worth testing directly.
+ */
+
+/** Records every table touched and the filters applied, then returns fixtures. */
+function makeSupabase(fixtures: Record<string, unknown[]>) {
+  const calls: Array<{ table: string; filters: Record<string, unknown> }> = [];
+
+  const from = (table: string) => {
+    const record = { table, filters: {} as Record<string, unknown> };
+    calls.push(record);
+
+    const builder: Record<string, unknown> = {};
+    const chain = () => builder;
+
+    builder.select = chain;
+    builder.order = chain;
+    builder.eq = (col: string, val: unknown) => {
+      record.filters[col] = val;
+      return builder;
+    };
+    builder.in = (col: string, vals: unknown[]) => {
+      record.filters[col] = vals;
+      return builder;
+    };
+    // Awaiting the builder resolves to the fixture for this table.
+    builder.then = (resolve: (v: unknown) => unknown) =>
+      resolve({ data: fixtures[table] ?? [], error: null, count: (fixtures[table] ?? []).length });
+
+    return builder;
+  };
+
+  return { client: { from }, calls };
+}
+
+let supabaseMock: ReturnType<typeof makeSupabase>;
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: () => supabaseMock.client,
+}));
+
+const { listAccounts, merchantOwnsAccount } = await import('./summary');
+
+const MERCHANT = 'merchant-aaa';
+const OTHER = 'merchant-bbb';
+
+describe('listAccounts scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves connections by merchant before reading any account', async () => {
+    supabaseMock = makeSupabase({
+      finance_connections: [{ id: 'conn-1' }],
+      finance_accounts: [
+        {
+          id: 'acc-1',
+          connection_id: 'conn-1',
+          name: 'Checking',
+          currency: 'USD',
+          balance: 10,
+          kind: 'checking',
+          is_hidden: false,
+        },
+      ],
+    });
+
+    const accounts = await listAccounts(MERCHANT);
+
+    expect(accounts).toHaveLength(1);
+
+    const connectionQuery = supabaseMock.calls.find((c) => c.table === 'finance_connections');
+    expect(connectionQuery?.filters.merchant_id).toBe(MERCHANT);
+
+    // Accounts are reached only through the ids that query returned.
+    const accountQuery = supabaseMock.calls.find((c) => c.table === 'finance_accounts');
+    expect(accountQuery?.filters.connection_id).toEqual(['conn-1']);
+  });
+
+  it('returns nothing — and queries nothing — for a merchant with no connections', async () => {
+    supabaseMock = makeSupabase({ finance_connections: [], finance_accounts: [] });
+
+    const accounts = await listAccounts(OTHER);
+
+    expect(accounts).toEqual([]);
+    // The bug this guards: `.in('connection_id', [])` is not "match nothing" in
+    // every query builder, and a filter that silently drops would return every
+    // account on the platform. The query must not be issued at all.
+    expect(supabaseMock.calls.some((c) => c.table === 'finance_accounts')).toBe(false);
+  });
+});
+
+describe('merchantOwnsAccount', () => {
+  it('confirms ownership through the connection', async () => {
+    supabaseMock = makeSupabase({
+      finance_connections: [{ id: 'conn-1' }],
+      finance_accounts: [{ id: 'acc-1' }],
+    });
+
+    await expect(merchantOwnsAccount('acc-1', MERCHANT)).resolves.toBe(true);
+
+    const accountQuery = supabaseMock.calls.find((c) => c.table === 'finance_accounts');
+    expect(accountQuery?.filters.id).toBe('acc-1');
+    expect(accountQuery?.filters.connection_id).toEqual(['conn-1']);
+  });
+
+  it('denies a merchant with no connections without querying accounts', async () => {
+    supabaseMock = makeSupabase({ finance_connections: [], finance_accounts: [{ id: 'acc-1' }] });
+
+    await expect(merchantOwnsAccount('acc-1', OTHER)).resolves.toBe(false);
+    expect(supabaseMock.calls.some((c) => c.table === 'finance_accounts')).toBe(false);
+  });
+});

--- a/src/lib/finances/summary.ts
+++ b/src/lib/finances/summary.ts
@@ -158,15 +158,39 @@ export function toAccountView(row: FinanceAccount): AccountView {
   };
 }
 
-export async function listAccounts({
-  includeHidden = false,
-}: { includeHidden?: boolean } = {}): Promise<AccountView[]> {
+/**
+ * The connection ids one merchant owns.
+ *
+ * Ownership lives on `finance_connections` alone, so every scoped read starts
+ * here and filters accounts by `connection_id`. An empty result must be
+ * treated as "this merchant sees nothing", never as "no filter" — passing an
+ * empty array to `.in()` would return every row on the platform.
+ */
+async function connectionIdsFor(merchantId: string): Promise<string[]> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('finance_connections')
+    .select('id')
+    .eq('merchant_id', merchantId);
+
+  if (error) throw new Error(`Could not resolve finance connections: ${error.message}`);
+  return (data ?? []).map((row) => row.id as string);
+}
+
+export async function listAccounts(
+  merchantId: string,
+  { includeHidden = false }: { includeHidden?: boolean } = {},
+): Promise<AccountView[]> {
+  const connectionIds = await connectionIdsFor(merchantId);
+  if (connectionIds.length === 0) return [];
+
   const supabase = getSupabaseAdmin();
   let query = supabase
     .from('finance_accounts')
     .select(
       'id, connection_id, external_id, org_name, org_domain, name, currency, balance, available_balance, balance_date, kind, kind_override, is_hidden, last_seen_at',
     )
+    .in('connection_id', connectionIds)
     .order('org_name', { ascending: true })
     .order('name', { ascending: true });
 
@@ -176,6 +200,27 @@ export async function listAccounts({
   if (error) throw new Error(`Could not load accounts: ${error.message}`);
 
   return (data ?? []).map((row) => toAccountView(row as unknown as FinanceAccount));
+}
+
+/**
+ * Confirm an account belongs to a merchant, for routes that mutate one by id.
+ */
+export async function merchantOwnsAccount(
+  accountId: string,
+  merchantId: string,
+): Promise<boolean> {
+  const connectionIds = await connectionIdsFor(merchantId);
+  if (connectionIds.length === 0) return false;
+
+  const supabase = getSupabaseAdmin();
+  const { count, error } = await supabase
+    .from('finance_accounts')
+    .select('id', { count: 'exact', head: true })
+    .eq('id', accountId)
+    .in('connection_id', connectionIds);
+
+  if (error) throw new Error(`Could not verify account ownership: ${error.message}`);
+  return (count ?? 0) > 0;
 }
 
 /**
@@ -274,13 +319,20 @@ export interface TransactionPage {
  * join, because PostgREST cannot filter a parent by an embedded child's column
  * without changing the row shape.
  */
-export async function listTransactions(filters: TransactionFilters = {}): Promise<TransactionPage> {
+export async function listTransactions(
+  merchantId: string,
+  filters: TransactionFilters = {},
+): Promise<TransactionPage> {
   const supabase = getSupabaseAdmin();
 
   const limit = Math.min(Math.max(filters.limit ?? 50, 1), 500);
   const offset = Math.max(filters.offset ?? 0, 0);
 
-  const accounts = await listAccounts({ includeHidden: filters.includeHiddenAccounts ?? false });
+  // Scoping runs through the merchant's own accounts, so `?account=` can only
+  // ever narrow that set — never reach outside it.
+  const accounts = await listAccounts(merchantId, {
+    includeHidden: filters.includeHiddenAccounts ?? false,
+  });
   const accountById = new Map(accounts.map((a) => [a.id, a]));
 
   const visibleIds = filters.accountId
@@ -342,15 +394,17 @@ export async function listTransactions(filters: TransactionFilters = {}): Promis
  * @param windowDays how far back cashflow and categories look; balances are
  *        always current, since a balance has no window.
  */
-export async function getSummary({
-  windowDays = 30,
-  includeHidden = false,
-}: { windowDays?: number; includeHidden?: boolean } = {}): Promise<FinanceSummary> {
+export async function getSummary(
+  merchantId: string,
+  { windowDays = 30, includeHidden = false }: { windowDays?: number; includeHidden?: boolean } = {},
+): Promise<FinanceSummary> {
   const supabase = getSupabaseAdmin();
   const days = Math.min(Math.max(Math.floor(windowDays) || 30, 1), 3650);
 
-  const accounts = await listAccounts({ includeHidden });
-  const allAccounts = includeHidden ? accounts : await listAccounts({ includeHidden: true });
+  const accounts = await listAccounts(merchantId, { includeHidden });
+  const allAccounts = includeHidden
+    ? accounts
+    : await listAccounts(merchantId, { includeHidden: true });
   const hiddenCount = allAccounts.filter((a) => a.is_hidden).length;
 
   const { totals, primaryCurrency, byKind, byInstitution } = aggregateAccounts(accounts);

--- a/src/lib/finances/sync.ts
+++ b/src/lib/finances/sync.ts
@@ -104,9 +104,9 @@ const CONNECTION_COLUMNS =
  * somebody's bank and a setup token cannot be re-claimed to rotate it.
  */
 export async function createConnection(params: {
+  merchantId: string;
   accessUrl: string;
   label?: string | null;
-  createdBy?: string | null;
 }): Promise<FinanceConnectionRow> {
   // Reject a malformed URL before it is encrypted and becomes hard to inspect.
   parseAccessUrl(params.accessUrl);
@@ -118,9 +118,9 @@ export async function createConnection(params: {
     .from('finance_connections')
     .insert({
       provider: 'simplefin',
+      merchant_id: params.merchantId,
       label: params.label?.trim() || null,
       access_url_encrypted: encrypt(params.accessUrl, key),
-      created_by: params.createdBy ?? null,
     })
     .select(CONNECTION_COLUMNS)
     .single();
@@ -130,34 +130,20 @@ export async function createConnection(params: {
 }
 
 /**
- * Adopt `SIMPLEFIN_ACCESS_URL` as a connection when the table is empty.
+ * One merchant's connections, without their credentials.
  *
- * The access URL for this deployment was claimed out of band, and a claim
- * cannot be repeated — so the environment holds the only copy. This promotes it
- * into the database once, encrypted, and then the env var is only a backup.
- * Returns null when there is nothing to do, which is the steady state.
+ * There is no unscoped variant of this on purpose. `SIMPLEFIN_ACCESS_URL` is
+ * also no longer read anywhere: an earlier version adopted it as a connection
+ * whenever the table was empty, which was harmless for single-tenant admin
+ * tooling but under per-merchant ownership would have handed one person's bank
+ * accounts to whichever merchant happened to link first.
  */
-export async function bootstrapConnectionFromEnv(): Promise<FinanceConnectionRow | null> {
-  const envUrl = process.env.SIMPLEFIN_ACCESS_URL?.trim();
-  if (!envUrl) return null;
-
-  const supabase = getSupabaseAdmin();
-  const { count, error } = await supabase
-    .from('finance_connections')
-    .select('id', { count: 'exact', head: true });
-
-  if (error) throw new Error(`Could not read finance connections: ${error.message}`);
-  if ((count ?? 0) > 0) return null;
-
-  return createConnection({ accessUrl: envUrl, label: 'SimpleFIN (from environment)' });
-}
-
-/** Active connections, without their credentials. */
-export async function listConnections(): Promise<FinanceConnectionRow[]> {
+export async function listConnections(merchantId: string): Promise<FinanceConnectionRow[]> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('finance_connections')
     .select(CONNECTION_COLUMNS)
+    .eq('merchant_id', merchantId)
     .order('created_at', { ascending: true });
 
   if (error) throw new Error(`Could not list finance connections: ${error.message}`);
@@ -167,17 +153,24 @@ export async function listConnections(): Promise<FinanceConnectionRow[]> {
 /**
  * Decrypt one connection's access URL.
  *
- * Falls back to `SIMPLEFIN_ACCESS_URL` only when decryption fails *and* the env
- * var is present — which is what happens if `ENCRYPTION_KEY` is rotated without
- * re-encrypting. Without that, a key rotation would permanently orphan a
- * credential that can never be re-claimed.
+ * Scoped by `merchant_id` in the same query that fetches the credential, so a
+ * caller cannot decrypt a connection it does not own by guessing an id. A
+ * connection belonging to someone else is reported as missing rather than
+ * forbidden — whether a given uuid exists is not this caller's business.
+ *
+ * There is no environment fallback when decryption fails. An earlier version
+ * returned `SIMPLEFIN_ACCESS_URL` in that case to survive an `ENCRYPTION_KEY`
+ * rotation; with per-merchant connections that would serve one merchant's bank
+ * feed to another whose credential happened to be undecryptable. Failing is
+ * the only safe answer.
  */
-async function getAccessUrl(connectionId: string): Promise<string> {
+async function getAccessUrl(connectionId: string, merchantId: string): Promise<string> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('finance_connections')
     .select('id, access_url_encrypted')
     .eq('id', connectionId)
+    .eq('merchant_id', merchantId)
     .single();
 
   if (error || !data) throw new Error('Finance connection not found');
@@ -186,12 +179,10 @@ async function getAccessUrl(connectionId: string): Promise<string> {
   try {
     return decrypt(data.access_url_encrypted as string, key);
   } catch (err) {
-    const envUrl = process.env.SIMPLEFIN_ACCESS_URL?.trim();
-    if (envUrl) return envUrl;
     throw new Error(
       `Stored SimpleFIN credential could not be decrypted (${
         err instanceof Error ? err.message : 'unknown error'
-      }). ENCRYPTION_KEY may have changed.`,
+      }). ENCRYPTION_KEY may have changed; the connection must be re-linked with a new setup token.`,
     );
   }
 }
@@ -239,6 +230,7 @@ async function chunkedUpsert(
  * Sync one connection.
  *
  * @param connectionId the connection to read
+ * @param merchantId the owner; a connection belonging to anyone else is not found
  * @param days how far back to read transactions, clamped to SimpleFIN's 90-day window
  * @throws {Error} when the whole request fails; per-institution failures are
  *         reported in `errors` with status `partial` instead, because one
@@ -246,13 +238,14 @@ async function chunkedUpsert(
  */
 export async function syncConnection(
   connectionId: string,
+  merchantId: string,
   { days = DEFAULT_SYNC_DAYS }: { days?: number } = {},
 ): Promise<SyncResult> {
   const supabase = getSupabaseAdmin();
   const windowDays = Math.min(Math.max(Math.floor(days) || DEFAULT_SYNC_DAYS, 1), MAX_SYNC_DAYS);
 
   try {
-    const accessUrl = await getAccessUrl(connectionId);
+    const accessUrl = await getAccessUrl(connectionId, merchantId);
     const startDate = new Date(Date.now() - windowDays * 86_400_000);
 
     const set = await fetchAccountSet(accessUrl, { startDate, pending: true });
@@ -339,7 +332,8 @@ export async function syncConnection(
         last_sync_accounts: accountRows.length,
         last_sync_transactions: txRows.length,
       })
-      .eq('id', connectionId);
+      .eq('id', connectionId)
+      .eq('merchant_id', merchantId);
 
     return {
       connectionId,
@@ -352,6 +346,10 @@ export async function syncConnection(
     };
   } catch (err) {
     const message = redactAccessUrl(err instanceof Error ? err.message : 'Unknown sync failure');
+    // Scoped by owner as well as id. This runs for *any* failure, including
+    // "connection not found" — which is exactly what a caller passing someone
+    // else's connection id gets. Without the merchant filter, that caller
+    // would stamp an error onto a stranger's connection.
     await supabase
       .from('finance_connections')
       .update({
@@ -359,7 +357,8 @@ export async function syncConnection(
         last_sync_status: 'error',
         last_sync_error: message.slice(0, 2000),
       })
-      .eq('id', connectionId);
+      .eq('id', connectionId)
+      .eq('merchant_id', merchantId);
     throw new Error(message);
   }
 }
@@ -405,30 +404,35 @@ async function countNewTransactions(
   return fresh;
 }
 
-/**
- * Sync every active connection, bootstrapping one from the environment first if
- * the table is empty.
- */
-export async function syncAllConnections({
-  days = DEFAULT_SYNC_DAYS,
-}: { days?: number } = {}): Promise<SyncResult[]> {
-  await bootstrapConnectionFromEnv();
-
-  const connections = (await listConnections()).filter((c) => c.is_active);
+/** Sync every active connection belonging to one merchant. */
+export async function syncAllConnections(
+  merchantId: string,
+  { days = DEFAULT_SYNC_DAYS }: { days?: number } = {},
+): Promise<SyncResult[]> {
+  const connections = (await listConnections(merchantId)).filter((c) => c.is_active);
   const results: SyncResult[] = [];
 
-  // Sequential on purpose: SimpleFIN allows roughly 24 requests per day, and
-  // parallel requests would spend that budget in bursts for no gain.
+  // Sequential on purpose: SimpleFIN allows roughly 24 requests per day *per
+  // connection*, and parallel requests would spend one merchant's budget in
+  // bursts for no gain.
   for (const connection of connections) {
-    results.push(await syncConnection(connection.id, { days }));
+    results.push(await syncConnection(connection.id, merchantId, { days }));
   }
 
   return results;
 }
 
-/** Deactivate a connection and drop its accounts and transactions. */
-export async function deleteConnection(connectionId: string): Promise<void> {
+/**
+ * Unlink a connection and cascade away its accounts and transactions.
+ *
+ * Scoped by owner, so passing a stranger's id deletes nothing.
+ */
+export async function deleteConnection(connectionId: string, merchantId: string): Promise<void> {
   const supabase = getSupabaseAdmin();
-  const { error } = await supabase.from('finance_connections').delete().eq('id', connectionId);
+  const { error } = await supabase
+    .from('finance_connections')
+    .delete()
+    .eq('id', connectionId)
+    .eq('merchant_id', merchantId);
   if (error) throw new Error(`Could not delete the connection: ${error.message}`);
 }

--- a/supabase/migrations/20260819220000_finances_per_merchant.sql
+++ b/supabase/migrations/20260819220000_finances_per_merchant.sql
@@ -1,0 +1,47 @@
+-- /finances becomes a per-merchant feature rather than house-only tooling.
+--
+-- The original tables had no owner column at all: one shared connection, every
+-- route behind requireAdmin(). That is the wrong shape for a feature each
+-- merchant uses with their own SimpleFIN token, so ownership is added here and
+-- every query is scoped by it in the application layer.
+--
+-- Ownership lives only on `finance_connections`. Accounts and transactions
+-- reach it by walking connection_id, which they already cascade from — adding
+-- a redundant merchant_id to the child tables would create a second source of
+-- truth that could disagree with the first after a bad update.
+--
+-- `created_by` is dropped: it recorded which admin added the shared connection,
+-- and `merchant_id` now says who owns it. Two nullable references to
+-- `merchants` on one table is an invitation to scope a query by the wrong one.
+-- The single existing row has `created_by = null`, so nothing is lost.
+--
+-- On RLS: these tables stay RLS-enabled with **no policies**, which denies
+-- `anon` and `authenticated` outright. That is deliberate and is not a gap.
+-- CoinPay authenticates with its own JWT (`JWT_SECRET`, `verifyToken`), not
+-- Supabase Auth, so `auth.uid()` is null in every request and a policy written
+-- against it would either deny everything or, written loosely, expose one
+-- merchant's bank data to another. The service client plus explicit
+-- `merchant_id` scoping in the app is the honest boundary here.
+
+alter table public.finance_connections
+  add column if not exists merchant_id uuid references public.merchants(id) on delete cascade;
+
+-- Backfill before the not-null constraint. The one existing connection was
+-- claimed out of band during development and holds real accounts, so it is
+-- assigned to its actual owner rather than deleted.
+update public.finance_connections
+   set merchant_id = '5d79f032-b9ec-42b6-a34a-577c9ab9688d'
+ where merchant_id is null;
+
+alter table public.finance_connections
+  alter column merchant_id set not null;
+
+alter table public.finance_connections
+  drop column if exists created_by;
+
+-- Every scoped read starts by resolving a merchant's connections.
+create index if not exists finance_connections_merchant_idx
+  on public.finance_connections (merchant_id);
+
+comment on column public.finance_connections.merchant_id is
+  'Owning merchant. Accounts and transactions inherit ownership via connection_id.';


### PR DESCRIPTION
Follow-up to #281 — replaces #283, which conflicted because #281 was squash-merged. Same change, replayed cleanly onto master.

`/finances` shipped as house tooling: one shared connection, no owner column, every route behind `requireAdmin()`. This makes it a feature each merchant uses with their own SimpleFIN token.

## Ownership

`finance_connections` gains `merchant_id` (not null, cascade). Ownership lives there alone; accounts and transactions reach it by walking `connection_id`, so there's no second copy to disagree after a bad update. The existing connection is backfilled to its real owner rather than dropped. `created_by` is removed — `merchant_id` supersedes it, and two nullable references to `merchants` on one table invites scoping by the wrong one.

New `requireMerchant()` sits alongside `requireAdmin()`: same cookie-or-bearer handling, no `is_admin` check. It returns the merchant id so callers are forced to scope, and it **deliberately rejects API keys** — those are issued to businesses for payment operations, and none should carry an implicit grant over the owner's linked bank accounts.

## Three cross-tenant paths, all closed

None were exploitable while there was one tenant, but all three would have gone live the moment a second merchant connected.

- **`bootstrapConnectionFromEnv()`** adopted `SIMPLEFIN_ACCESS_URL` whenever the connection table was empty — it would have handed one person's bank accounts to whichever merchant linked first. Removed, along with the same env fallback inside `getAccessUrl()`, which would have served that credential to anyone whose own failed to decrypt.
- **`syncConnection()`'s failure path** stamped `last_sync_error` filtering on id alone. That path runs for *any* failure including "connection not found" — exactly what passing a stranger's id produces — so it wrote to a row the caller didn't own. Both update sites are now scoped by `merchant_id`.
- **`PATCH /accounts/[id]`** filtered on the account id only. Ownership runs through the connection, so it's now checked explicitly, and a miss reports 404 rather than 403.

## On RLS

The tables stay RLS-enabled with **no policies**, which denies `anon` and `authenticated` outright. That's deliberate, not a gap: CoinPay authenticates with its own JWT (`JWT_SECRET`/`verifyToken`), not Supabase Auth, so `auth.uid()` is null in every request — a policy written against it would either deny everything or, written loosely, leak across tenants.

That makes the app-layer scoping load-bearing, so `scoping.test.ts` covers it directly — including that a merchant with **no** connections issues no account query at all. `.in(col, [])` silently matching everything is the failure mode that wouldn't look like one.

## Onboarding

SimpleFIN has no OAuth, no redirect URI and no callback — confirmed against the spec — so pasting a single-use setup token is the entire handshake. The empty state now walks through it and states plainly that the Bridge is a paid third-party service ($1.50/month or $15/year, billed by them).

## Verification

Migration applied to prod; the existing connection is owned by `anthony@profullstack.com` with its 20 accounts intact. Typecheck clean and 263 finance/auth tests green on this exact commit; full suite (333 files / 4677 tests) green before the replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)