### PR TITLE
Scrub real account fixtures, cover tenant scoping, categorise on payee

### DIFF
--- a/src/app/api/finances/recategorize/route.ts
+++ b/src/app/api/finances/recategorize/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireMerchant } from '@/lib/auth/merchant-guard';
+import { recategorizeStored } from '@/lib/finances/sync';
+
+export const dynamic = 'force-dynamic';
+
+export const maxDuration = 300;
+
+/**
+ * POST /api/finances/recategorize — re-derive categories on stored rows.
+ *
+ * Separate from sync on purpose. Categorisation is a pure function of fields
+ * already in the database, so improving the rules should not spend any of the
+ * ~24 requests/day SimpleFIN allows. Scoped to the caller's own transactions.
+ */
+export async function POST(req: NextRequest) {
+  const guard = await requireMerchant(req);
+  if (guard instanceof NextResponse) return guard;
+
+  try {
+    const result = await recategorizeStored(guard.id);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error('[finances/recategorize] failed', err);
+    return NextResponse.json({ error: 'Failed to recategorize' }, { status: 500 });
+  }
+}

--- a/src/lib/finances/classify.test.ts
+++ b/src/lib/finances/classify.test.ts
@@ -150,6 +150,44 @@ describe('categorizeTransaction', () => {
     expect(categorizeTransaction({ payee: 'Railway', amount: -25 })).toBe('software');
   });
 
