### PR TITLE
Require a funding transaction before settling a SOL balance

### DIFF
--- a/src/lib/payments/monitor-balance.test.ts
+++ b/src/lib/payments/monitor-balance.test.ts
@@ -226,3 +226,156 @@ describe('processPayment expiry', () => {
     expect(updates[0].status).toBe('expired');
   });
 });
+
+/**
+ * #290.
+ *
+ * A SOL invoice settled with nothing behind it: the payment reported
+ * `confirmed`, `tx_hash` was null, and `getSignaturesForAddress` returned an
+ * empty result for the derived address. The funding-signature lookup was
+ * best-effort — a failed lookup, a malformed answer and "this address has never
+ * been transacted with" all fell through to the same `{ balance, txHash:
+ * undefined }`, and a settling balance confirmed the payment with no evidence
+ * that any money had arrived.
+ *
+ * Lamports only reach an address by transaction, so a positive balance next to
+ * an empty signature list is two RPC reads contradicting each other. Neither is
+ * worth settling on.
+ */
+describe('SOL settlement requires a funding transaction', () => {
+  const mockFetch = vi.fn();
+
+  function makeSupabase() {
+    const updates: Array<Record<string, unknown>> = [];
+    const client = {
+      from: () => ({
+        update: (values: Record<string, unknown>) => {
+          updates.push(values);
+          return { eq: async () => ({ error: null }) };
+        },
+      }),
+    };
+    return { client: client as never, updates };
+  }
+
+  /** Answers `getBalance` with `lamports` and `getSignaturesForAddress` with `signatures`. */
+  function mockChain(lamports: number, signatures: unknown) {
+    mockFetch.mockImplementation(async (_url: string, init: any) => {
+      const { method } = JSON.parse(init.body);
+      if (method === 'getSignaturesForAddress') {
+        if (signatures === 'unavailable') {
+          return { ok: false, status: 503, json: async () => ({}), text: async () => 'upstream down' };
+        }
+        return jsonOk({ result: signatures });
+      }
+      return jsonOk({ result: { value: lamports } });
+    });
+  }
+
+  const pendingPayment = {
+    id: 'pay-290',
+    payment_address: ADDRESSES[0],
+    blockchain: 'SOL',
+    crypto_amount: '1.5',
+    expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+  };
+
+  beforeEach(() => {
+    resetSolBalanceCache();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports a balance with no funding transaction as unreadable', async () => {
+    mockChain(1_500_000_000, []);
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+
+    expect(result.balance).toBe(0);
+    expect(result.error).toMatch(/no funding transaction/);
+  });
+
+  it('does not confirm a payment whose balance no transaction delivered', async () => {
+    mockChain(1_500_000_000, []);
+    const { client, updates } = makeSupabase();
+
+    const result = await processPayment(client, pendingPayment as never);
+
+    expect(result.confirmed).toBe(false);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('does not expire that payment either — the reading is what is in doubt', async () => {
+    mockChain(1_500_000_000, []);
+    const { client, updates } = makeSupabase();
+
+    const result = await processPayment(
+      client,
+      { ...pendingPayment, expires_at: new Date(Date.now() - 60_000).toISOString() } as never
+    );
+
+    expect(result.expired).toBe(false);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('refuses to settle when the signature lookup itself fails', async () => {
+    mockChain(1_500_000_000, 'unavailable');
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+
+    expect(result.balance).toBe(0);
+    expect(result.error).toMatch(/signature lookup 503/);
+  });
+
+  it('refuses to settle on a signature response that is not a list', async () => {
+    // An RPC-level error body carries no `result` array. That is the lookup
+    // failing, not the chain saying the address is untouched.
+    mockChain(1_500_000_000, undefined);
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+
+    expect(result.balance).toBe(0);
+    expect(result.error).toMatch(/no result/);
+  });
+
+  it('still settles a genuinely funded address, and records its tx hash', async () => {
+    // The control: the fix must not make real payments unsettleable.
+    mockChain(1_500_000_000, [{ signature: 'sig-real' }]);
+    const { client, updates } = makeSupabase();
+
+    const balanceResult = await checkBalance(ADDRESSES[0], 'SOL');
+    expect(balanceResult.balance).toBe(1.5);
+    expect(balanceResult.txHash).toBe('sig-real');
+    expect(balanceResult.error).toBeUndefined();
+
+    const result = await processPayment(client, pendingPayment as never);
+
+    expect(result.confirmed).toBe(true);
+    expect(updates[0]).toMatchObject({ status: 'confirmed', tx_hash: 'sig-real' });
+  });
+
+  it('applies to the primed path too, which is how the monitor reads balances', async () => {
+    // A cycle primes balances in one batched call; the per-address check then
+    // reads the cache. Both paths share `solanaBalanceResult`, so the evidence
+    // requirement has to hold on the primed side as well.
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({ jsonrpc: '2.0', result: { value: [{ lamports: 1_500_000_000 }] }, id: 1 })
+    );
+    await primeSolanaBalances([ADDRESSES[0]], 'https://rpc.example');
+
+    mockFetch.mockResolvedValue(jsonOk({ jsonrpc: '2.0', result: [], id: 1 }));
+
+    const result = await checkBalance(ADDRESSES[0], 'SOL');
+
+    expect(result.balance).toBe(0);
+    expect(result.error).toMatch(/no funding transaction/);
+  });
+});

--- a/src/lib/payments/monitor-balance.ts
+++ b/src/lib/payments/monitor-balance.ts
@@ -395,6 +395,21 @@ async function checkSolanaBalance(address: string, rpcUrl: string): Promise<Bala
  * Turn a lamport balance into a `BalanceResult`, looking up the funding
  * signature only when there is actually something there. Shared by the primed
  * and unprimed paths so both report identically.
+ *
+ * The signature lookup is the *evidence* for the balance, not a decoration on
+ * it. It used to be best-effort — every failure mode fell through to
+ * `{ balance, txHash: undefined }`, and a settling balance with no funding
+ * transaction confirmed the payment exactly as a real one would. That is the
+ * state reported in #290: a SOL payment `confirmed`, `tx_hash` null, and
+ * `getSignaturesForAddress` empty for the derived address.
+ *
+ * A balance and an empty signature list cannot both be true — lamports only
+ * arrive at an address by transaction — so the two reads disagreeing means one
+ * of them is wrong, and neither is worth settling on. Both cases below fail
+ * closed for the same reason `BalanceResult.error` exists (BL-01): a reading we
+ * could not complete must not drive a state transition. `processPayment`
+ * already refuses to expire a payment carrying an `error`, so failing closed
+ * costs a cycle's delay and never writes the payment off.
  */
 async function solanaBalanceResult(
   address: string,
@@ -406,7 +421,6 @@ async function solanaBalanceResult(
 
   // Only funded addresses cost this extra call, which is a small fraction of
   // the pending set — the rest are still waiting for money to arrive.
-  let txHash: string | undefined;
   try {
     const sigResponse = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
@@ -419,20 +433,45 @@ async function solanaBalanceResult(
       }),
     });
 
-    if (sigResponse.ok) {
-      const sigData = await sigResponse.json();
-      if (sigData.result && sigData.result.length > 0) {
-        txHash = sigData.result[0].signature;
-        console.log(`[Monitor] SOL tx hash for ${address}: ${txHash}`);
-      }
-    } else {
+    if (!sigResponse.ok) {
       await drainResponse(sigResponse);
+      console.error(
+        `[Monitor] SOL funding-signature lookup for ${address} failed: ${sigResponse.status} — ` +
+          `refusing to settle ${balance} SOL on an unverified balance.`
+      );
+      return { balance: 0, error: `solanaBalanceResult: signature lookup ${sigResponse.status}` };
     }
+
+    const sigData = await sigResponse.json();
+
+    // Only an array is an answer. An RPC-level error, or any other shape, is
+    // the lookup failing — not the chain telling us the address is untouched.
+    if (!Array.isArray(sigData.result)) {
+      console.error(
+        `[Monitor] SOL funding-signature lookup for ${address} returned no usable result — ` +
+          `refusing to settle ${balance} SOL on an unverified balance.`
+      );
+      return { balance: 0, error: 'solanaBalanceResult: signature lookup returned no result' };
+    }
+
+    if (sigData.result.length === 0) {
+      console.error(
+        `[Monitor] SOL address ${address} reports ${balance} SOL but has no transactions on chain — ` +
+          `contradictory reads, refusing to settle. (#290)`
+      );
+      return { balance: 0, error: 'solanaBalanceResult: balance with no funding transaction' };
+    }
+
+    const txHash = sigData.result[0].signature;
+    console.log(`[Monitor] SOL tx hash for ${address}: ${txHash}`);
+    return { balance, txHash };
   } catch (txError) {
     console.error(`[Monitor] Error fetching SOL transactions for ${address}:`, txError);
+    return {
+      balance: 0,
+      error: txError instanceof Error ? txError.message : String(txError),
+    };
   }
-
-  return { balance, txHash };
 }
 
 async function checkSolanaTokenBalance(


### PR DESCRIPTION
This PR proposes requiring a funding transaction before a SOL balance is allowed to settle a payment, closing the false-positive settlement path reported in #290. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/465. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #290.

## What was wrong

`solanaBalanceResult` in `src/lib/payments/monitor-balance.ts` treats the funding-signature lookup as best-effort. A non-OK HTTP response, an RPC-level error body, a thrown request and a genuine "this address has never been transacted with" all fall through to the same `{ balance, txHash: undefined }`. The caller only reads `balance`, so a settling balance confirms the payment exactly as a real one would, and `tx_hash` is left null because no signature was ever resolved.

That is the state #290 describes: a SOL payment reporting `confirmed` with `tx_hash` null while `getSignaturesForAddress` returns an empty result for the derived address. Lamports only reach an address by transaction, so a positive balance next to an empty signature list is two RPC reads contradicting each other — and the code was silently picking the optimistic one.

This matters beyond the one invoice because that module is the oracle for the whole SOL settlement rail: `processPayment` (called from `runMonitorCycle` in `src/lib/payments/monitor.ts`) and the invoice settlement route `src/app/api/invoices/[id]/check-balance/route.ts` both read their balance through it.

## Reproducing it on current `master`

Mock the pair of RPC reads #290 observed — a funded `getBalance` and an empty `getSignaturesForAddress` — and run the oracle at `ffc834f`:

```js
// getBalance            -> { result: { value: 1_500_000_000 } }   // 1.5 SOL
// getSignaturesForAddress -> { result: [] }                       // no transactions

await checkBalance(address, 'SOL');
// => {"balance":1.5}                       <- settles, and carries no txHash

await processPayment(client, { id: 'pay-290', blockchain: 'SOL', crypto_amount: '1.5', ... });
// => {"confirmed":true,"expired":false}
// payments row written: {"status":"confirmed","updated_at":"...","confirmed_at":"..."}
//                        ^ no tx_hash, because none was ever resolved
```

## The change

All three unresolved cases now fail closed, returning `{ balance: 0, error }` instead of a settling balance: the lookup returned no signatures, the lookup failed, or the response was not a list. The reasoning is the one already encoded in `BalanceResult.error` for BL-01 — a reading we could not complete must not drive a state transition. Because `processPayment` already refuses to expire a payment carrying an `error`, failing closed costs a cycle's delay and never writes a payment off; the next cycle settles it once the reads agree. A genuinely funded address is unaffected and still records its tx hash.

Scope is deliberately the native SOL oracle in `src/lib/payments/monitor-balance.ts`. The SPL-token and non-Solana checkers resolve no funding transaction at all, so the same evidence rule cannot be applied to them without new lookups per chain; they are left alone rather than half-changed. This is your call to make, not a stranger's, so nothing outside the reported rail moved.

## Verification

Seven tests were added to `src/lib/payments/monitor-balance.test.ts`, including the regression #290 asks for — a SOL payment whose address reports a balance with no transaction behind it. Six of them fail on the unpatched tree and pass with the change; the seventh is a control asserting that a genuinely funded address still settles and still records `tx_hash`, and it is green both before and after on purpose, so an over-correction would show up as a failure rather than as silence.

```
# on master, with the new tests applied and the fix reverted
Tests  6 failed | 11 passed (17)

# with the fix
Tests  17 passed (17)
```

Full suite before and after, on this machine, so the comparison is a failure set rather than a pass count:

```
baseline (ffc834f):  Test Files  1 failed | 338 passed (339)
                          Tests  1 failed | 4729 passed | 3 skipped (4733)

with this change:    Test Files  1 failed | 338 passed (339)
                          Tests  1 failed | 4736 passed | 3 skipped (4740)
```

The single failure is the same one in both runs and is not related to this change — `src/lib/finances/format.test.ts > formatCompact` expects `'$34K'` and gets `'$34.0K'`, an `Intl.NumberFormat` compact-notation difference from the ICU build in the local Node. No new failures. `pnpm type-check` and `eslint` on the changed files are both clean, and your `pre-commit` hook passed on the staged files.

## How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests — 252 stories and 6 labels — with the fix carried by the story for #290: [Invoice/payment can show confirmed with zero confirmations and no on-chain transaction](https://eastagiletracker.com/projects/465/stories/416548). The full board is at https://eastagiletracker.com/projects/465.

![board](https://raw.githubusercontent.com/eastagiletracker/coinpayportal/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
