### PR TITLE
Show the card tab on the hosted checkout page

### DIFF
--- a/src/lib/payments/service.public-fields.test.ts
+++ b/src/lib/payments/service.public-fields.test.ts
@@ -45,7 +45,56 @@ describe('getPaymentPublic field contract', () => {
     const fields = selected[0]!.split(',');
     expect(fields).not.toContain('business_id');
     expect(fields).not.toContain('merchant_wallet_address');
-    expect(fields).not.toContain('metadata');
+  });
+
+  /**
+   * metadata IS selected, because the card checkout URL lives in it and the
+   * checkout page needs that URL to offer a "Pay with Card" tab. Everything
+   * else in the column stays private, so the guarantee is about what comes
+   * back, not about what is selected.
+   */
+  it('publishes the card checkout URL so the pay page can offer a card tab', async () => {
+    const { client } = mockSupabase({
+      id: 'pay_1',
+      metadata: {
+        stripe_checkout_url: 'https://checkout.stripe.com/c/pay/cs_live_x',
+        payment_method: 'both',
+      },
+    });
+
+    const result = await getPaymentPublic(client, 'pay_1');
+
+    expect(result.payment?.metadata?.stripe_checkout_url).toBe(
+      'https://checkout.stripe.com/c/pay/cs_live_x'
+    );
+  });
+
+  it('strips every other metadata key from the response', async () => {
+    const { client } = mockSupabase({
+      id: 'pay_1',
+      metadata: {
+        stripe_checkout_url: 'https://checkout.stripe.com/c/pay/cs_live_x',
+        user_id: 'user-should-not-leak',
+        wallet_source: 'business',
+        network_fee_usd: 0.01,
+        redirect_url: 'https://merchant.example/thanks',
+      },
+    });
+
+    const result = await getPaymentPublic(client, 'pay_1');
+
+    expect(Object.keys(result.payment?.metadata ?? {})).toEqual(['stripe_checkout_url']);
+  });
+
+  it('returns null metadata for a crypto-only payment', async () => {
+    const { client } = mockSupabase({
+      id: 'pay_1',
+      metadata: { wallet_source: 'business', network_fee_usd: 0.01 },
+    });
+
+    const result = await getPaymentPublic(client, 'pay_1');
+
+    expect(result.payment?.metadata).toBeNull();
   });
 
   it('returns the hashes on the payment', async () => {

--- a/src/lib/payments/service.ts
+++ b/src/lib/payments/service.ts
@@ -97,7 +97,8 @@ export interface Payment {
 
 /**
  * Public payment data - safe to expose without authentication.
- * Excludes: business_id, merchant_wallet_address, metadata
+ * Excludes: business_id, merchant_wallet_address, and all of metadata
+ * except the checkout URL the customer is meant to be sent to.
  */
 export interface PublicPayment {
   id: string;
@@ -115,6 +116,13 @@ export interface PublicPayment {
   tx_hash?: string | null;
   /** Forward of the funds to the merchant. Null until the payment is forwarded. */
   forward_tx_hash?: string | null;
+  /**
+   * Pruned metadata. Only the card checkout URL is published; the rest of the
+   * row's metadata (wallet source, fee breakdown, user ids, redirect targets)
+   * stays private. The checkout page reads stripe_checkout_url to decide
+   * whether to offer a "Pay with Card" tab.
+   */
+  metadata?: { stripe_checkout_url?: string } | null;
 }
 
 export interface PaymentResult {
@@ -402,6 +410,9 @@ const PUBLIC_PAYMENT_FIELDS = [
   'expires_at',
   'tx_hash',
   'forward_tx_hash',
+  // Fetched only so the card checkout URL can be projected out of it below.
+  // Never return this column as-is: it holds internal fee math and user ids.
+  'metadata',
 ].join(',');
 
 /**
@@ -427,9 +438,20 @@ export async function getPaymentPublic(
     }
 
     // Cast through unknown since Supabase returns generic type
+    const { metadata, ...publicFields } = payment as unknown as PublicPayment & {
+      metadata?: Record<string, unknown> | null;
+    };
+    const checkoutUrl = metadata?.stripe_checkout_url;
+
     return {
       success: true,
-      payment: payment as unknown as PublicPayment,
+      payment: {
+        ...publicFields,
+        metadata:
+          typeof checkoutUrl === 'string' && checkoutUrl.length > 0
+            ? { stripe_checkout_url: checkoutUrl }
+            : null,
+      },
     };
   } catch (error) {
     return {


### PR DESCRIPTION
## The bug

`POST /api/payments/create` with `payment_method: "both"` does the right thing: it derives a crypto address **and** opens a real Stripe Checkout session, storing the session URL on the payment row.

The checkout page at `/pay/[id]` decides whether to render a **Pay with Card** tab from `payment.metadata.stripe_checkout_url`, which it reads off the public `GET /api/payments/[id]`.

That endpoint selects a column allowlist, and `metadata` was not on it. So the URL never reached the page and **every dual-rail checkout rendered crypto-only, for every merchant**, no matter what was requested. The tab markup was shipping in the bundle the whole time, just never reachable.

Verified against prod before the fix — a `both` payment on a Stripe-enabled business returned a live `cs_live_…` URL, and the rendered page showed only the crypto panel.

## The fix

Select `metadata`, then project exactly one field out of it before returning.

Returning the column as-is would also have fixed the tab, and leaked the fee breakdown, the wallet source, redirect targets and (on some rows) a `user_id` to anyone holding a payment id. So the response carries `metadata: { stripe_checkout_url }` or `null`, nothing else.

## Tests

`service.public-fields.test.ts` asserted `metadata` was never *selected*. That guarantee moves to where it actually matters — the response rather than the query — plus new cases for the pruning and for crypto-only payments.

- 321 tests across `src/lib/payments` and `src/app/api/payments` pass
- clean `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)