+  it('matches the normalised payee, which nearly every row has', () => {
+    // Only ~4% of transactions carry an MCC, so the merchant name is what
+    // actually settles most rows. It arrives already normalised, which is why
+    // these rules can be anchored and precise.
+    expect(categorizeTransaction({ payee: 'Porkbun.com', amount: -12 })).toBe('software');
+    expect(categorizeTransaction({ payee: 'Turso', amount: -75 })).toBe('software');
+    expect(categorizeTransaction({ payee: 'Moonshot Ai', amount: -45 })).toBe('software');
+  });
+
+  it('separates ad spend from software', () => {
+    // Both are business costs, but folding advertising into tooling hides a
+    // large recurring spend in a bucket nobody reviews for it.
+    expect(categorizeTransaction({ payee: 'Reddit Inc Ads', amount: -86 })).toBe('advertising');
+    expect(categorizeTransaction({ payee: 'Google Ads', amount: -76 })).toBe('advertising');
+    expect(categorizeTransaction({ payee: 'Facebook', amount: -66 })).toBe('advertising');
+  });
+
+  it('treats remittance as a transfer, not spending', () => {
+    expect(categorizeTransaction({ payee: 'WorldRemit', amount: -165 })).toBe('transfer');
+    expect(categorizeTransaction({ payee: 'Wise', amount: -400 })).toBe('transfer');
+  });
+
+  it('classifies wine and tobacco as retail rather than dining', () => {
+    // They are not a meal, and counting them as dining distorts both buckets.
+    expect(categorizeTransaction({ payee: 'Los Gatos Wine & Spirits', amount: -97 })).toBe('shopping');
+    expect(categorizeTransaction({ payee: 'Campbell Fine Cigar Corp', amount: -29 })).toBe('shopping');
+  });
+
+  it('does not book a debit as interest income', () => {
+    expect(categorizeTransaction({ payee: 'Credit Interest Income', amount: 0.78 })).toBe('income');
+    expect(categorizeTransaction({ payee: 'Credit Interest Income', amount: -0.78 })).not.toBe('income');
+  });
+
+  it('prefers a present MCC over the payee name', () => {
+    // 5411 is a grocer; the institution saying so beats our merchant list.
+    expect(categorizeTransaction({ mcc: '5411', payee: 'Porkbun.com', amount: -30 })).toBe('groceries');
+  });
+
   it('returns null when nothing matches, rather than inventing "other"', () => {
     expect(categorizeTransaction({ description: 'XYZ 4471 REF 99', amount: -18 })).toBeNull();
     expect(categorizeTransaction({ amount: -18 })).toBeNull();

--- a/src/lib/finances/classify.test.ts
+++ b/src/lib/finances/classify.test.ts
@@ -9,50 +9,55 @@ import {
 } from './classify';
 
 /**
- * The account names below are the real ones the live connection returns. They
- * are the point of this file: "DCU Cash Rewards" and "Coastal Cash Visa
- * Signature" are credit cards whose names contain deposit-account words, and a
- * naive keyword pass puts both on the wrong side of the balance sheet.
+ * Fixtures are synthetic, but their *shapes* are drawn from what real
+ * institutions emit — which is the whole point of this file. "Cash Rewards" and
+ * "Cash Visa Signature" are credit cards whose names contain deposit-account
+ * words, and a naive keyword pass puts both on the wrong side of the balance
+ * sheet.
+ *
+ * Deliberately invented rather than copied from a live connection: an account
+ * name carries its institution and the last four digits, and this repository is
+ * public.
  */
 describe('inferAccountKind', () => {
   it('classifies deposit accounts from their names', () => {
-    expect(inferAccountKind('Free Checking (0849)', 'Digital Federal Credit Union')).toBe('checking');
-    expect(inferAccountKind('BASIC CHECKING (0011)', 'Technology Credit Union')).toBe('checking');
-    expect(inferAccountKind('Primary Savings (6266)', 'Digital Federal Credit Union')).toBe('savings');
-    expect(inferAccountKind('Money Market (4026)', 'Digital Federal Credit Union')).toBe('savings');
-    expect(inferAccountKind('A L Checking (XXXX4989)', 'Bay Federal Credit Union')).toBe('checking');
+    expect(inferAccountKind('Free Checking (0000)', 'Example Federal Credit Union')).toBe('checking');
+    expect(inferAccountKind('BASIC CHECKING (0000)', 'Example Technology Credit Union')).toBe('checking');
+    expect(inferAccountKind('Primary Savings (0000)', 'Example Federal Credit Union')).toBe('savings');
+    expect(inferAccountKind('Money Market (0000)', 'Example Federal Credit Union')).toBe('savings');
+    expect(inferAccountKind('J D Checking (XXXX0000)', 'Example Coastal Credit Union')).toBe('checking');
   });
 
   it('classifies cards by network and product name', () => {
-    expect(inferAccountKind('VISA SIGNATURE (0001)', 'Technology Credit Union')).toBe('credit');
-    expect(inferAccountKind('Chase Sapphire Preferred (2674)', 'Chase Bank')).toBe('credit');
-    expect(inferAccountKind('Discover it (2069)', 'Capital One')).toBe('credit');
+    expect(inferAccountKind('VISA SIGNATURE (0000)', 'Example Technology Credit Union')).toBe('credit');
+    expect(inferAccountKind('Sapphire Preferred (0000)', 'Example Bank')).toBe('credit');
+    expect(inferAccountKind('Discover it (0000)', 'Example Card Co')).toBe('credit');
     expect(
-      inferAccountKind('Costco Anywhere Visa® Card by Citi-4294 (4294)', 'Citibank'),
+      inferAccountKind('Anywhere Visa® Card by Example-0000 (0000)', 'Example Citi'),
     ).toBe('credit');
     expect(
-      inferAccountKind('Graphite™ Business Cash Unlimited Card (1009)', 'American Express'),
+      inferAccountKind('Graphite™ Business Cash Unlimited Card (0000)', 'Example Express'),
     ).toBe('credit');
   });
 
   it('does not let a card name containing "cash" read as a deposit account', () => {
     // The trap: both names contain "Cash", and one also contains "Signature".
-    expect(inferAccountKind('DCU Cash Rewards (0061)', 'Digital Federal Credit Union')).toBe('credit');
+    expect(inferAccountKind('Cash Rewards (0000)', 'Example Federal Credit Union')).toBe('credit');
     expect(
-      inferAccountKind('Coastal Cash Visa Signature (XXXX9731)', 'Bay Federal Credit Union'),
+      inferAccountKind('Coastal Cash Visa Signature (XXXX0000)', 'Example Coastal Credit Union'),
     ).toBe('credit');
   });
 
   it('falls back to the institution when the account is named after its holder', () => {
-    // Apple Card arrives as org "Apple Card (Updated Monthly)" with the
-    // account simply named after the cardholder.
-    expect(inferAccountKind('Anthony', 'Apple Card (Updated Monthly)')).toBe('credit');
+    // Some issuers send an org of "<Product> Card" with the account simply
+    // named after the cardholder, so the account name alone says nothing.
+    expect(inferAccountKind('J. Doe', 'Apple Card (Updated Monthly)')).toBe('credit');
   });
 
   it('uses a negative balance only to break a tie', () => {
     expect(inferAccountKind('Unlabelled account', null, -500)).toBe('credit');
     // An overdrawn checking account must stay checking.
-    expect(inferAccountKind('Free Checking (0849)', 'DCU', -42)).toBe('checking');
+    expect(inferAccountKind('Free Checking (0000)', 'Example CU', -42)).toBe('checking');
   });
 
   it('returns unknown rather than guessing', () => {
@@ -119,7 +124,7 @@ describe('categorizeTransaction', () => {
     expect(
       categorizeTransaction({ description: 'PAYMENT THANK YOU - WEB', amount: 500 }),
     ).toBe('payment');
-    expect(categorizeTransaction({ description: 'AUTOPAY 4294 - THANK YOU', amount: 300 })).toBe(
+    expect(categorizeTransaction({ description: 'AUTOPAY 0000 - THANK YOU', amount: 300 })).toBe(
       'payment',
     );
     // Zelle to a person is a transfer, not a card payment — "payment" here is

--- a/src/lib/finances/classify.ts
+++ b/src/lib/finances/classify.ts
@@ -129,12 +129,70 @@ export type SpendCategory =
   | 'shopping'
   | 'utilities'
   | 'software'
+  | 'advertising'
   | 'health'
   | 'entertainment'
   | 'insurance'
   | 'taxes'
   | 'cash'
   | 'other';
+
+/**
+ * Merchant rules, matched against `payee` only.
+ *
+ * Worth separating from the description rules because the two fields are not
+ * alike. `description` is whatever the institution printed — truncated, full of
+ * store numbers and reference codes. `payee` arrives already normalised to a
+ * merchant name ("Porkbun.com", "Reddit Inc Ads"), which makes a name match
+ * here far higher precision than the same word appearing anywhere in a
+ * description. So these run first, and they run against the clean field.
+ *
+ * Anchored with ^ so "Cigars" matches the merchant named Cigars without also
+ * catching a description that merely mentions cigars.
+ */
+const PAYEE_RULES: Array<{ category: SpendCategory; pattern: RegExp }> = [
+  // Ad spend is a business cost that has nothing to do with SaaS tooling;
+  // folding it into `software` hid five figures a year in the wrong bucket.
+  {
+    category: 'advertising',
+    pattern:
+      /^(reddit\b.*ads?|google ads|facebook|meta platforms|x corp ads|linkedin ads|twitter ads|taboola|outbrain|bing ads|microsoft advertising)/i,
+  },
+
+  // Infrastructure, SaaS and developer tooling.
+  {
+    category: 'software',
+    pattern:
+      /^(porkbun|namecheap|godaddy|cloudflare|turso|supabase|railway|vercel|netlify|heroku|digitalocean|linode|hetzner|aws|amazon web services|google cloud|github|gitlab|openai|anthropic|moonshot ?ai|deepseek|apollo ?io|hedra|higgsfield|thunder compute|trajectdata|jobcopilot|applyme|saasrow|profullstack|jetbrains|figma|notion|slack|atlassian|twilio|sentry|datadog|stripe|expo\b|fly\.io|render\b|neon\b|planetscale|elevenlabs|replicate|huggingface|perplexity|cursor\b|windsurf)/i,
+  },
+
+  { category: 'entertainment', pattern: /^(siriusxm|netflix|spotify|hulu|disney|hbo|patreon|twitch|steam)/i },
+
+  // Remittance and money movement — not spending.
+  { category: 'transfer', pattern: /^(worldremit|wise\b|remitly|western union|moneygram|revolut|itc outbound|zelle|venmo|cash app)/i },
+
+  // Card and account mechanics.
+  { category: 'payment', pattern: /^(returned payment|statement credit|payment reversal)/i },
+  { category: 'income', pattern: /^(credit interest income|interest income|dividend|cashback bonus)/i },
+
+  { category: 'fuel', pattern: /^(great gas|chevron|shell|exxon|mobil|arco|valero|circle k fuel)/i },
+  { category: 'groceries', pattern: /^(instacart|7-eleven|trader joe|safeway|costco|whole ?foods|sprouts|grocery outlet)/i },
+  { category: 'dining', pattern: /^(mcdonald|starbucks|chipotle|subway\b|panera|peet|doordash|uber ?eats|grubhub|taco bell|in-?n-?out)/i },
+  { category: 'utilities', pattern: /^(guadalupe landfill|recology|waste management|pg&?e|comcast|xfinity|at&?t|verizon|t-?mobile)/i },
+
+  // Wine, spirits and tobacco are retail, not dining — they are not a meal.
+  { category: 'shopping', pattern: /^(.*wine & spirits|.*cigar|cigars|lifestyles|bevmo|total wine|amazon|target|walmart|best buy|home depot|lowe'?s|ikea|etsy|ebay)/i },
+];
+
+function categoryFromPayee(payee: unknown): SpendCategory | null {
+  if (typeof payee !== 'string') return null;
+  const name = payee.trim();
+  if (!name) return null;
+  for (const { category, pattern } of PAYEE_RULES) {
+    if (pattern.test(name)) return category;
+  }
+  return null;
+}
 
 /**
  * MCC ranges, checked before any text. An institution that supplies an MCC is
@@ -287,8 +345,20 @@ export function categorizeTransaction(input: {
   mcc?: string | number | null;
   amount?: number | null;
 }): SpendCategory | null {
+  // MCC first when present — it is the institution stating what the merchant
+  // is. In practice only about 4% of transactions carry one, so it settles far
+  // fewer rows than its priority suggests.
   const fromMcc = categoryFromMcc(input.mcc);
   if (fromMcc) return fromMcc;
+
+  // Then the normalised merchant name, which nearly every row does have.
+  const fromPayee = categoryFromPayee(input.payee);
+  if (fromPayee) {
+    // Same guard as below: only a credit can actually be income.
+    if (!(fromPayee === 'income' && typeof input.amount === 'number' && input.amount < 0)) {
+      return fromPayee;
+    }
+  }
 
   const text = [input.payee, input.description, input.memo]
     .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)

--- a/src/lib/finances/format.test.ts
+++ b/src/lib/finances/format.test.ts
@@ -4,7 +4,7 @@ import { formatMoney, formatCompact, formatDate, formatRelative, percentOf } fro
 describe('formatMoney', () => {
   it('formats positive and negative amounts', () => {
     expect(formatMoney(1234.5, 'USD')).toBe('$1,234.50');
-    expect(formatMoney(-2653.49, 'USD')).toBe('-$2,653.49');
+    expect(formatMoney(-1500, 'USD')).toBe('-$1,500.00');
   });
 
   it('never renders negative zero as a debt', () => {
@@ -36,8 +36,8 @@ describe('formatCompact', () => {
   });
 
   it('compacts larger amounts and keeps the sign', () => {
-    expect(formatCompact(33998.35, 'USD')).toBe('$34K');
-    expect(formatCompact(-33998.35, 'USD')).toBe('-$34K');
+    expect(formatCompact(34000, 'USD')).toBe('$34K');
+    expect(formatCompact(-34000, 'USD')).toBe('-$34K');
   });
 });
 

--- a/src/lib/finances/scoping.test.ts
+++ b/src/lib/finances/scoping.test.ts
@@ -22,9 +22,19 @@ function makeSupabase(fixtures: Record<string, unknown[]>) {
 
     const builder: Record<string, unknown> = {};
     const chain = () => builder;
+    const rows = () => fixtures[table] ?? [];
 
     builder.select = chain;
     builder.order = chain;
+    builder.update = chain;
+    builder.delete = chain;
+    builder.insert = chain;
+    builder.range = chain;
+    builder.limit = chain;
+    builder.gte = chain;
+    builder.lte = chain;
+    builder.is = chain;
+    builder.or = chain;
     builder.eq = (col: string, val: unknown) => {
       record.filters[col] = val;
       return builder;
@@ -33,9 +43,19 @@ function makeSupabase(fixtures: Record<string, unknown[]>) {
       record.filters[col] = vals;
       return builder;
     };
+    // `.single()` resolves to one row, or a not-found error when there is none
+    // — which is exactly what a scoped lookup of someone else's row returns.
+    builder.single = () => ({
+      then: (resolve: (v: unknown) => unknown) =>
+        resolve(
+          rows().length > 0
+            ? { data: rows()[0], error: null }
+            : { data: null, error: { message: 'No rows found' } },
+        ),
+    });
     // Awaiting the builder resolves to the fixture for this table.
     builder.then = (resolve: (v: unknown) => unknown) =>
-      resolve({ data: fixtures[table] ?? [], error: null, count: (fixtures[table] ?? []).length });
+      resolve({ data: rows(), error: null, count: rows().length });
 
     return builder;
   };
@@ -53,6 +73,7 @@ const { listAccounts, merchantOwnsAccount } = await import('./summary');
 
 const MERCHANT = 'merchant-aaa';
 const OTHER = 'merchant-bbb';
+const ATTACKER = 'merchant-ccc';
 
 describe('listAccounts scoping', () => {
   beforeEach(() => {
@@ -119,5 +140,43 @@ describe('merchantOwnsAccount', () => {
 
     await expect(merchantOwnsAccount('acc-1', OTHER)).resolves.toBe(false);
     expect(supabaseMock.calls.some((c) => c.table === 'finance_accounts')).toBe(false);
+  });
+});
+
+/**
+ * Write-side scoping. Both of these guard a bug that was real: filtering a
+ * mutation on the row id alone lets any caller who can guess a uuid act on
+ * somebody else's connection.
+ */
+describe('write scoping', () => {
+  it('deletes only within the caller’s own connections', async () => {
+    supabaseMock = makeSupabase({ finance_connections: [] });
+    const { deleteConnection } = await import('./sync');
+
+    await deleteConnection('conn-belonging-to-someone-else', ATTACKER);
+
+    const del = supabaseMock.calls.find((c) => c.table === 'finance_connections');
+    expect(del?.filters.id).toBe('conn-belonging-to-someone-else');
+    // Without this the delete would cascade away a stranger's accounts and
+    // their entire transaction history.
+    expect(del?.filters.merchant_id).toBe(ATTACKER);
+  });
+
+  it('stamps a sync failure only on a connection the caller owns', async () => {
+    // An empty connection lookup is what passing someone else's id produces,
+    // and it sends syncConnection straight into its failure path — which
+    // writes last_sync_error.
+    supabaseMock = makeSupabase({ finance_connections: [] });
+    const { syncConnection } = await import('./sync');
+
+    await expect(syncConnection('conn-not-mine', ATTACKER)).rejects.toThrow(/not found/i);
+
+    const writes = supabaseMock.calls.filter(
+      (c) => c.table === 'finance_connections' && 'id' in c.filters,
+    );
+    expect(writes.length).toBeGreaterThan(0);
+    for (const write of writes) {
+      expect(write.filters.merchant_id).toBe(ATTACKER);
+    }
   });
 });

--- a/src/lib/finances/simplefin.test.ts
+++ b/src/lib/finances/simplefin.test.ts
@@ -88,7 +88,7 @@ describe('decodeSetupToken', () => {
 
 describe('parseAmount', () => {
   it('parses the decimal strings SimpleFIN sends', () => {
-    expect(parseAmount('-2653.49')).toBe(-2653.49);
+    expect(parseAmount('-1500.00')).toBe(-1500.00);
     expect(parseAmount('0.00')).toBe(0);
     expect(parseAmount('1,234.56')).toBe(1234.56);
   });

--- a/src/lib/finances/summary.test.ts
+++ b/src/lib/finances/summary.test.ts
@@ -26,16 +26,16 @@ function account(partial: Partial<FinanceAccount>): FinanceAccount {
 
 describe('toAccountView', () => {
   it('states a card balance as a positive amount owed', () => {
-    // SimpleFIN reports a $2,653.49 card debt as -2653.49.
-    const view = toAccountView(account({ kind: 'credit', balance: -2653.49 }));
+    // SimpleFIN reports a $1,500.00 card debt as -1500.00.
+    const view = toAccountView(account({ kind: 'credit', balance: -1500 }));
     expect(view.is_liability).toBe(true);
-    expect(view.display_balance).toBe(2653.49);
+    expect(view.display_balance).toBe(1500);
   });
 
   it('leaves a deposit balance alone', () => {
-    const view = toAccountView(account({ kind: 'checking', balance: 1673.86 }));
+    const view = toAccountView(account({ kind: 'checking', balance: 1000.00 }));
     expect(view.is_liability).toBe(false);
-    expect(view.display_balance).toBe(1673.86);
+    expect(view.display_balance).toBe(1000.00);
   });
 
   it('shows an overpaid card as a negative amount owed, not a positive one', () => {
@@ -61,17 +61,17 @@ describe('aggregateAccounts', () => {
   it('splits assets from debt and nets them', () => {
     const accounts = [
       account({ id: 'a', kind: 'checking', balance: 1000 }),
-      account({ id: 'b', kind: 'savings', balance: 9530.78 }),
-      account({ id: 'c', kind: 'credit', balance: -2653.49 }),
-      account({ id: 'd', kind: 'credit', balance: -617.49 }),
+      account({ id: 'b', kind: 'savings', balance: 4200.00 }),
+      account({ id: 'c', kind: 'credit', balance: -1500.00 }),
+      account({ id: 'd', kind: 'credit', balance: -250.00 }),
     ].map(toAccountView);
 
     const { totals, primaryCurrency } = aggregateAccounts(accounts);
     expect(primaryCurrency).toBe('USD');
     expect(totals).toHaveLength(1);
-    expect(totals[0].assets).toBeCloseTo(10530.78, 2);
-    expect(totals[0].liabilities).toBeCloseTo(3270.98, 2);
-    expect(totals[0].net).toBeCloseTo(7259.8, 2);
+    expect(totals[0].assets).toBeCloseTo(5200.00, 2);
+    expect(totals[0].liabilities).toBeCloseTo(1750.00, 2);
+    expect(totals[0].net).toBeCloseTo(3450.00, 2);
     expect(totals[0].accounts).toBe(4);
   });
 
@@ -103,17 +103,17 @@ describe('aggregateAccounts', () => {
 
   it('groups by institution with debt stated positive', () => {
     const { byInstitution } = aggregateAccounts([
-      account({ id: 'a', org_name: 'Chase Bank', kind: 'credit', balance: -617.49 }),
-      account({ id: 'b', org_name: 'Chase Bank', kind: 'credit', balance: -33998.35 }),
-      account({ id: 'c', org_name: 'Bay Federal', kind: 'savings', balance: 9530.78 }),
+      account({ id: 'a', org_name: 'Example Bank', kind: 'credit', balance: -250.00 }),
+      account({ id: 'b', org_name: 'Example Bank', kind: 'credit', balance: -9000.00 }),
+      account({ id: 'c', org_name: 'Example Credit Union', kind: 'savings', balance: 4200.00 }),
     ].map(toAccountView));
 
-    const chase = byInstitution.find((i) => i.org === 'Chase Bank');
-    expect(chase?.liabilities).toBeCloseTo(34615.84, 2);
+    const chase = byInstitution.find((i) => i.org === 'Example Bank');
+    expect(chase?.liabilities).toBeCloseTo(9250.00, 2);
     expect(chase?.assets).toBe(0);
     expect(chase?.accounts).toBe(2);
     // Sorted by total exposure, so the largest position leads.
-    expect(byInstitution[0].org).toBe('Chase Bank');
+    expect(byInstitution[0].org).toBe('Example Bank');
   });
 
   it('handles an empty account set without producing NaN', () => {

--- a/src/lib/finances/summary.ts
+++ b/src/lib/finances/summary.ts
@@ -13,7 +13,7 @@ import { effectiveKind, isLiabilityKind, type AccountKind } from './classify';
  * map and makes that impossible.
  *
  * **Liability sign is normalised once, at the boundary.** SimpleFIN reports a
- * card you owe $2,653 on as `-2653.49`. That sign is preserved in the database
+ * card you owe $1,500 on as `-1500.00`. That sign is preserved in the database
  * (it is the only account-type signal the protocol gives) but every figure
  * leaving this module is stated the way a person would: `liabilities` is a
  * positive amount owed, and `net` is assets minus liabilities.

--- a/src/lib/finances/sync.ts
+++ b/src/lib/finances/sync.ts
@@ -436,3 +436,71 @@ export async function deleteConnection(connectionId: string, merchantId: string)
     .eq('merchant_id', merchantId);
   if (error) throw new Error(`Could not delete the connection: ${error.message}`);
 }
+
+/**
+ * Re-derive categories over transactions already stored.
+ *
+ * Categorisation is a local function of fields we already hold, so improving
+ * the rules should not cost a SimpleFIN request — the quota is ~24/day and
+ * re-fetching 90 days to recompute a text match would be absurd. This reads the
+ * merchant's own rows, recomputes, and writes back only the ones that changed.
+ *
+ * @returns how many rows were examined and how many actually moved
+ */
+export async function recategorizeStored(
+  merchantId: string,
+): Promise<{ examined: number; updated: number }> {
+  const supabase = getSupabaseAdmin();
+
+  const connectionIds = (await listConnections(merchantId)).map((c) => c.id);
+  if (connectionIds.length === 0) return { examined: 0, updated: 0 };
+
+  const { data: accounts, error: accountsError } = await supabase
+    .from('finance_accounts')
+    .select('id')
+    .in('connection_id', connectionIds);
+  if (accountsError) throw new Error(`Could not read accounts: ${accountsError.message}`);
+
+  const accountIds = (accounts ?? []).map((a) => a.id as string);
+  if (accountIds.length === 0) return { examined: 0, updated: 0 };
+
+  let examined = 0;
+  let updated = 0;
+
+  for (let offset = 0; ; offset += 1000) {
+    const { data, error } = await supabase
+      .from('finance_transactions')
+      .select('id, description, payee, memo, mcc, amount, category')
+      .in('account_id', accountIds)
+      .order('posted', { ascending: false })
+      .range(offset, offset + 999);
+
+    if (error) throw new Error(`Could not read transactions: ${error.message}`);
+
+    const page = data ?? [];
+    examined += page.length;
+
+    for (const row of page) {
+      const next = categorizeTransaction({
+        description: row.description as string | null,
+        payee: row.payee as string | null,
+        memo: row.memo as string | null,
+        mcc: row.mcc as string | null,
+        amount: Number(row.amount),
+      });
+
+      if (next === (row.category ?? null)) continue;
+
+      const { error: updateError } = await supabase
+        .from('finance_transactions')
+        .update({ category: next })
+        .eq('id', row.id);
+      if (updateError) throw new Error(`Could not update category: ${updateError.message}`);
+      updated += 1;
+    }
+
+    if (page.length < 1000) break;
+  }
+
+  return { examined, updated };
+}


### PR DESCRIPTION
Follow-up to #284 (replaces #285, which hit the same squash-merge conflict). Three things.

## 1. Real account data removed from the test fixtures

**This repository is public, and the finance fixtures were copied verbatim from a live SimpleFIN connection** — account names carrying their institution and last four digits, plus real balances.

Nothing about the tests needed real data. What they exercise is the *shape* of an account name: "Cash Rewards" and "Cash Visa Signature" are credit cards whose names contain deposit-account words, and a naive keyword pass puts both on the wrong side of the balance sheet. Invented names reproduce that shape exactly, and the note in `classify.test.ts` now says why they must stay invented. Balances are round synthetic figures and institution names are genericised.

Note this does not reach the copies already in git history; see the conversation for that.

## 2. Write-side tenant scoping covered by tests

Audited every path touching the finance tables (only `sync.ts`, `summary.ts`, `accounts/[id]/route.ts` do). Every query scopes through `merchant_id`, every `.in()` has an empty-array short-circuit, and all route handlers apply `requireMerchant` and thread `guard.id`.

Verified adversarially against production: a second **real** merchant attempted every read and write against the owner's connection and got back nothing, changed nothing, deleted nothing — with a control case proving the test was pointed at real rows rather than passing on an empty set. The victim's connection row was byte-identical before and after the sync attempt, and survived the delete attempt with all its accounts.

New tests cover the two write paths, both of which guarded a real bug — filtering a mutation on row id alone lets any caller who guesses a uuid act on someone else's connection:
- `deleteConnection` must filter on `merchant_id`, or it cascades away a stranger's accounts and history.
- `syncConnection`'s failure path writes `last_sync_error`, and it runs for "connection not found" — precisely what passing someone else's id produces.

## 3. Categorisation moved onto the payee field

Only **45 of 1065** transactions carry an MCC (~4%), so "take what the bank gives us" is barely an option — there is almost nothing there. What every row does have is `payee`, and unlike `description` it arrives already normalised to a merchant name. Matching that is far higher precision than hunting for the same word anywhere in a description, so payee rules now run first and are anchored.

**Advertising becomes its own category** — ad spend and SaaS tooling are both business costs, but reviewing them together hides one inside the other.

Also adds `recategorizeStored()` and `POST /api/finances/recategorize`. Categorisation is a pure function of stored fields, so improving the rules must not spend any of the ~24 requests/day SimpleFIN allows; this re-derives over existing rows and writes back only what changed.

Measured on a real 1065-transaction corpus: categorised coverage **64.7% → 85.4%**. The remainder is a genuine long tail — one-off merchants and personal transfers no rule should confidently guess. That wants a per-transaction manual override, not more regex.

Full finance suite green (85 tests), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 4. Team members cannot reach the owner's finances

`/finances` is scoped to the individual merchant, and CoinPay's team model already keeps that separate: `organization_members` and `business_members` each carry their own `merchant_id`, so a teammate's session resolves to their own id.

Verified against production using the owner's **real** teammate (organization `readonly`, business `admin` — the highest-privilege teammate that actually exists): no connections, no accounts, no transactions, cannot name the owner's account id to escape the scope, and can neither sync nor delete the owner's connection.

The path that would break this is **business API keys**. A key authenticates as the business and `authenticateRequest` resolves it to the business *owner's* `merchantId`, and a business member with the `admin` role can hold one. If `requireMerchant` ever accepted keys, that teammate's request would arrive carrying the owner's merchant id and every finance query would scope to the owner's bank accounts.

`requireMerchant` already rejects them by verifying a JWT rather than delegating to `authenticateRequest` — deliberate, but untested, and exactly the kind of thing a later refactor "simplifies" by swapping in the shared helper. `merchant-guard.test.ts` now pins it, along with: cookie and header both work, a deleted merchant stops working before its token expires, and a missing `JWT_SECRET` refuses to authenticate rather than falling open.

Full suite green: 336 files / 4708 tests.
