### PR TITLE
Remove the last references to real accounts

### DIFF
--- a/src/lib/finances/classify.test.ts
+++ b/src/lib/finances/classify.test.ts
@@ -22,14 +22,14 @@ import {
 describe('inferAccountKind', () => {
   it('classifies deposit accounts from their names', () => {
     expect(inferAccountKind('Free Checking (0000)', 'Example Federal Credit Union')).toBe('checking');
-    expect(inferAccountKind('BASIC CHECKING (0000)', 'Example Technology Credit Union')).toBe('checking');
+    expect(inferAccountKind('BASIC CHECKING (0000)', 'Example Second Credit Union')).toBe('checking');
     expect(inferAccountKind('Primary Savings (0000)', 'Example Federal Credit Union')).toBe('savings');
     expect(inferAccountKind('Money Market (0000)', 'Example Federal Credit Union')).toBe('savings');
-    expect(inferAccountKind('J D Checking (XXXX0000)', 'Example Coastal Credit Union')).toBe('checking');
+    expect(inferAccountKind('J D Checking (XXXX0000)', 'Example Harbor Credit Union')).toBe('checking');
   });
 
   it('classifies cards by network and product name', () => {
-    expect(inferAccountKind('VISA SIGNATURE (0000)', 'Example Technology Credit Union')).toBe('credit');
+    expect(inferAccountKind('VISA SIGNATURE (0000)', 'Example Second Credit Union')).toBe('credit');
     expect(inferAccountKind('Sapphire Preferred (0000)', 'Example Bank')).toBe('credit');
     expect(inferAccountKind('Discover it (0000)', 'Example Card Co')).toBe('credit');
     expect(
@@ -44,7 +44,7 @@ describe('inferAccountKind', () => {
     // The trap: both names contain "Cash", and one also contains "Signature".
     expect(inferAccountKind('Cash Rewards (0000)', 'Example Federal Credit Union')).toBe('credit');
     expect(
-      inferAccountKind('Coastal Cash Visa Signature (XXXX0000)', 'Example Coastal Credit Union'),
+      inferAccountKind('Harbor Cash Visa Signature (XXXX0000)', 'Example Harbor Credit Union'),
     ).toBe('credit');
   });
 
@@ -66,7 +66,7 @@ describe('inferAccountKind', () => {
   });
 
   it('recognises loans and investments', () => {
-    expect(inferAccountKind('Auto Loan 4432', 'DCU')).toBe('loan');
+    expect(inferAccountKind('Auto Loan 0000', 'Example CU')).toBe('loan');
     expect(inferAccountKind('Roth IRA', 'Fidelity')).toBe('investment');
     expect(inferAccountKind('Brokerage', 'Schwab')).toBe('investment');
   });

--- a/src/lib/finances/classify.ts
+++ b/src/lib/finances/classify.ts
@@ -42,10 +42,11 @@ export function isAccountKind(value: unknown): value is AccountKind {
 }
 
 /**
- * Ordered because the first match wins and the names overlap: "DCU Cash
- * Rewards" is a credit card despite containing "cash", and "Coastal Cash Visa
- * Signature" is one despite containing both "cash" and "checking"-adjacent
- * words. Card signals are therefore tested before deposit-account signals.
+ * Ordered because the first match wins and the names overlap: a card called
+ * "<something> Cash Rewards" is credit despite containing "cash", and a
+ * "<something> Cash Visa Signature" is credit despite containing both "cash"
+ * and words adjacent to a deposit account. Card signals are therefore tested
+ * before deposit-account signals.
  */
 const KIND_PATTERNS: Array<{ kind: AccountKind; pattern: RegExp }> = [
   // Card networks and issuer product names are the strongest signal there is.

--- a/src/lib/finances/sync.test.ts
+++ b/src/lib/finances/sync.test.ts
@@ -17,7 +17,7 @@ describe('isAdvisory', () => {
 
   it('leaves a real institution failure alone', () => {
     // The signal that must never be swallowed: a bank that stopped answering.
-    expect(isAdvisory('Connection to Chase Bank needs to be re-authenticated')).toBe(false);
+    expect(isAdvisory('Connection to Example Bank needs to be re-authenticated')).toBe(false);
     expect(isAdvisory('Account temporarily unavailable')).toBe(false);
     expect(isAdvisory('')).toBe(false);
   });


### PR DESCRIPTION
The earlier scrub fixed the test fixtures but missed two places, both naming cards from the live connection they were written against:

- `classify.ts`'s own comment explained the rule ordering using two real card names. **Source comments are as public as fixtures** — I only scrubbed the test file the first time.
- `classify.test.ts` still carried one real product name and the real credit union behind two others, plus a real bank name in a `sync.test.ts` fixture.

Rules in `KIND_PATTERNS` still list product names — a classifier needs a dictionary, and "sapphire" or "apple card" sitting in a rule says nothing about who holds one. What had to go is anything asserting that a *particular person* holds a *particular card*.

Coverage is unchanged: the substituted names exercise the same rules. 85 finance tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)